### PR TITLE
Add the enabled flags in the ci recommended alerts template

### DIFF
--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
@@ -15,6 +15,7 @@
                 "scopes": [
                     "$mac"
                 ],
+                "enabled": true,
                 "interval": "PT5M",
                 "rules": [
                     {
@@ -27,6 +28,7 @@
                         "annotations": {
                             "description": "Average CPU usage per container is greater than 95%"
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -48,6 +50,7 @@
                         "annotations": {
                             "description": "Average Memory usage per container is greater than 95%"
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -69,6 +72,7 @@
                         "annotations": {
                             "description": "Number of OOM killed containers is greater than 0"
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -90,6 +94,7 @@
                         "annotations": {
                             "description": "Average PV usage is greater than 80%"
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -111,6 +116,7 @@
                         "annotations": {
                             "description": "Pod container restarted in last 1 hour"
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -132,6 +138,7 @@
                         "annotations": {
                             "description": "Node has been unready for more than 15 minutes "
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -153,6 +160,7 @@
                         "annotations": {
                             "description": "Ready state of pods is less than 80%."
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -174,6 +182,7 @@
                         "annotations": {
                             "description": "Number of stale jobs older than six hours is greater than 0"
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -195,6 +204,7 @@
                         "annotations": {
                             "description": "Average node CPU utilization is greater than 80%"
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -216,6 +226,7 @@
                         "annotations": {
                             "description": "Working set memory for a node is greater than 80%."
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,
@@ -237,6 +248,7 @@
                         "annotations": {
                             "description": "Number of pods in failed state are greater than 0"
                         },
+                        "enabled": true,
                         "severity": 4,
                         "resolveConfiguration": {
                             "autoResolved": true,


### PR DESCRIPTION
This change adds the enabled flags in the  ci recommended alerts template which the customers can use to enable/disable specific alert rules by setting the parameter value to 'false'. This is based on the setting up alert documentation [here](https://eng.ms/docs/products/geneva/metrics/prometheus/prommdmtutorial7setupalerts).