### PR TITLE
Remove stray 'p' in regex merge.

### DIFF
--- a/otelcollector/configmapparser/tomlparser-default-targets-metrics-keep-list.rb
+++ b/otelcollector/configmapparser/tomlparser-default-targets-metrics-keep-list.rb
@@ -119,7 +119,7 @@ def populateSettingValuesFromConfigMap(parsedConfig)
       if !cadvisorRegex.empty?
         if isValidRegex(cadvisorRegex) == true
           @cadvisorRegex = cadvisorRegex
-          pConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap metrics keep list regex for cadvisor")
+          ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap metrics keep list regex for cadvisor")
         else
           ConfigParseErrorLogger.logError(LOGGING_PREFIX, "Invalid keep list regex for cadvisor")
         end


### PR DESCRIPTION
I'm seeing this error when our Prometheus configuration loads, and tries to merge the metrics we require with the minimal keep list. I think there's a stray 'p' on this line.

```
**************************End debug-mode Settings Processing**************************
default-scrape-keep-lists::error::Exception while reading config map settings for default targets metrics keep list - undefined local variable or method `pConfigParseErrorLogger' for main:Object, using defaults, please check config map for errors
```