### PR TITLE
add explicit permissions to ensure dependabot PRs dont fail

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -7,6 +7,7 @@ jobs:
   size-label:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: size-label


### PR DESCRIPTION
This adds explicit permissions required for sizing . Now Depenabot PRs wont fail on this we are explicitly granting required permissions for this action (default if no permissions are specified is - RO , for dependabots)
* read contents
* write pr (to add label to PR).