### PR TITLE
Updating MAC docs to use the version with the chart bug fix for MinimalIngestionProfile

### DIFF
--- a/otelcollector/docs/MAC-3P-Docs/Instructions for Private Preview Onboarding.md
+++ b/otelcollector/docs/MAC-3P-Docs/Instructions for Private Preview Onboarding.md
@@ -39,20 +39,20 @@ Ex: bash Onboarding-script.sh "00000000-0000-0000-0000-000000000000" "rg-name" "
 Cloud shell doesn’t let you replace the exe in location /usr/local/bin/helm.
 You can instead run the helm commands from the path ~/linux-amd64. Prefix the helm with "./" for it to pick up helm from this folder.**
 
-**Ex - ./helm pull oci://mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector --version 3.0.0-main-04-07-2022-33676484**
+**Ex - ./helm pull oci://mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector --version 3.0.0-main-04-21-2022-9c0c3a39**
 
 1.	Download the helm chart - 
 
         set HELM_EXPERIMENTAL_OCI=1
 
-        helm pull oci://mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector --version 3.0.0-main-04-07-2022-33676484
+        helm pull oci://mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector --version 3.0.0-main-04-21-2022-9c0c3a39
 
 2.  Install the helm chart with the following parameters  -
     
-        helm upgrade --install <release-name> ./prometheus-collector-3.0.0-main-04-07-2022-33676484.tgz --dependency-update --set useMonitoringAccount=true --set azureResourceId="<aks-resource-id>" --set azureResourceRegion="<aks-resource-location>" --set mode.advanced=true --namespace="kube-system" --create-namespace
+        helm upgrade --install <release-name> ./prometheus-collector-3.0.0-main-04-21-2022-9c0c3a39.tgz --dependency-update --set useMonitoringAccount=true --set azureResourceId="<aks-resource-id>" --set azureResourceRegion="<aks-resource-location>" --set mode.advanced=true --namespace="kube-system" --create-namespace
 
 
-Ex - helm upgrade --install my-collector-dev-release ./prometheus-collector-3.0.0-main-04-07-2022-33676484.tgz --dependency-update --set useMonitoringAccount=true --set azureResourceId="/subscriptions/subid/resourcegroups/rg-name/providers/Microsoft.ContainerService/managedClusters/clustername" --set azureResourceRegion="eastus2" --set mode.advanced=true --namespace="kube-system" --create-namespace
+Ex - helm upgrade --install my-collector-dev-release ./prometheus-collector-3.0.0-main-04-21-2022-9c0c3a39.tgz --dependency-update --set useMonitoringAccount=true --set azureResourceId="/subscriptions/subid/resourcegroups/rg-name/providers/Microsoft.ContainerService/managedClusters/clustername" --set azureResourceRegion="eastus2" --set mode.advanced=true --namespace="kube-system" --create-namespace
 
     Please make sure you have set the right context for the AKS cluster you want to install the chart on
     - az aks get-credentials -g <aks-rg-name> -n <aks-cluster-name> (This gets the cluster kubeconfig and sets it as the current context)

--- a/otelcollector/docs/MAC-3P-Docs/Onboarding-script.sh
+++ b/otelcollector/docs/MAC-3P-Docs/Onboarding-script.sh
@@ -207,5 +207,5 @@ done;
 
 echo "Onboarding was completed successfully, please deploy the prometheus-collector helm chart for data collection using the helm command below."
 echo "Please ensure to set the right cluster context before running the helm install command - See Step #2 in the instructions on how to set this."
-echo "helm upgrade --install prometheus-collector-release ./prometheus-collector-3.0.0-main-04-07-2022-33676484.tgz --dependency-update --set useMonitoringAccount=true --set azureResourceId=\"$aksResourceId\" --set azureResourceRegion=\"$trimmedRegion\" --set mode.advanced=true --namespace=\"kube-system\" --create-namespace"
+echo "helm upgrade --install prometheus-collector-release ./prometheus-collector-3.0.0-main-04-21-2022-9c0c3a39.tgz --dependency-update --set useMonitoringAccount=true --set azureResourceId=\"$aksResourceId\" --set azureResourceRegion=\"$trimmedRegion\" --set mode.advanced=true --namespace=\"kube-system\" --create-namespace"
 


### PR DESCRIPTION
Updated MAC 3P docs to use the latest chart version which has the fix for using minimalIngestionProfile for MAC mode for replicaset