### PR TITLE
Config bug when custom prometheus config isn't given

### DIFF
--- a/otelcollector/configmapparser/tomlparser-prometheus-config.rb
+++ b/otelcollector/configmapparser/tomlparser-prometheus-config.rb
@@ -23,7 +23,7 @@ def parseConfigMap
   begin
     # Check to see if config map is created
     puts "config::configmap prometheus-collector-configmap for prometheus-config file: #{@configMapMountPath}"
-    if (File.file?(@configMapMountPath))
+    if (File.file?(@configMapMountPath) && ENV["AZMON_USE_DEFAULT_PROMETHEUS_CONFIG"] != "true")
       puts "config::configmap prometheus-collector-configmap for prometheus config mounted, parsing values"
       config = File.read(@configMapMountPath)
       puts "config::Successfully parsed mounted config map"

--- a/otelcollector/scripts/main.sh
+++ b/otelcollector/scripts/main.sh
@@ -113,19 +113,18 @@ if [ -e "/etc/config/settings/prometheus/prometheus-config" ]; then
       if [ $? -ne 0 ]; then
             echo "export AZMON_USE_DEFAULT_PROMETHEUS_CONFIG=true" >> ~/.bashrc
             export AZMON_USE_DEFAULT_PROMETHEUS_CONFIG=true
-      # Get prometheus config and replace in otelcollector config
-      else 
-            ruby /opt/microsoft/configmapparser/tomlparser-prometheus-config.rb
-
-            cat /opt/microsoft/configmapparser/config_prometheus_collector_prometheus_config_env_var | while read line; do
-                  echo $line >> ~/.bashrc
-            done
-            source /opt/microsoft/configmapparser/config_prometheus_collector_prometheus_config_env_var
       fi
 else
       echo "export AZMON_USE_DEFAULT_PROMETHEUS_CONFIG=true" >> ~/.bashrc
       export AZMON_USE_DEFAULT_PROMETHEUS_CONFIG=true
 fi 
+
+# Get prometheus config and/or default scrape_config settings and replace in otelcollector config
+ruby /opt/microsoft/configmapparser/tomlparser-prometheus-config.rb
+cat /opt/microsoft/configmapparser/config_prometheus_collector_prometheus_config_env_var | while read line; do
+    echo $line >> ~/.bashrc
+done
+source /opt/microsoft/configmapparser/config_prometheus_collector_prometheus_config_env_var
 
 
 


### PR DESCRIPTION
This fix allows the user to not have a prometheus-config configmap, but still specify true or false for each default scrape config setting to have that scrape config included or excluded.