### PR TITLE
Dashboard changes

### DIFF
--- a/mixins/kubernetes/dashboards/windows.libsonnet
+++ b/mixins/kubernetes/dashboards/windows.libsonnet
@@ -18,6 +18,8 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       dashboard.new(
         '%(dashboardNamePrefix)sCompute Resources / Cluster(Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-windows-cluster.json']),
+        refresh=($._config.grafanaK8s.refresh),
+        time_from='now-1h',
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
@@ -135,6 +137,8 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       dashboard.new(
         '%(dashboardNamePrefix)sCompute Resources / Namespace(Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-windows-namespace.json']),
+        refresh=($._config.grafanaK8s.refresh),
+        time_from='now-1h',
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
@@ -228,6 +232,8 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       dashboard.new(
         '%(dashboardNamePrefix)sCompute Resources / Pod(Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-windows-pod.json']),
+        refresh=($._config.grafanaK8s.refresh),
+        time_from='now-1h',
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
@@ -349,6 +355,8 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       dashboard.new(
         '%(dashboardNamePrefix)sUSE Method / Cluster(Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-windows-cluster-rsrc-use.json']),
+        refresh=($._config.grafanaK8s.refresh),
+        time_from='now-1h',
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
@@ -434,6 +442,8 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       dashboard.new(
         '%(dashboardNamePrefix)sUSE Method / Node(Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-windows-node-rsrc-use.json']),
+        refresh=($._config.grafanaK8s.refresh),
+        time_from='now-1h',
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {

--- a/otelcollector/deploy/dashboard/api-server/api-server.json
+++ b/otelcollector/deploy/dashboard/api-server/api-server.json
@@ -1686,7 +1686,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(apiserver_request_total, cluster)",
+          "query": "label_values(up{job=\"kube-apiserver\", cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Cluster.json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Cluster.json
@@ -3182,7 +3182,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(node_cpu_seconds_total, cluster)",
+        "definition": "label_values(up{job=\"cadvisor\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3192,7 +3192,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(node_cpu_seconds_total, cluster)",
+          "query": "label_values(up{job=\"cadvisor\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Namespace (Pods).json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Namespace (Pods).json
@@ -2996,7 +2996,7 @@
         "options": [],
         "query": "prometheus",
         "queryValue": "",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
@@ -3009,7 +3009,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_pod_info, cluster)",
+        "definition": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3019,7 +3019,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -3046,7 +3046,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info{cluster=~\"$cluster\"}, namespace)",
+          "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
           "refId": "Prometheus-INT-Cluster-namespace-Variable-Query"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Namespace (Workloads).json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Namespace (Workloads).json
@@ -2311,7 +2311,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_pod_info, cluster)",
+        "definition": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2321,7 +2321,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Node (Pods).json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Node (Pods).json
@@ -913,7 +913,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_pod_info, cluster)",
+        "definition": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -923,7 +923,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -950,7 +950,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info{cluster=~\"$cluster\"}, node)",
+          "query": "label_values(kube_node_info{cluster=~\"$cluster\"}, node)",
           "refId": "Prometheus-INT-Cluster-node-Variable-Query"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Pod.json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Pod.json
@@ -2466,7 +2466,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_pod_info, cluster)",
+        "definition": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2476,7 +2476,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2503,7 +2503,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info{cluster=~\"$cluster\"}, namespace)",
+          "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
           "refId": "Prometheus-INT-Cluster-namespace-Variable-Query"
         },
         "refresh": 2,
@@ -2530,7 +2530,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info{cluster=~\"$cluster\", namespace=\"$namespace\"}, pod)",
+          "query": "label_values(kube_pod_info{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\"}, pod)",
           "refId": "Prometheus-INT-Cluster-pod-Variable-Query"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Workload.json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Compute Resources _ Workload.json
@@ -2108,7 +2108,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
           "refId": "Prometheus-INT-Cluster-cluster-Variable-Query"
         },
         "refresh": 2,
@@ -2135,7 +2135,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info{cluster=~\"$cluster\"}, namespace)",
+          "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Kubelet.json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Kubelet.json
@@ -2279,7 +2279,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "$datasource",
-        "definition": "label_values(kubelet_node_name, cluster)",
+        "definition": "label_values(up{job=\"kubelet\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2289,7 +2289,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"kubelet\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2315,7 +2315,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(kubelet_runtime_operations_total{cluster=~\"$cluster\", job=\"kubelet\"}, instance)",
+          "query": "label_values(up{job=\"kubelet\",cluster=\"$cluster\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Cluster.json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Cluster.json
@@ -1873,7 +1873,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"cadvisor\"}, cluster)",
           "refId": "Prometheus-INT-Cluster-cluster-Variable-Query"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Namespace (Pods).json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Namespace (Pods).json
@@ -1318,7 +1318,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_pod_info, cluster)",
+        "definition": "label_values(up{job=\"cadvisor\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1328,7 +1328,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"cadvisor\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Namespace (Workload).json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Namespace (Workload).json
@@ -1670,7 +1670,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_pod_info, cluster)",
+        "definition": "label_values(up{job=\"cadvisor\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1680,7 +1680,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"cadvisor\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Pod.json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Pod.json
@@ -1063,7 +1063,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_pod_info, cluster)",
+        "definition": "label_values(up{job=\"cadvisor\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1073,10 +1073,10 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"cadvisor\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Workload.json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes _ Networking _ Workload.json
@@ -1260,7 +1260,7 @@
         "options": [],
         "query": "prometheus",
         "queryValue": "",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
