### PR TITLE
Fix dashboard bugs from 09/29 bug bash

### DIFF
--- a/mixins/kubernetes/dashboards/resources/cluster.libsonnet
+++ b/mixins/kubernetes/dashboards/resources/cluster.libsonnet
@@ -20,20 +20,23 @@ local template = grafana.template;
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&from=$__from&to=$__to&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
           linkTooltip: 'Drill down to pods',
+          linkTargetBlank: true,
         },
         'Value #A': {
           alias: 'Pods',
           linkTooltip: 'Drill down to pods',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&from=$__from&to=$__to&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
           decimals: 0,
+          linkTargetBlank: true,
         },
         'Value #B': {
           alias: 'Workloads',
           linkTooltip: 'Drill down to workloads',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix,  uid: $._config.grafanaDashboardIDs['k8s-resources-workloads-namespace.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workloads-namespace?var-datasource=$datasource&from=$__from&to=$__to&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix,  uid: $._config.grafanaDashboardIDs['k8s-resources-workloads-namespace.json'] },
           decimals: 0,
+          linkTargetBlank: true,
         },
       };
 
@@ -55,8 +58,9 @@ local template = grafana.template;
       local networkTableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&from=$__from&to=$__to&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
           linkTooltip: 'Drill down to pods',
+          linkTargetBlank: true,
         },
         'Value #A': {
           alias: 'Current Receive Bandwidth',
@@ -96,8 +100,9 @@ local template = grafana.template;
       local storageIOTableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&from=$__from&to=$__to&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
           linkTooltip: 'Drill down to pods',
+          linkTargetBlank: true,
         },
         'Value #A': {
           alias: 'IOPS(Reads)',

--- a/mixins/kubernetes/dashboards/resources/namespace.libsonnet
+++ b/mixins/kubernetes/dashboards/resources/namespace.libsonnet
@@ -32,7 +32,8 @@ local template = grafana.template;
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&from=$__from&to=$__to&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
+          linkTargetBlank: true,
         },
       };
 
@@ -48,8 +49,9 @@ local template = grafana.template;
       local networkTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&from=$__from&to=$__to&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
           linkTooltip: 'Drill down to pods',
+          linkTargetBlank: true,
         },
         'Value #A': {
           alias: 'Current Receive Bandwidth',
@@ -97,8 +99,9 @@ local template = grafana.template;
       local storageIOTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&from=$__from&to=$__to&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
           linkTooltip: 'Drill down to pods',
+          linkTargetBlank: true,
         },
         'Value #A': {
           alias: 'IOPS(Reads)',

--- a/mixins/kubernetes/dashboards/resources/workload-namespace.libsonnet
+++ b/mixins/kubernetes/dashboards/resources/workload-namespace.libsonnet
@@ -52,7 +52,8 @@ local template = grafana.template;
       local tableStyles = {
         workload: {
           alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-workload.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&from=$__from&to=$__to&var-workload=$__cell&var-type=$__cell_2' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-workload.json'] },
+          linkTargetBlank: true,
         },
         workload_type: {
           alias: 'Workload Type',
@@ -95,8 +96,9 @@ local template = grafana.template;
       local networkTableStyles = {
         workload: {
           alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-workload.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&from=$__from&to=$__to&var-workload=$__cell&var-type=$type' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-workload.json'] },
           linkTooltip: 'Drill down to pods',
+          linkTargetBlank: true,
         },
         workload_type: {
           alias: 'Workload Type',

--- a/mixins/kubernetes/dashboards/resources/workload.libsonnet
+++ b/mixins/kubernetes/dashboards/resources/workload.libsonnet
@@ -56,7 +56,8 @@ local template = grafana.template;
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&from=$__from&to=$__to&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
+          linkTargetBlank: true,
         },
       };
 
@@ -96,7 +97,8 @@ local template = grafana.template;
       local networkTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&from=$__from&to=$__to&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
+          linkTargetBlank: true,
         },
         'Value #A': {
           alias: 'Current Receive Bandwidth',


### PR DESCRIPTION
1) Drill-down dashboards (thru links) now preserve the time range selected in the original dashboard
2) Drill downs now open in a new tab (new window will be considered pop-up, so new tab, since its 'internal' uri w.r.t to original dashboard that has the link)

You can see all the new dashboards in here -- https://vishwago-gchpbqhhg6e8hdfe.wcus.grafana.azure.com/dashboards/f/fF_f0b44z/test-10-03-2022-vishwa

(Note that when u click on links in the updated dashboards in this folder, the links in the newly opened dashboard will be from the *old* dashboard in this grafana instance -- to the links work only first level in this grafana instance. But in reality it will work when the change is fully deployed )
