### PR TITLE
Default alerts for Prometheus

### DIFF
--- a/mixins/kubernetes/alerts/apps_alerts.libsonnet
+++ b/mixins/kubernetes/alerts/apps_alerts.libsonnet
@@ -205,6 +205,34 @@
             alert: 'KubeContainerWaiting',
           },
           {
+            expr: |||
+              sum by (namespace, pod, container) (kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'container {{ $labels.container}} has been restarted in the last 1 hour.',
+              summary: 'Pod container restarted in last 1 hour',
+            },
+            'for': '1h',
+            alert: 'KubeContainerRestart',
+          },
+          {
+            expr: |||
+              sum(kubelet_volume_stats_used_bytes) by (persistentvolumeclaim) / sum(kubelet_volume_stats_capacity_bytes) by (persistentvolumeclaim) >.8 
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Average PV usage is greater than 80%',
+              summary: 'Average PV usage is greater than 80%',
+            },
+            'for': '1h',
+            alert: 'KubePersistentVolumeFillingUp',
+          },
+          {
             alert: 'KubeDaemonSetNotScheduled',
             expr: |||
               kube_daemonset_status_desired_number_scheduled{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}

--- a/mixins/kubernetes/alerts/resource_alerts.libsonnet
+++ b/mixins/kubernetes/alerts/resource_alerts.libsonnet
@@ -39,6 +39,48 @@
             'for': '10m',
           },
           {
+            alert: 'KubeContainerCPUPercentage',
+            expr: |||
+              sum(sum by (cluster, namespace, pod, container) ( rate(container_cpu_usage_seconds_total{image!=""}[5m]) ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""}) )) / sum(kube_pod_container_resource_requests{resource="cpu"})  >.95 
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Average CPU usage per container is greater than 95%.',
+              summary: 'Average CPU usage per container is greater than 95%',
+            },
+            'for': '10m',
+          },
+          {
+            alert: 'KubeContainerMemoryPercentage',
+            expr: |||
+              sum(container_memory_working_set_bytes{container!="", image!=""}) / sum(kube_pod_container_resource_limits{resource="memory"})  >.95 
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Average Memory usage per container is greater than 95%.',
+              summary: 'Average Memory usage per container is greater than 95%',
+            },
+            'for': '10m',
+          },
+          {
+            alert: 'KubeOOMKilled',
+            expr: |||
+              kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} > 0
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Number of OOM killed containers is greater than 0',
+              summary: 'Number of OOM killed containers is greater than 0',
+            },
+            'for': '10m',
+          },
+          {
             alert: 'KubeMemoryOvercommit',
             expr: |||
               sum(namespace_memory:kube_pod_container_resource_requests:sum{%(ignoringOverprovisionedWorkloadSelector)s}) - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0

--- a/mixins/kubernetes/rules/windows_recording_rules/templates/default-prometheus-alerts.json
+++ b/mixins/kubernetes/rules/windows_recording_rules/templates/default-prometheus-alerts.json
@@ -1,0 +1,260 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "variables": {},
+    "resources": [
+        {
+            "name": "containerinsightsprodclusteraccount_alerts",
+            "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+            "apiVersion": "2021-07-22-preview",
+            "location": "eastus2euap",
+            "properties": {
+                "description": "rule group for cluster sohamcluster",
+                "scopes": [
+                    "/subscriptions/ce4d1293-71c0-4c72-bc55-133553ee9e50/resourcegroups/sohamTestKV/providers/microsoft.monitor/accounts/sohamtest3"
+                ],
+                "rules": [
+                    {
+                        "record": "namespace_cpu:kube_pod_container_resource_requests:sum",
+                        "expression": "sum by (namespace, cluster) (sum by (namespace, pod, cluster) (max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{resource=\"cpu\",job=\"kube-state-metrics\"}) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))"
+                    },  
+                    {
+                        "record": "namespace_memory:kube_pod_container_resource_requests:sum",
+                        "expression": "sum by (namespace, cluster) (sum by (namespace, pod, cluster) (max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{resource=\"memory\",job=\"kube-state-metrics\"}) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))"
+                    },  
+                    {
+                        "alert": "Average CPU usage per container is greater than 95%",
+                        "expression": "sum(sum by (cluster, namespace, pod, container) ( rate(container_cpu_usage_seconds_total{image!=\"\"}[5m]) ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}) )) / sum(kube_pod_container_resource_requests{resource=\"cpu\"})  >.95",
+                        "for": "PT5M",
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Average CPU usage per container is greater than 95%"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT15M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Average Memory usage per container is greater than 95%.",
+                        "expression": "sum(container_memory_working_set_bytes{container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_limits{resource=\"memory\"})  >.95",
+                        "for": "PT10M",
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Average Memory usage per container is greater than 95%"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Memory limits in total exceed the capacity of the cluster",
+                        "expression": "kube_pod_container_status_last_terminated_reason{reason=\"OOMKilled\"} > 0",
+                        "for": "PT10M",
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Memory limits in total exceed the capacity of the cluster"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Average PV usage is greater than 80%",
+                        "expression": "sum(kubelet_volume_stats_used_bytes{job=\"kubelet\"}) / sum(kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) >.8",
+                        "for": "PT10M",
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Average PV usage is greater than 80%"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT15M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Pod container restarted in last 1 hour",
+                        "expression": "sum by (namespace, pod, container) (kube_pod_container_status_restarts_total{job=\"kube-state-metrics\"}) > 0",
+                        "for": "PT60M", 
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Pod container restarted in last 1 hour"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Node is  ready.",
+                        "expression": "kube_node_status_condition{job=\"kube-state-metrics\",condition=\"Ready\",status=\"true\"} == 0",
+                        "for": "PT60M",
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Node is  ready."
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT15M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Pod container waiting longer than 1 hour ",
+                        "expression": "sum by (namespace, pod, container, cluster)(kube_pod_container_status_waiting{job=\"kube-state-metrics\"}) > 0",
+                        "for": "PT60M",
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Pod container waiting longer than 1 hour"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT15M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Job did not complete in time",
+                        "expression": "kube_job_spec_completions{job=\"kube-state-metrics\"} - kube_job_status_succeeded{job=\"kube-state-metrics\"} > 0",
+                        "for": "PT720M",
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Job is taking more than 12 hours to complete."
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT15M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Cluster has overcommitted CPU resource requests",
+                        "expression": "sum(namespace_cpu:kube_pod_container_resource_requests:sum) - (sum(kube_node_status_allocatable{resource=\"cpu\"}) - max(kube_node_status_allocatable{resource=\"cpu\"})) > 0 and (sum(kube_node_status_allocatable{resource=\"cpu\"}) - max(kube_node_status_allocatable{resource=\"cpu\"})) > 0 ",
+                        "for": "PT720M",
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Cluster has overcommitted CPU resource requests"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT15M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Cluster has overcommitted memory resource requests",
+                        "expression": "sum(namespace_memory:kube_pod_container_resource_requests:sum) - (sum(kube_node_status_allocatable{resource=\"memory\"}) - max(kube_node_status_allocatable{resource=\"memory\"})) > 0 and (sum(kube_node_status_allocatable{resource=\"memory\"}) - max(kube_node_status_allocatable{resource=\"memory\"})) > 0",
+                        "for": "PT720M",
+                        "labels": {
+                            "cluster": "$cluster"
+                        },
+                        "annotations": {
+                            "description": "Cluster has overcommitted memory resource requests"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT15M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    }  
+                ]
+            }
+        }
+    ]
+}

--- a/otelcollector/referenceapp/testTemplates/azure-pvc-disk.yaml
+++ b/otelcollector/referenceapp/testTemplates/azure-pvc-disk.yaml
@@ -1,0 +1,22 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: mypod
+spec:
+  containers:
+  - name: mypod
+    image: mcr.microsoft.com/oss/nginx/nginx:1.15.5-alpine
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi
+    volumeMounts:
+    - mountPath: "/mnt/azure"
+      name: volume
+  volumes:
+    - name: volume
+      persistentVolumeClaim:
+        claimName: azure-managed-disk

--- a/otelcollector/referenceapp/testTemplates/azure-pvc.yaml
+++ b/otelcollector/referenceapp/testTemplates/azure-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: azure-managed-disk
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: managed-csi
+  resources:
+    requests:
+      storage: 5Gi

--- a/otelcollector/referenceapp/testTemplates/memory-leak.yaml
+++ b/otelcollector/referenceapp/testTemplates/memory-leak.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: memory-leak
+  name: memory-leak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: memory-leak
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: memory-leak
+    spec:
+      volumes:
+        - name: html
+          emptyDir: {}
+      containers:
+        - name: memoryleak-1
+          image: valentinomiazzo/jvm-memory-test
+          resources:
+            limits:
+              cpu: 150m
+              memory: 15Mi
+            requests:
+              cpu: 75m
+              memory: 12Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext: {}
+      schedulerName: default-scheduler
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600


### PR DESCRIPTION
This commit is for the template changes for the default Prometheus alerts. I have added the test templates needed for generating persistent volumes, etc in the test folder here. I will add the list of the generated ICM alert links in a separate comment.