### PR TITLE
Update dependabot to ignore opentelemetry dependencies for otelcollector and promconfigvalidator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       interval: "daily"
       time: "10:00"
       timezone: "America/Los_Angeles"
+    ignore:
+    - dependency-name: "go.opentelemetry.io/collector"
+    - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
     open-pull-requests-limit: 2
     rebase-strategy: "auto"
   - package-ecosystem: "gomod"
@@ -19,6 +22,9 @@ updates:
       interval: "daily"
       time: "10:00"
       timezone: "America/Los_Angeles"
+    ignore:
+    - dependency-name: "go.opentelemetry.io/collector"
+    - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
     open-pull-requests-limit: 2
     rebase-strategy: "auto"
   - package-ecosystem: "gomod"


### PR DESCRIPTION
This should stop dependabot from opening PRs since we want to always update these manually