### PR TITLE
Upgrade telegraf version

### DIFF
--- a/.github/workflows/build-and-push-image-and-chart.yml
+++ b/.github/workflows/build-and-push-image-and-chart.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - grace/telegraf-upgrade
   pull_request:
     types: [opened, synchronize, reopened]
     branches:


### PR DESCRIPTION
Validated that the telemetry is still sending after the upgrade.

This fixes most vulnerabilities but a newer one remains for `github.com/apache/thrift` which hasn't been fixed in telegraf yet and is fixed in the 0.28.0 otelcollector, so we will still need to exclude those two files from the check for now