### PR TITLE
Otelcollector error to stdout/telemetry bug

### DIFF
--- a/.github/workflows/build-and-push-image-and-chart.yml
+++ b/.github/workflows/build-and-push-image-and-chart.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - grace/otelcollector-error-telemetry
   pull_request:
     types: [opened, synchronize, reopened]
     branches:

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -231,7 +231,7 @@ func PushLogErrorsToAppInsightsTraces(records []map[interface{}]interface{}, sev
 
 		// Logs have different parsed formats depending on if they're from otelcollector or metricsextension
 		if tag == fluentbitOtelCollectorLogsTag {
-			logEntry = fmt.Sprintf("%s %s %s", ToString(record["caller"]), ToString(record["msg"]), ToString(record["error"]))
+			logEntry = fmt.Sprintf("%s %s", ToString(record["caller"]), ToString(record["msg"]))
 		} else if tag == fluentbitContainerLogsTag {
 			logEntry = ToString(record["log"])
 		}


### PR DESCRIPTION
The json encoding setting in the otelcollector pipeline wasn't being added since I added the `Service` part for debug mode to the `OtelConfig` struct. Fluentbit wasn't able to parse the collector errors correctly and these weren't being sent to stdout/our telemetry. The whole error message will also be sent to our telemetry now so we will know the full reason for the exporting failed errors