### PR TITLE
Fix Kube state upgrade issue due to incompatible label selectors

### DIFF
--- a/.github/workflows/build-and-push-image-and-chart.yml
+++ b/.github/workflows/build-and-push-image-and-chart.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - vishwa/kubestateupgradefix
   pull_request:
     types: [opened, synchronize, reopened]
     branches:


### PR DESCRIPTION
When upgrading from chart version 3.5.2 to 4.7.0, upgrade fails due to selector labels being changed from 3.5.2 to 4.7.0. This fix is for that compat breaking issue.

I also filed a k-s-m bug to hear from them  if backcompat is expected to be broken between major versions, so we can plan accordingly. -- https://github.com/prometheus-community/helm-charts/issues/2013