### PR TITLE
Remove icmsetting from recommended alerts template

### DIFF
--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
@@ -34,11 +34,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Average CPU usage for container is greater than 95% in cluster: {{$labels.cluster}} for container: {{$labels.container}}"
-
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -59,10 +55,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Average Memory usage per container is greater than 95% in cluster: {{$labels.cluster}} for container: {{$labels.container}}"
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -83,10 +76,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Number of OOM killed containers is greater than 0 in cluster: {{$labels.cluster}} for container: {{$labels.container}}"
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -107,10 +97,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Average PV usage is greater than 80% in cluster: {{$labels.cluster}} in pod: {{$labels.pod}} in container: {{$labels.container}}"
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -131,10 +118,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Pod container restarted in last 1 hour in cluster: {{$labels.cluster}} in pod: {{$labels.pod}} in container: {{$labels.container}}"
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -155,11 +139,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Node {{$labels.node}} is not ready in cluster: {{$labels.cluster}}"
-
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -180,10 +160,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Ready state of pods is less than 80% in cluster: {{$labels.cluster}} in deployment: {{$labels.deployment}}"
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -204,10 +181,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Number of stale jobs older than six hours is greater than 0 in cluster: {{$labels.cluster}}"
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -228,10 +202,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Average node CPU utilization is greater than 80% in cluster: {{$labels.cluster}} in node: {{$labels.instance}}"
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -252,10 +223,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Working set memory for a node is greater than 80% in cluster: {{$labels.cluster}} in node: {{$labels.instance}}"
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     },
@@ -276,10 +244,7 @@
                         },
                         "actions": [
                             {
-                                "ActionProperties": {
-                                    "Icm.Enabled": "True",
-                                    "Icm.Title": "Number of pods in failed state are greater than 0 in cluster: {{$labels.cluster}} pod: {{$labels.pod}}"
-                                }
+                                "actionGroupId": "$actionGroupResourceId"
                             }
                         ]
                     }  


### PR DESCRIPTION
This change removes the Icm setting from the recommended alerts template for external customers since Icm setting is internal for us.