@@ -1273,7 +1273,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_pod_info, cluster)",
+        "definition": "label_values(kube_pod_info{job=\"kube-state-metrics\"}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1283,7 +1283,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(kube_pod_info{job=\"kube-state-metrics\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/kube-proxy/Kubernetes _ Proxy.json
+++ b/otelcollector/deploy/dashboard/kube-proxy/Kubernetes _ Proxy.json
@@ -1183,7 +1183,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kubeproxy_sync_proxy_rules_duration_seconds_count, cluster)",
+        "definition": "label_values(up{job=\"kube-proxy\"}, cluster)",
         "description": "Source-https://github.com/monitoring-mixins/website/blob/master/assets/kubernetes/dashboards/proxy.json",
         "error": null,
         "hide": 0,
@@ -1193,7 +1193,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, cluster)",
+          "query": "label_values(up{job=\"kube-proxy\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/node-exporter/Nodes (Node exporter).json
+++ b/otelcollector/deploy/dashboard/node-exporter/Nodes (Node exporter).json
@@ -912,7 +912,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(node_filesystem_size_bytes{job=\"node\"},cluster)",
+        "definition": "label_values(up{job=\"node\"},cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -922,7 +922,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(node_filesystem_size_bytes{job=\"node\"},cluster)",
+          "query": "label_values(up{job=\"node\"},cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/node-exporter/USE Method _ Cluster (Node exporter).json
+++ b/otelcollector/deploy/dashboard/node-exporter/USE Method _ Cluster (Node exporter).json
@@ -1081,7 +1081,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(node_filesystem_size_bytes{job=\"node\"},cluster)",
+        "definition": "label_values(node_time_seconds{job=\"node\"},cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1091,7 +1091,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(node_filesystem_size_bytes{job=\"node\"},cluster)",
+          "query": "label_values(node_time_seconds{job=\"node\"},cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/otelcollector/deploy/dashboard/node-exporter/USE Method _ Node (Node exporter).json
+++ b/otelcollector/deploy/dashboard/node-exporter/USE Method _ Node (Node exporter).json
@@ -1089,7 +1089,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(node_filesystem_size_bytes{job=\"node\"},cluster)",
+        "definition": "label_values(node_time_seconds{job=\"node\"},cluster)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1099,7 +1099,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(node_filesystem_size_bytes{job=\"node\"},cluster)",
+          "query": "label_values(node_time_seconds{job=\"node\"},cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1116,7 +1116,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
-        "definition": "label_values(node_filesystem_size_bytes{job=\"node\",cluster=~\"$cluster\"},instance)",
+        "definition": "label_values(node_exporter_build_info{job=\"node\", cluster=\"$cluster\"}, instance)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1126,10 +1126,10 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(node_filesystem_size_bytes{job=\"node\",cluster=~\"$cluster\"},instance)",
+          "query": "label_values(node_exporter_build_info{job=\"node\", cluster=\"$cluster\"}, instance)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,

--- a/otelcollector/deploy/dashboard/prometheus-collector/prometheus-collector-health.json
+++ b/otelcollector/deploy/dashboard/prometheus-collector/prometheus-collector-health.json
@@ -306,7 +306,7 @@
           "query": "label_values(timeseries_received_per_minute{cluster=~\"$cluster\", release=~\"$release\"}, controller_type)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -329,7 +329,7 @@
           "query": "label_values(timeseries_received_per_minute{cluster=~\"$cluster\", release=~\"$release\", controller_type=~\"$controller_type\"}, computer)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,


### PR DESCRIPTION
Changes for Mixins (future dashboards)

1) Add 1m refresh and 1h query back for all windows dashboards

Changes for currently used dashboards (pending full testing)

2) Fix 2 issues (below) as reported by @dougbrad 

    2.1) A lot of our cluster variables are querying highly cardinal metrics (ex;- kube_pod_info) for just getting the distinct clusters in the account, which is causing large number of time-series being returned , which in turn affects the SLA/Perf for PQS for AML. Updated all those to use 'Up' metric (https://msazure.visualstudio.com/InfrastructureInsights/_workitems/edit/12632949)

    2.2) Ensured all variable refreshes are consistent with being refreshed when time interval changes. With 2.1 (above) , this should be better than what it is now. But still need to validate if auto-refreshes trigger variable updates. [@dougbrad just confirmed after creating this PR that variables are indeed getting refreshed for auto-refreshes] (https://msazure.visualstudio.com/InfrastructureInsights/_workitems/edit/12613530)