### PR TITLE
add MAC support for chart

### DIFF
--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-azure-keyVault-secret.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-azure-keyVault-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.azureKeyVault.useManagedIdentity }}
+{{- if and (not .Values.azureKeyVault.useManagedIdentity) (not .Values.useMonitoringAccount) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
@@ -36,9 +36,18 @@ spec:
           resources:
             {{- toYaml .Values.resources.daemonSet | nindent 12 }}
           env:
+            {{- if not .Values.useMonitoringAccount }}
             - name: CLUSTER
-              value: {{ required "clusterName is required" .Values.clusterName | toString | quote }}
-            {{- if .Values.internalSettings.intEnvironment  }}
+              value: {{ required "clusterName is required" .Values.clusterName | toString | trim | quote }}
+            {{- else }}
+            - name: CLUSTER
+              value: {{ required "azureResourceId is required when using monitoring account" .Values.azureResourceId | toString | quote }}
+            - name: AKSREGION
+              value: {{ required "azureResourceRegion is required when using monitoring account" .Values.azureResourceRegion | toString | trim | lower | quote }}
+            - name: MAC
+              value: "true"
+            {{- end }}
+            {{- if and (.Values.internalSettings.intEnvironment) (not .Values.useMonitoringAccount) }}
             - name: ME_ADDITIONAL_FLAGS
               value: "-FrontEndUrl https://az-int.int.microsoftmetrics.com"
             {{- end }}  
@@ -93,9 +102,9 @@ spec:
             - name: MODE
               value: "" # only supported mode is 'advanced', any other value will be the default/non-advance mode
             {{- end }}
-            {{- if .Values.windowsDaemonset  }}
+            {{- if and (.Values.windowsDaemonset) (not .Values.useMonitoringAccount) }}
             - name: WINMODE
-              value: "advanced" # WINDOWS: only supported mode is 'advanced', any other value will be the default/non-advance mode
+              value: "advanced" # WINDOWS: only supported mode is 'advanced' [when not using MAC], any other value will be the default/non-advance mode
             {{- else }}
             - name: WINMODE
               value: "" # WINDOWS: only supported mode is 'advanced', any other value will be the default/non-advance mode
@@ -109,9 +118,11 @@ spec:
             - mountPath: /etc/config/settings/prometheus
               name: prometheus-config-vol
               readOnly: true
+            {{- if not .Values.useMonitoringAccount }}
             - mountPath: /etc/config/settings/akv
               name: secrets-store-inline
               readOnly: true
+            {{- end }}
             - name: host-log-containers
               readOnly: true
               mountPath: /var/log/containers
@@ -165,6 +176,7 @@ spec:
         - name: host-log-pods
           hostPath:
             path: /var/log/pods
+        {{- if not .Values.useMonitoringAccount }}
         - name: secrets-store-inline
           csi:
             driver: secrets-store.csi.k8s.io
@@ -175,9 +187,10 @@ spec:
             nodePublishSecretRef:           # Only required when using service principal mode
               name: {{ template "prometheus-collector.fullname" . }}-akv-creds               # Only required when using service principal mode. The name of the Kubernetes secret that contains the service principal credentials to access keyvault
             {{- end }}
+        {{- end }}
 {{- end }}        
----     
-{{- if and (eq .Values.mode.advanced true) (eq .Values.windowsDaemonset true) -}}
+---
+{{- if and (eq .Values.mode.advanced true) (eq .Values.windowsDaemonset true) (not .Values.useMonitoringAccount) }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
@@ -28,9 +28,18 @@ spec:
           resources:
             {{- toYaml .Values.resources.deployment | nindent 12 }}
           env:
+            {{- if not .Values.useMonitoringAccount }}
             - name: CLUSTER
-              value: {{ required "clusterName is required" .Values.clusterName | toString | quote }}
-            {{- if .Values.internalSettings.intEnvironment  }}
+              value: {{ required "clusterName is required" .Values.clusterName | toString | trim | quote }}
+            {{- else }}
+            - name: CLUSTER
+              value: {{ required "azureResourceId is required when using monitoring account" .Values.azureResourceId | toString | quote }}
+            - name: AKSREGION
+              value: {{ required "azureResourceRegion is required when using monitoring account" .Values.azureResourceRegion | toString | trim | lower | quote }}
+            - name: MAC
+              value: "true"
+            {{- end }}
+            {{- if and (.Values.internalSettings.intEnvironment) (not .Values.useMonitoringAccount) }}
             - name: ME_ADDITIONAL_FLAGS
               value: "-FrontEndUrl https://az-int.int.microsoftmetrics.com"
             {{- end }}
@@ -85,13 +94,14 @@ spec:
             - name: MODE
               value: "" # only supported mode is 'advanced', any other value will be the default/non-advance mode
             {{- end }}
-            {{- if .Values.windowsDaemonset  }}
+            {{- if and (.Values.windowsDaemonset) (not .Values.useMonitoringAccount) }}
             - name: WINMODE
-              value: "advanced" # WINDOWS: only supported mode is 'advanced', any other value will be the default/non-advance mode
+              value: "advanced" # WINDOWS: only supported mode is 'advanced' [when not using MAC], any other value will be the default/non-advance mode
             {{- else }}
             - name: WINMODE
               value: "" # WINDOWS: only supported mode is 'advanced', any other value will be the default/non-advance mode
             {{- end }}
+            {{- if not .Values.useMonitoringAccount }}
             {{- if .Values.azureKeyVault.useManagedIdentity  }}
               {{- if .Values.azureKeyVault.userAssignedIdentityID }}
             - name: AKVAUTH
@@ -104,6 +114,7 @@ spec:
             - name: AKVAUTH
               value: "sp" # service principal
             {{- end }}
+            {{- end }}
           securityContext:
             privileged: false
           volumeMounts:
@@ -113,9 +124,11 @@ spec:
             - mountPath: /etc/config/settings/prometheus
               name: prometheus-config-vol
               readOnly: true
+            {{- if not .Values.useMonitoringAccount }}
             - mountPath: /etc/config/settings/akv
               name: secrets-store-inline
               readOnly: true
+            {{- end }}
             - name: host-log-containers
               readOnly: true
               mountPath: /var/log/containers
@@ -183,6 +196,7 @@ spec:
         - name: host-log-pods
           hostPath:
             path: /var/log/pods
+        {{- if not .Values.useMonitoringAccount }}
         - name: secrets-store-inline
           csi:
             driver: secrets-store.csi.k8s.io
@@ -193,3 +207,4 @@ spec:
             nodePublishSecretRef:           # Only required when using service principal mode
               name: {{ template "prometheus-collector.fullname" . }}-akv-creds   # Only required when using service principal mode. The name of the Kubernetes secret that contains the service principal credentials to access keyvault
             {{- end }}
+        {{- end }}

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useMonitoringAccount }}
 # This is a SecretProviderClass example using a service principal to access Keyvault
 # This cannot be renamed (metadata.name)
 # This needs to be in kube-system namespace (same namespace as prometheus collector)
@@ -35,3 +36,4 @@ spec:
           objectVersion: ""                                  # [OPTIONAL] object versions, default to latest if empty
       {{- end}}
     tenantId: {{ required "azureKeyVault.tenantId is required" .Values.azureKeyVault.tenantId | toString | quote }}       # [CHANGE AS APPROPRIATE][REQUIRED] the tenant ID of the KeyVault specified above
+{{- end }}

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-settings-configmap.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-settings-configmap.yaml
@@ -7,8 +7,13 @@ data:
   config-version:
     #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
     ver1
+  {{- if not .Values.useMonitoringAccount }}
   prometheus-collector-settings: |-
     default_metric_account_name = {{ required "azureMetricAccount.defaultAccountName is required" .Values.azureMetricAccount.defaultAccountName | toString | quote }}
+  {{- else }}
+  prometheus-collector-settings: |-
+    default_metric_account_name = "notapplicable"
+  {{- end }}
   default-scrape-settings-enabled: |-
     kubelet = {{ .Values.scrapeTargets.kubelet }}
     coredns = {{ .Values.scrapeTargets.coreDns }}

--- a/otelcollector/deploy/chart/prometheus-collector/values-template.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/values-template.yaml
@@ -2,6 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- when true, ingestion will be based on Monitor account & DCR(s)
+useMonitoringAccount: false
+
+# -- required & used only when useMonitoringAccount=true. This is the full ARM ResourceId for the Kubernetes cluster that is going to be monitoring with this chart
+azureResourceId: ""
+
+# -- required & used only when useMonitoringAccount=true. This is the Azure region for the Kubernetes cluster that is going to be monitoring with this chart
+azureResourceRegion: ""
+
 scrapeTargets:
   # -- when true, automatically scrape coredns service in the k8s cluster without any additional scrape config
   coreDns: true

--- a/otelcollector/docs/eng.ms/PromMDMTutorial2DeployAgentHELM.md
+++ b/otelcollector/docs/eng.ms/PromMDMTutorial2DeployAgentHELM.md
@@ -12,8 +12,13 @@ For deploying the metrics collection agent, we will leverage [HELM](https://kube
 The prometheus-collector is the name of the agent pod (replica set) that will collect Prometheus metrics from your Kubernetes cluster.
 
 > If you've worked with Geneva Metrics before, you maybe familiar with the Geneva Metrics Extension [ME]. ME will be used for Prometheus collection as well, and is a sub-component of the prometheus-collector
+> You can either deploy by specifying geneva account(s) and their certificates (or) you can deploy by requiring to use a Monitoring Account (MAC), in which case it doesn't require certificates and it will use Azure Resource's System Managed Identity, which also requires setting up MAC account(s) and configuring DCR* (Data collection rules*)
 
-To deploy the agent we will leverage HELM again. At this step you will need to provide the KeyVault certificate information that you saved in the previous step.  The following commands can be used for this. See an example of this below.  
+To deploy the agent we will leverage HELM again. 
+
+### Using geneva account & certificates (in key vault)
+
+At this step you will need to provide the KeyVault certificate information that you saved in the previous step.  The following commands can be used for this. See an example of this below.  
 
 > Note you must set the following environment variable for the below commands to work: HELM_EXPERIMENTAL_OCI=1
 
@@ -57,6 +62,18 @@ You can verify that there are not any configuration or authentication issues by 
 Enabling `--set advanced.mode=true` for large clusters with more than 50 nodes and 1500 pods is highly recommended. See [here](~/metrics/Prometheus/advanced-mode.md) for more information about advanced mode. If the cluster has greater than 25 Windows nodes, enabling advanced mode and `--set windowsDaemonset=true` is recommended. See [here](~/metrics/Prometheus/windows.md) for more information about collecting Windows metrics.
 
 > If you want to have your metrics be sent to multiple metrics accounts, follow the guidelines for [multiple accounts](~/metrics/Prometheus/configuration.md#multiple-metric-accounts) that outlines how Prometheus collector works with multiple metrics accounts.  
+
+### Using geneva account & certificates (in key vault)
+
+```shell
+helm pull oci://mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector --version 1.1.2-main-03-07-2022-df71b65a
+```
+ **Example (using Monitoring account)**
+
+```shell
+helm upgrade --install <chart_release_name> ./prometheus-collector-1.1.2-main-03-07-2022-df71b65a.tgz --dependency-update --set useMonitoringAccount=true --set azureResourceId="/subscriptions/<my_cluster_sub_id>/resourceGroups/<my_cluster_resource_group>/providers/Microsoft.ContainerService/managedClusters/<my_cluster>" --set azureResourceRegion="eastus" --namespace=<my_prom_collector_namespace> --create-namespace
+```
+
 
 --------------------------------------
 

--- a/otelcollector/docs/eng.ms/chartvalues.md
+++ b/otelcollector/docs/eng.ms/chartvalues.md
@@ -1,4 +1,4 @@
-# Chart Values for Prometheus-collector
+# Chart Values for Prometheus-collector (when using geneva account and theor certificates)
 
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
@@ -11,6 +11,50 @@
 | azureKeyVault.userAssignedIdentityID | string | Optional | `""` | used when useManagedIdentity parameter is set to true. This specifies which user assigned managed identity to use when acccesing keyvault. If you are using a user assigned identity as managed identity, then specify the identity's client id. If empty, AND 'useManagedIdentity' is true, then defaults to use the system assigned identity on the VM |
 | azureMetricAccount.defaultAccountName | string | <mark>`Required`</mark> | `""` | default metric account name to ingest metrics into. This will be the account used if metric itself does not have account 'hinting' label. The certificate for this account should be specified in one of the further arguments below here |
 | clusterName | string | <mark>`Required`</mark> | `""` | name of the k8s cluster. This will be added as a 'cluster' label for every metric scraped |
+| image.pullPolicy | string | Optional | `"IfNotPresent"` |  |
+| image.repository | string | Optional | `"mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images"` |  |
+| image.tag | string | Optional | `"1.1.2-main-03-07-2022-df71b65a"` |  |
+| internalSettings.intEnvironment | bool | Optional | `false` | do not use any of the internal settings. This is for testing purposes |
+| mode.advanced | bool | Optional | `false` | if mode.advanced==true (default is false), then it will deploy a daemonset in addition to replica, and move some of the default node targets (kubelet, cadvisor & nodeexporter) to daemonset. On bigger clusters (> 50+ nodes and > 1500+ pods), it is highly recommended to set this to `true`, as this will distribute the metric volumes to individual nodes as nodes & pods scale out & grow. Note:- When this is set to `true`, the `up` metric for the node target will be generated from the replica, so when the node (and daemonset in the node) becomes unvailable), the target availability can still be tracked.
+| windowsDaemonset | bool | Optional | `false` | if mode.advanced==true (default is false), and windowsDaemonset==true (default is false) then it will deploy a windows daemonset on windows nodes, and move the default windows node targets (windowsexporter, windows-kube-proxy) to windows daemonset. On bigger windows clusters (> 50+ windows nodes and > 1500+ windows pods), it is highly recommended to set this to `true`, as this will distribute the metric volumes to individual windows nodes, as windows nodes & windows pods scale out & grow. Note:- When this is set to `true`, the `up` metric for the windows node targets will be generated from the replica, so when the windows node (and daemonset in the windows node) becomes unvailable), the target availability can still be tracked. Note:- This setting will be effective only when mode.advanced==true.
+| resources.deployment.limits.cpu | string | Optional | `4` |  |
+| resources.deployment.limits.memory | string | Optional | `"7Gi"` |  |
+| resources.deployment.requests.cpu | string | Optional | `"1"` |  |
+| resources.deployment.requests.memory | string | Optional | `"2Gi"` |  |
+| resources.daemonSet.limits.cpu | string | Optional | `1` |  |
+| resources.daemonSet.limits.memory | string | Optional | `"2Gi"` |  |
+| resources.daemonSet.requests.cpu | string | Optional | `"500m"` |  |
+| resources.daemonSet.requests.memory | string | Optional | `"1Gi"` |  |
+| updateStrategy.daemonSet.maxUnavailable | string | Optional | `"1"` | This can be a number or percentage of pods |
+| scrapeTargets.coreDns | bool | Optional | `true` | when true, automatically scrape coredns service in the k8s cluster without any additional scrape config |
+| scrapeTargets.kubelet | bool | Optional | `true` | when true, automatically scrape kubelet in every node in the k8s cluster without any additional scrape config |
+| scrapeTargets.cAdvisor | bool | Optional | `true` | when true, automatically scrape cAdvisor in every node in the k8s cluster without any additional scrape config |
+| scrapeTargets.kubeProxy | bool | Optional | `true` | `linux only` - when true, automatically scrape kube-proxy in every linux node discovered in the k8s cluster without any additional scrape config |
+| scrapeTargets.apiServer | bool | Optional | `true` | when true, automatically scrape the kubernetes api server in the k8s cluster without any additional scrape config |
+| scrapeTargets.kubeState | bool | Optional | `true` | when true, automatically install kube-state-metrics and scrape kube-state-metrics in the k8s cluster without any additional scrape config |
+| scrapeTargets.nodeExporter | bool | Optional | `true` | `linux only` - when true, automatically install prometheus-node-exporter in every linux node in the k8s cluster and scrape node metrics without any additional scrape config |
+| scrapeTargets.prometheusCollectorHealth | bool | Optional | `true` | when true, automatically scrape info about the Prometheus-Collector such as the amount and size of timeseries scraped |
+| scrapeTargets.windowsExporter | bool | Optional | `false` | `windows only` - when true, will scrape windows node exporter in every windows node discovered in the cluster, without requiring any additional scrape configuration. Note:- Windows-exporter is not installed by this tool on windows node(s). You would need to install it by yourselves, before turning this ON |
+| scrapeTargets.windowsKubeProxy | bool | Optional | `false` | `windows only` - when true, will scrape windows node's kubeproxy service, without requiring any additional scrape configuration, in every windows node discovered in the cluster. Note:- Windows kube-proxy metrics will soon be enabled on windows nodes for AKS clusters |
+| keepListRegexes.coreDns | string | Optional | `""` | when set to a regex string, the collector only collects the metrics whose names match the regex pattern for the coreDns service
+| keepListRegexes.kubelet | string | Optional | `""` | when set to a regex string, the collector only collects the metrics whose names match the regex pattern for kubelet
+| keepListRegexes.cAdvisor | string | Optional | `""` | when set to a regex string, the collector only collects the metrics whose names match the regex pattern for cAdvisor
+| keepListRegexes.kubeProxy | string | Optional | `""` | when set to a regex string, the collector only collects the metrics whose names match the regex pattern for kube-proxy
+| keepListRegexes.apiServer | string | Optional | `""` | when set to a regex string, the collector only collects the metrics whose names match the regex pattern for the kubernetes api server
+| keepListRegexes.kubeState | string | Optional | `""` | when set to a regex string, the collector only collects the metrics whose names match the regex pattern for kube-state metrics
+| keepListRegexes.nodeExporter | string | Optional | `""` | when set to a regex string, the collector only collects the metrics whose names match the regex pattern for node-exporter
+| keepListRegexes.windowsExporter | string | Optional | `""` | when set to a regex string, the collector only collects the metrics whose names match the regex pattern for windows exporter
+| keepListRegexes.windowsKubeProxy | string | Optional | `""` | when set to a regex string, the collector only collects the metrics whose names match the regex pattern for windows kube-proxy
+| prometheus-node-exporter.service.targetPort | INT | Optional | `true` | `linux only` - when a port is specified, node exporter uses this as bind/listen port, both prometheus-node-exporter.service.targetPort and prometheus-node-exporter.service.port should be set for this to work. |
+| prometheus-node-exporter.service.port | INT | Optional | `true` | `linux only` - when a port is specified, node exporter uses this as bind/listen port |
+
+# Chart Values for Prometheus-collector (when using monitoring account)
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| useMonitoringAccount | bool | <mark> `required` </mark> | `true` | ingest metrics into monitoring account(s) |
+| azureResourceId | string | <mark> `Required` </mark> | `""` | Azure ARM resource id for AKS cluster that will be monitored by this install |
+| azureResourceRegion | string | <mark> `Required` </mark> | `""` | Azure region for the AKS resource spricied in `azureResourceId` |
 | image.pullPolicy | string | Optional | `"IfNotPresent"` |  |
 | image.repository | string | Optional | `"mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images"` |  |
 | image.tag | string | Optional | `"1.1.2-main-03-07-2022-df71b65a"` |  |

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -122,10 +122,11 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 	CommonProperties["podname"] = os.Getenv(envPodName)
 	CommonProperties["helmreleasename"] = os.Getenv(envHelmReleaseName)
 	CommonProperties["osType"] = os.Getenv("OS_TYPE")
+	CommonProperties["macmode"] = os.Getenv("MAC")
 
 
 	aksResourceID := os.Getenv(envAKSResourceID)
-	// if the aks resource id is not defined, it is most likely an ACS Cluster
+	// if the aks resource id is not defined, it is most likely an ACS Cluster -- clean this up
 	//todo
 	//fix all the casing issues below for property names and also revist these telemetry before productizing as AKS addon
 	if aksResourceID == "" && os.Getenv(envACSResourceName) != "" {

--- a/otelcollector/scripts/livenessprobe.sh
+++ b/otelcollector/scripts/livenessprobe.sh
@@ -14,6 +14,7 @@ then
   exit 1
 fi
 
+if [ "${MAC}" != "true" ]; then
 # The mounted cert files are modified by the keyvault provider every time it probes for new certs
 # even if the actual contents don't change. Need to check if actual contents changed.
 if [ -d "/etc/config/settings/akv" ] && [ -d "/opt/akv-copy/akv" ]
@@ -24,6 +25,7 @@ then
     echo "A Metrics Account certificate has changed" > /dev/termination-log
     exit 1
   fi
+fi
 fi
 
 if [ ! -s "/opt/inotifyoutput.txt" ] #file doesn't exists or size == 0

--- a/otelcollector/telegraf/telegraf-prometheus-collector.conf
+++ b/otelcollector/telegraf/telegraf-prometheus-collector.conf
@@ -24,6 +24,7 @@
   nodeip = "$NODE_IP"
   mode = "$MODE"
   winmode = "$WINMODE"
+  macmode = "$MAC"
   controllertype = "$CONTROLLER_TYPE"
   defaultmetricaccountname = "$AZMON_DEFAULT_METRIC_ACCOUNT_NAME"
   namespace = "$POD_NAMESPACE"


### PR DESCRIPTION
* `useMonitoringAccount` (boolean) - this will turn on MAC 
* `azureResourceId` and `azureRegion` (strings) parameters are added
* when MAC is enabled, `azureResourceId` and `azureRegion` are required (else chart will warn and fail with error message)
* if both certificate info and MAC params are specified & turned ON, MAC will take precedence
* Disable windows daemonset when MAC is enabled
* Disable AKV & secrets when MAC is enabled
* Dont check for cert changes in liveness when MAC is enabled (linux)
* include 'macmode' to all telemetry
* Check for MDM INT (internal use) since it is not applicable when using MAC
* Update chartvalue list & deployment doc

$MAC environment variable (when "true") will tell that macmode is set, so that scripts & code can switch appropriately.

if $MAC="true", below will happen -- 

* $CLUSTER will have the value of `azureResourceId` passed in ( no case conversion, trimmed string, no other validation except for empty value check) - This is the same variable in non-MAC scenario will have the value passed in thru `clusterName` chart paramater 
* $AKSREGION will have the value of `azureResourceRegion`  (trimmed and converted to lower case, no other validation except for empty value check)