### PR TITLE
explicitly specify win 2019 for windows builds

### DIFF
--- a/.github/workflows/build-and-push-image-and-chart.yml
+++ b/.github/workflows/build-and-push-image-and-chart.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - vishwa/win02252022
   pull_request:
     types: [opened, synchronize, reopened]
     branches:


### PR DESCRIPTION
So for windows build we need to explicitly reference win 2019 as gihub moved to win 2022 (when using windows-latest)