### PR TITLE
Fix memory usage alert which hits multiple matches for labels issue 

### DIFF
--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
@@ -26,7 +26,7 @@
         }
     },
     "variables": {
-        "kubernetesAlertRuleGroup": "KubernetesAlert-RecommendedCIAlerts",
+        "kubernetesAlertRuleGroup": "RecommendedCIAlerts-",
         "kubernetesAlertRuleGroupName": "[concat(variables('kubernetesAlertRuleGroup'), parameters('clusterName'))]",
         "kubernetesAlertRuleGroupDescription": "Kubernetes Alert RuleGroup-RecommendedCIAlerts",
         "version": " - 0.1"
@@ -67,7 +67,7 @@
                     },
                     {
                         "alert": "Average Memory usage per container is greater than 95%.",
-                        "expression": "(container_memory_working_set_bytes{container!=\"\", image!=\"\", container_name!=\"POD\"} / on(namespace,cluster,pod,container) kube_pod_container_resource_limits{resource=\"memory\"}) > .95 ",
+                        "expression": "(container_memory_working_set_bytes{container!=\"\", image!=\"\", container_name!=\"POD\"} / on(namespace,cluster,pod,container) group_left kube_pod_container_resource_limits{resource=\"memory\"}) > .95 ",
                         "for": "PT10M",
                         "annotations": {
                             "description": "Average Memory usage per container is greater than 95%"


### PR DESCRIPTION
This PR adds a group_left clause on the memory alert which hit some alerts from Ruler service like "multiple matches for labels: many-to-one matching must be explicit (group_left/group_right)", although the alerts were firing properly before when I tested in my personal dev cluster. 
I followed this [doc](https://prometheus.io/docs/prometheus/latest/querying/operators/#many-to-one-and-one-to-many-vector-matches) to add the group_left and tested this again in my cluster, the alerts fire fine. [Here](https://ms.portal.azure.com/#view/Microsoft_Azure_Monitoring/AzureMonitoringBrowseBlade/~/alertsV2) are the unique test alerts generated for each collection of namespace,cluster,pod,container.