### PR TITLE
Collect k-s-m stdout logs

### DIFF
--- a/otelcollector/fluent-bit/fluent-bit-daemonset.conf
+++ b/otelcollector/fluent-bit/fluent-bit-daemonset.conf
@@ -24,11 +24,11 @@
     Skip_Long_Lines On
     Ignore_Older 2m
 
-# kube-state-metrics logs
+# kube-state-metrics container logs
 [INPUT]
     Name tail
-    Tag prometheus.log.prometheuscollectorcontainer
-    Path /var/log/containers/*kube-state-metrics*kube-state-metrics*.log
+    Tag prometheus.log.kubestatemetricscontainer
+    Path /var/log/containers/ama-metrics-ksm*kube-system*.log
     DB /var/opt/microsoft/state/prometheus-collector-ai.db
     DB.Sync Off
     Parser cri


### PR DESCRIPTION
The path for k-s-m logs in the daemonset is /var/log/containers/*kube-state-metrics*kube-state-metrics*.log. For example, the   k-s-m log name in the daemonset of my cluster is soham-test-chart-8-kube-state-metrics-68ff744774-lrq5f_default_kube-state-metrics-6e83493f2af7348237ced97b6c466e732ccced910e9a2efa574d012b70d7317f.log. I have included this path in the tail plugin.