### PR TITLE
send container logs to appinsights and change max batch size

### DIFF
--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
@@ -73,6 +73,12 @@ spec:
             - mountPath: /etc/config/settings/akv
               name: secrets-store-inline
               readOnly: true
+            - name: host-log-containers
+              readOnly: true
+              mountPath: /var/log/containers
+            - name: host-log-pods
+              readOnly: true
+              mountPath: /var/log/pods
           livenessProbe:
             exec:
               command:
@@ -127,6 +133,12 @@ spec:
           configMap:
             name: {{ .Release.Name }}-prometheus-config
             optional: true
+        - name: host-log-containers
+          hostPath:
+            path: /var/log/containers
+        - name: host-log-pods
+          hostPath:
+            path: /var/log/pods
         - name: secrets-store-inline
           csi:
             driver: secrets-store.csi.k8s.io

--- a/otelcollector/deploy/prometheus-collector.yaml
+++ b/otelcollector/deploy/prometheus-collector.yaml
@@ -122,6 +122,12 @@ spec:
             - mountPath: /etc/config/settings/akv
               name: secrets-store-inline
               readOnly: true
+            - name: host-log-containers
+              readOnly: true
+              mountPath: /var/log/containers
+            - name: host-log-pods
+              readOnly: true
+              mountPath: /var/log/pods
           livenessProbe:
             exec:
               command:
@@ -180,6 +186,12 @@ spec:
           configMap:
             name: prometheus-config
             optional: true
+        - name: host-log-containers
+          hostPath:
+            path: /var/log/containers
+        - name: host-log-pods
+          hostPath:
+            path: /var/log/pods
         - name: secrets-store-inline
           csi:
             driver: secrets-store.csi.k8s.io

--- a/otelcollector/fluent-bit/fluent-bit-parsers.conf
+++ b/otelcollector/fluent-bit/fluent-bit-parsers.conf
@@ -3,7 +3,7 @@
     Format json
     Time_Key T
     Time_Format %Y-%m-%dT%H:%M:%S.%L
-    Time_Format On
+    Time_Keep On
 
 [PARSER]
     Name me-parser
@@ -11,4 +11,12 @@
     Regex ^(?<time>[^\s]+)\s+(?<level>[^\s]+)\s+(?<message>.*)$
     Time_Key time
     Time_Format %Y-%m-%dT%H:%M:%S.%L
-    Time_Format On
+    Time_Keep On
+
+[PARSER]
+    Name cri
+    Format regex
+    Regex ^(?<time>[^\s]+)\s+(?<stream>stdout|stderr)\s+(?<logtag>[^\s]*)\s+(?<log>.*)$
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Keep   On

--- a/otelcollector/fluent-bit/fluent-bit.conf
+++ b/otelcollector/fluent-bit/fluent-bit.conf
@@ -10,6 +10,20 @@
     Parsers_File  /opt/fluent-bit/fluent-bit-parsers.conf
     Log_File      /opt/fluent-bit/fluent-bit.log
 
+# prometheus-collector container logs
+[INPUT]
+    Name tail
+    Tag prometheus.log.prometheuscollectorcontainer
+    Path /var/log/containers/prometheus-collector*.log
+    DB /var/opt/microsoft/state/prometheus-collector-ai.db
+    DB.Sync Off
+    Parser cri
+    Read_from_Head true
+    Mem_Buf_Limit 1m
+    Path_Key filepath
+    Skip_Long_Lines On
+    Ignore_Older 2m
+
 # otelcollector is only logging at error level
 [INPUT]
     Name tail

--- a/otelcollector/fluent-bit/src/appinsights.go
+++ b/otelcollector/fluent-bit/src/appinsights.go
@@ -48,7 +48,7 @@ var (
 
 func createLogger() *log.Logger {
 	var logfile *os.File
-	var logPath = "/var/opt/microsoft/log/fluent-bit-out-appinsights-runtime.log"
+	var logPath = "/opt/fluent-bit/fluent-bit-out-appinsights-runtime.log"
 
 	if _, err := os.Stat(logPath); err == nil {
 		fmt.Printf("File Exists. Opening file in append mode...\n")

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -26,16 +26,17 @@ const (
 	clusterTypeAKS                                    = "AKS"
 	envAKSResourceID                                  = "AKS_RESOURCE_ID"
 	envACSResourceName                                = "ACS_RESOURCE_NAME"
-	envAgentVersion									  = "AGENT_VERSION"
-	envControllerType								  = "CONTROLLER_TYPE"
-	envCluster										  = "customResourceId"
+	envAgentVersion                                   = "AGENT_VERSION"
+	envControllerType                                 = "CONTROLLER_TYPE"
+	envCluster                                        = "customResourceId"
 	envAppInsightsAuth                                = "APPLICATIONINSIGHTS_AUTH"
 	envAppInsightsEndpoint                            = "APPLICATIONINSIGHTS_ENDPOINT"
 	envComputerName                                   = "NODE_NAME"
-	envTelemetryOffSwitch							  = "DISABLE_TELEMETRY"
+	envTelemetryOffSwitch                             = "DISABLE_TELEMETRY"
 	fluentbitOtelCollectorLogsTag                     = "prometheus.log.otelcollector"
 	fluentbitMetricsExtensionLogsTag                  = "prometheus.log.metricsextension"
 	fluentbitMetricsExtensionMetricsTag               = "prometheus.log.scrapedmetrics"
+	fluentbitContainerLogsTag                         = "prometheus.log.prometheuscollectorcontainer"
 )
 
 // SendException  send an event to the configured app insights instance
@@ -123,6 +124,8 @@ func PushLogErrorsToAppInsightsTraces(records []map[interface{}]interface{}, sev
 			logEntry = ToString(record["message"])
 		} else if tag == fluentbitOtelCollectorLogsTag {
 			logEntry = fmt.Sprintf("%s %s", ToString(record["C"]), ToString(record["M"]))
+		} else if tag == fluentbitContainerLogsTag {
+			logEntry = ToString(record["log"])
 		}
 		logLines = append(logLines, logEntry)
 	}

--- a/otelcollector/opentelemetry-collector-builder/collector-config-default.yml
+++ b/otelcollector/opentelemetry-collector-builder/collector-config-default.yml
@@ -10,7 +10,7 @@ processors:
   batch:
     send_batch_size: 8192
     timeout: 200ms
-    send_batch_max_size: 0
+    send_batch_max_size: 10000
   resource:
     attributes:
     - key: cluster

--- a/otelcollector/opentelemetry-collector-builder/collector-config-template.yml
+++ b/otelcollector/opentelemetry-collector-builder/collector-config-template.yml
@@ -10,7 +10,7 @@ processors:
   batch:
     send_batch_size: 8192
     timeout: 200ms
-    send_batch_max_size: 0
+    send_batch_max_size: 10000
   resource:
     attributes:
     - key: cluster


### PR DESCRIPTION
- Mount as readonly only the files needed from the node's /var/log directory to get container logs
- Tail /var/log/containers/prometheus-collector*.log and use containerd parser to get logs
- Send logs to appinsights traces the same way as omsagent logs

- Set a max batch size for otelcollector. This was found during scale testing because sending 750000 timeseries from one scrape of one instance all at once causes an error in otlp exporter: "grpc received message larger than max (4417934 vs. 4194304)". The grpc message size limit is 4MB and if the error occurs, the whole message is dropped. Also, the max batch size is for the number of metrics rather than number of timeseries.