### PR TITLE
Alerts for production clusters

### DIFF
--- a/alerts/ci-prod-aks-mac-weu.json
+++ b/alerts/ci-prod-aks-mac-weu.json
@@ -225,7 +225,7 @@ Uncomment and deploy below when alerts are available in westeurope
 //                         ]
 //                     },
 //                     {
-//                         "alert": "CPU Requests % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+//                         "alert": "CPU usage % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
 //                         "expression": "sum(sum by (cluster, namespace, pod, container) ( rate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\", namespace=\"monitoring\", cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", container=\"prometheus-collector\"}[5m]) ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) ( 1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\", namespace=\"monitoring\", cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\"}) )) by (container, pod) > 0.9",
 //                         "for": "PT3M",
 //                         "labels": {
@@ -248,14 +248,14 @@ Uncomment and deploy below when alerts are available in westeurope
 //                         ]
 //                     },
 //                     {
-//                         "alert": "Memory Requests % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+//                         "alert": "Memory usage % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
 //                         "expression": "(sum(container_memory_working_set_bytes{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", namespace=\"monitoring\", container=\"prometheus-collector\", image!=\"\"}) by (container, pod) / sum(kube_pod_container_resource_requests{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", namespace=\"monitoring\", container=\"prometheus-collector\", resource=\"memory\"}) by (container, pod)) > 0.9",
 //                         "for": "PT3M",
 //                         "labels": {
 //                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
 //                         },
 //                         "annotations": {
-//                             "description": "Memory Requests % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+//                             "description": "Memory usage % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
 //                         },
 //                         "severity": 4,
 //                         "resolveConfiguration": {

--- a/alerts/ci-prod-aks-msi-eus2.json
+++ b/alerts/ci-prod-aks-msi-eus2.json
@@ -223,7 +223,7 @@
                         ]
                     },
                     {
-                        "alert": "CPU Requests % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-msi-eus2",
+                        "alert": "CPU usage % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-msi-eus2",
                         "expression": "sum(sum by (cluster, namespace, pod, container) ( rate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\", namespace=\"monitoring\", cluster=\"ci-prod-aks-msi-eus2\", container=\"prometheus-collector\"}[5m]) ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) ( 1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\", namespace=\"monitoring\", cluster=\"ci-prod-aks-msi-eus2\"}) )) by (container, pod) > 0.9",
                         "for": "PT3M",
                         "labels": {
@@ -246,14 +246,14 @@
                         ]
                     },
                     {
-                        "alert": "Memory Requests % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-msi-eus2",
+                        "alert": "Memory usage % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-msi-eus2",
                         "expression": "(sum(container_memory_working_set_bytes{cluster=\"ci-prod-aks-msi-eus2\", namespace=\"monitoring\", container=\"prometheus-collector\", image!=\"\"}) by (container, pod) / sum(kube_pod_container_resource_requests{cluster=\"ci-prod-aks-msi-eus2\", namespace=\"monitoring\", container=\"prometheus-collector\", resource=\"memory\"}) by (container, pod)) > 0.9",
                         "for": "PT3M",
                         "labels": {
                             "cluster": "ci-prod-aks-msi-eus2"
                         },
                         "annotations": {
-                            "description": "Memory Requests % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-msi-eus2"
+                            "description": "Memory usage % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-msi-eus2"
                         },
                         "severity": 4,
                         "resolveConfiguration": {

--- a/alerts/ci_prod_aks_eus.json
+++ b/alerts/ci_prod_aks_eus.json
@@ -223,7 +223,7 @@
                         ]
                     },
                     {
-                        "alert": "CPU Requests % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-eus",
+                        "alert": "CPU usage % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-eus",
                         "expression": "sum(sum by (cluster, namespace, pod, container) ( rate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\", namespace=\"monitoring\", cluster=\"ci-prod-aks-eus\", container=\"prometheus-collector\"}[5m]) ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) ( 1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\", namespace=\"monitoring\", cluster=\"ci-prod-aks-eus\"}) )) by (container, pod) > 0.9",
                         "for": "PT3M",
                         "labels": {
@@ -246,14 +246,37 @@
                         ]
                     },
                     {
-                        "alert": "Memory Requests % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-eus",
+                        "alert": "CPU usage % greater than 5 for prometheus-collector containers on cluster ci-prod-aks-eus",
+                        "expression": "sum(sum by (cluster, namespace, pod, container) ( rate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\", namespace=\"monitoring\", cluster=\"ci-prod-aks-eus\", container=\"prometheus-collector\"}[5m]) ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) ( 1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\", namespace=\"monitoring\", cluster=\"ci-prod-aks-eus\"}) )) by (container, pod) > 0.5",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "ci-prod-aks-eus"
+                        },
+                        "annotations": {
+                            "description": "CPU usage greater than 5% for prometheus-collector on cluster ci-prod-aks-eus"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Memory usage % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-eus",
                         "expression": "(sum(container_memory_working_set_bytes{cluster=\"ci-prod-aks-eus\", namespace=\"monitoring\", container=\"prometheus-collector\", image!=\"\"}) by (container, pod) / sum(kube_pod_container_resource_requests{cluster=\"ci-prod-aks-eus\", namespace=\"monitoring\", container=\"prometheus-collector\", resource=\"memory\"}) by (container, pod)) > 0.9",
                         "for": "PT3M",
                         "labels": {
                             "cluster": "ci-prod-aks-eus"
                         },
                         "annotations": {
-                            "description": "Memory Requests % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-eus"
+                            "description": "Memory usage % greater than 90 for prometheus-collector containers on cluster ci-prod-aks-eus"
                         },
                         "severity": 4,
                         "resolveConfiguration": {


### PR DESCRIPTION
Alerts for `ci-prod-aks-eus` and `ci-prod-aks-msi-eus2`

Absent UP metric for the following targets:
- node
- kubelet
- windows-exporter
- kube-proxy
- kube-apiserver
- kube-proxy-windows
- kube-state-metrics
- cadvisor
- kube-dns

CPU and Memory Requests percentage greater than 90%.

These will raise an ICM for the Container Insights / Triage team.


 `ci-prod-aks-mac-weu` is linked with a MAC account in westeurope (alerting is not available there yet, hence checking in a commented file with the tenative alerts)