### PR TITLE
Add MSI as an option for keyvault authentication

### DIFF
--- a/otelcollector/deploy/chart/prometheus-collector/README.md
+++ b/otelcollector/deploy/chart/prometheus-collector/README.md
@@ -52,10 +52,16 @@ helm upgrade --install csi csi-secrets-store-provider-azure/csi-secrets-store-pr
 - **Step 5** : Pull & Install prometheus-collector chart in your cluster
 ```shell
 helm pull oci://mcr.microsoft.com/azuremonitor/containerinsights/cidev:prometheus-collector --version 1.0.0-main-11-01-2021-e86fc50d
-
+```
+If using service principal:
+```shell
 helm upgrade --install <chart_release_name> ./prometheus-collector-1.0.0-main-11-01-2021-e86fc50d.tgz --dependency-update --set azureKeyVault.name="**" --set azureKeyVault.pfxCertNames="{**,**}" --set azureKeyVault.tenantId="**" --set clusterName="**" --set azureMetricAccount.defaultAccountName="**" --set azureKeyVault.clientId="**" --set azureKeyVault.clientSecret="****" --namespace=<my_prom_collector_namespace> --create-namespace
 ```
-  **Example** :-
+If using managed identity:
+```shell
+helm upgrade --install <chart_release_name> ./prometheus-collector-1.0.0-main-11-01-2021-e86fc50d.tgz --dependency-update --set azureKeyVault.name="**" --set azureKeyVault.pfxCertNames="{**,**}" --set azureKeyVault.tenantId="**" --set clusterName="**" --set azureMetricAccount.defaultAccountName="**" --set azureKeyVault.msiClientId="**" --namespace=<my_prom_collector_namespace> --create-namespace
+```
+  **Example with service principal** :-
 ```shell
 helm upgrade --install my-collector-dev-release ./prometheus-collector-1.0.0-main-11-01-2021-e86fc50d.tgz --dependency-update --set azureKeyVault.name="containerinsightstest1kv" --set azureKeyVault.pfxCertNames="{containerinsightsgenevaaccount1-pfx,containerinsightsgenevaaccount2-pfx}" --set azureKeyVault.tenantId="72f988bf-****-41af-****-2d7cd011db47" --set clusterName="mydevcluster" --set azureMetricAccount.defaultAccountName="containerinsightsgenevaaccount1" --set azureKeyVault.clientId="70937f05-****-4fc0-****-de917f2a9402" --set azureKeyVault.clientSecret="**********************************" --namespace=prom-collector --create-namespace
 ```

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-azure-keyVault-secret.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-azure-keyVault-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.azureKeyVault.msiClientId }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ type: Opaque
 data:
   clientid: {{ required "azureKeyVault.clientId is required" .Values.azureKeyVault.clientId | toString | b64enc | quote }}
   clientsecret: {{ required "azureKeyVault.clientSecret is required" .Values.azureKeyVault.clientSecret | toString | b64enc | quote }}
+{{- end }}

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
@@ -164,6 +164,8 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: "{{ template "prometheus-collector.fullname" . }}-azure-kv-metricstore"
+            {{- if not .Values.azureKeyVault.msiClientId }}
             nodePublishSecretRef:           # Only required when using service principal mode
               name: {{ template "prometheus-collector.fullname" . }}-akv-creds               # Only required when using service principal mode. The name of the Kubernetes secret that contains the service principal credentials to access keyvault
+            {{- end }}
 {{- end }}

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
@@ -170,5 +170,7 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: "{{ template "prometheus-collector.fullname" . }}-azure-kv-metricstore"
+            {{- if not .Values.azureKeyVault.msiClientId }}
             nodePublishSecretRef:           # Only required when using service principal mode
               name: {{ template "prometheus-collector.fullname" . }}-akv-creds   # Only required when using service principal mode. The name of the Kubernetes secret that contains the service principal credentials to access keyvault
+            {{- end }}

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
@@ -12,8 +12,13 @@ spec:
   provider: azure
   parameters:
     usePodIdentity: "false"                    # [OPTIONAL] if not provided, will default to "false"
+    {{- if not .Values.azureKeyVault.msiClientId }}
     useVMManagedIdentity: "false"              # [OPTIONAL available for version > 0.0.4] if not provided, will default to "false"
     userAssignedIdentityID: ""                 # [OPTIONAL available for version > 0.0.4] use the client id to specify which user assigned managed identity to use. If using a user assigned identity as the VM's managed identity, then specify the identity's client id. If empty, then defaults to use the system assigned identity on the VM
+    {{- else }}
+    useVMManagedIdentity: "true"              # [OPTIONAL available for version > 0.0.4] if not provided, will default to "false"
+    userAssignedIdentityID: {{ required "azureKeyVault.msiClientId is required" .Values.azureKeyVault.msiClientId | toString | quote }} # [OPTIONAL available for version > 0.0.4] use the client id to specify which user assigned managed identity to use. If using a user assigned identity as the VM's managed identity, then specify the identity's client id. If empty, then defaults to use the system assigned identity on the VM
+    {{- end }}
     keyvaultName: {{ required "azureKeyVault.name is required" .Values.azureKeyVault.name | toString | quote }} # [CHANGE AS APPROPRIATE][REQUIRED] the name of the KeyVault (also provide tenantid of this KeyVault in the 'tanantId' field below)
     cloudName: ""                              # [OPTIONAL available for version > 0.0.4] if not provided, azure environment will default to AzurePublicCloud
     cloudEnvFileName: ""                       # [OPTIONAL available for version > 0.0.7] use to define path to file for populating azure environment

--- a/otelcollector/deploy/chart/prometheus-collector/values-template.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/values-template.yaml
@@ -46,10 +46,12 @@ azureKeyVault:
   name: "" #required
   # -- tenantid for the azure key vault resource
   tenantId: "" #required
+  # -- clientId for a managed identity that has access to read the Pfx certificates from keyvault specified above
+  msiClientId: "" #required if using managed identities, uses sp if empty
   # -- clientid for a service principal that has access to read the Pfx certificates from keyvault specified above
-  clientId: "" #required
+  clientId: "" #required if using service principal 
   # -- client secret for the above service principal
-  clientSecret: "" #required
+  clientSecret: "" #required if using service principal 
   # -- name of the Pfx certificate(s) - one per metric account
   pfxCertNames: [] #required
 


### PR DESCRIPTION
Add MSI as an option in addition to SP for keyvault authentication. MSI is used when msiClientId is supplied, otherwise, defaults to SP. 