### PR TITLE
Add ability to set the maxUnavailable for the prometheus-collector da…

### DIFF
--- a/otelcollector/deploy/chart/prometheus-collector/README.md
+++ b/otelcollector/deploy/chart/prometheus-collector/README.md
@@ -104,6 +104,7 @@ kubectl create configmap my-collector-dev-release-prometheus-config --from-file=
 | resources.daemonSet.limits.memory | string | Optional | `"2Gi"` |  |
 | resources.daemonSet.requests.cpu | string | Optional | `"500m"` |  |
 | resources.daemonSet.requests.memory | string | Optional | `"1Gi"` |  |
+| updateStrategy.daemonSet.maxUnavailable | string | Optional | `"1"` | This can be a number or percentage of pods |
 | scrapeTargets.coreDns | bool | Optional | `true` | when true, automatically scrape coredns service in the k8s cluster without any additional scrape config |
 | scrapeTargets.kubelet | bool | Optional | `true` | when true, automatically scrape kubelet in every node in the k8s cluster without any additional scrape config |
 | scrapeTargets.cAdvisor | bool | Optional | `true` | when true, automatically scrape cAdvisor in every node in the k8s cluster without any additional scrape config |

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
@@ -12,6 +12,10 @@ spec:
       dsName: {{ template "prometheus-collector.fullname" . }}-node
   updateStrategy:
     type: RollingUpdate
+    {{- if .Values.updateStrategy.daemonSet.maxUnavailable }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.updateStrategy.daemonSet.maxUnavailable }}
+    {{- end }}  
   template:
     metadata:
       labels:

--- a/otelcollector/deploy/eng.ms/docs/Prometheus/chartvalues.md
+++ b/otelcollector/deploy/eng.ms/docs/Prometheus/chartvalues.md
@@ -22,6 +22,7 @@
 | resources.daemonSet.limits.memory | string | Optional | `"2Gi"` |  |
 | resources.daemonSet.requests.cpu | string | Optional | `"500m"` |  |
 | resources.daemonSet.requests.memory | string | Optional | `"1Gi"` |  |
+| updateStrategy.daemonSet.maxUnavailable | string | Optional | `"1"` | This can be a number or percentage of pods |
 | scrapeTargets.coreDns | bool | Optional | `true` | when true, automatically scrape coredns service in the k8s cluster without any additional scrape config |
 | scrapeTargets.kubelet | bool | Optional | `true` | when true, automatically scrape kubelet in every node in the k8s cluster without any additional scrape config |
 | scrapeTargets.cAdvisor | bool | Optional | `true` | when true, automatically scrape cAdvisor in every node in the k8s cluster without any additional scrape config |


### PR DESCRIPTION
…emonset

On large cluster with many nodes updating the prometheus-collector-node
pods one at a time can take a long time and will timeout frequently.

This change allows for the maxUnavailable to be set to make the deployment
of the daemonset faster and not timeout. 