### PR TITLE
Adding default collector settings configmap for MAC mode

### DIFF
--- a/otelcollector/deploy/prometheus-collector-settings-configmap-mac.yaml
+++ b/otelcollector/deploy/prometheus-collector-settings-configmap-mac.yaml
@@ -8,7 +8,6 @@ data:
     #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
     ver1
   prometheus-collector-settings: |-
-    default_metric_account_name = "mymetricaccountname"
     cluster_alias = ""
   default-scrape-settings-enabled: |-
     kubelet = true


### PR DESCRIPTION
Adding this configmap to reference in our documents, since the existing configmap resets the default targets - 
  coredns,kubeproxy,apiserver and prometheusCollectorHealth to true when applied. This is to keep it consistent with the code.