### PR TITLE
Update per job scrape interval

### DIFF
--- a/otelcollector/configmapparser/prometheus-config-merger.rb
+++ b/otelcollector/configmapparser/prometheus-config-merger.rb
@@ -17,6 +17,8 @@ LOGGING_PREFIX = "prometheus-config-merger"
 @regexHashFile = "/opt/microsoft/configmapparser/config_def_targets_metrics_keep_list_hash"
 @regexHash = {}
 @sendDSUpMetric = false
+@intervalHashFile = "/opt/microsoft/configmapparser/config_def_targets_scrape_intervals_hash"
+@intervalHash = {}
 
 @kubeletDefaultFileRsSimple = @defaultPromConfigPathPrefix + "kubeletDefaultRsSimple.yml"
 @kubeletDefaultFileRsAdvanced = @defaultPromConfigPathPrefix + "kubeletDefaultRsAdvanced.yml"
@@ -63,6 +65,39 @@ def loadRegexHash
     @regexHash = YAML.load_file(@regexHashFile)
   rescue => errorStr
     ConfigParseErrorLogger.logError(LOGGING_PREFIX, "Exception in loadRegexHash for prometheus config: #{errorStr}. Keep list regexes will not be used")
+  end
+end
+
+def loadIntervalHash
+  begin
+    @intervalHash = YAML.load_file(@intervalHashFile)
+  rescue => errorStr
+    ConfigParseErrorLogger.logError(LOGGING_PREFIX, "Exception in loadIntervalHash for prometheus config: #{errorStr}. Scrape interval will not be used")
+  end
+end
+
+def UpdateScrapeIntervalConfig(yamlConfigFile, scrapeInterval)
+  begin
+    ConfigParseErrorLogger.log(LOGGING_PREFIX, "Updating scrape interval config for #{yamlConfigFile}")
+    config = YAML.load(File.read(yamlConfigFile))
+    scrapeIntervalConfig = scrapeInterval
+
+    # Iterate through each scrape config and update scrape interval config 
+    if !config.nil?
+      scrapeConfigs = config["scrape_configs"]
+      if !scrapeConfigs.nil? && !scrapeConfigs.empty?
+        scrapeConfigs.each { |scfg|
+          scrapeCfgs = scfg["scrape_interval"]
+          if !scrapeCfgs.nil?
+            scfg["scrape_interval"] = scrapeIntervalConfig
+          end
+        }
+        cfgYamlWithScrapeConfig = YAML::dump(config)
+        File.open(yamlConfigFile, "w") { |file| file.puts cfgYamlWithScrapeConfig }
+      end
+    end
+  rescue => errorStr
+    ConfigParseErrorLogger.logError(LOGGING_PREFIX, "Exception while updating scrape interval config in default target file - #{yamlConfigFile} : #{errorStr}. The Scrape interval will not be used")
   end
 end
 
@@ -117,10 +152,12 @@ def populateDefaultPrometheusConfig
     defaultConfigs = []
     if !ENV["AZMON_PROMETHEUS_KUBELET_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_KUBELET_SCRAPING_ENABLED"].downcase == "true"
       kubeletMetricsKeepListRegex = @regexHash["KUBELET_METRICS_KEEP_LIST_REGEX"]
+      kubeletScrapeInterval = @intervalHash["KUBELET_SCRAPE_INTERVAL"]
       if currentControllerType == @replicasetControllerType
         if advancedMode == false
           if !kubeletMetricsKeepListRegex.nil? && !kubeletMetricsKeepListRegex.empty?
             AppendMetricRelabelConfig(@kubeletDefaultFileRsSimple, kubeletMetricsKeepListRegex)
+            UpdateScrapeIntervalConfig(@kubeletDefaultFileRsSimple, kubeletScrapeInterval)
           end
           defaultConfigs.push(@kubeletDefaultFileRsSimple)
         elsif windowsDaemonset == true && @sendDSUpMetric == true
@@ -132,6 +169,7 @@ def populateDefaultPrometheusConfig
         if advancedMode == true && (windowsDaemonset == true || ENV["OS_TYPE"].downcase == "linux")
           if !kubeletMetricsKeepListRegex.nil? && !kubeletMetricsKeepListRegex.empty?
             AppendMetricRelabelConfig(@kubeletDefaultFileDs, kubeletMetricsKeepListRegex)
+            UpdateScrapeIntervalConfig(@kubeletDefaultFileRsSimple, kubeletScrapeInterval)
           end
           contents = File.read(@kubeletDefaultFileDs)
           contents = contents.gsub("$$NODE_IP$$", ENV["NODE_IP"])
@@ -144,26 +182,32 @@ def populateDefaultPrometheusConfig
     end
     if !ENV["AZMON_PROMETHEUS_COREDNS_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_COREDNS_SCRAPING_ENABLED"].downcase == "true" && currentControllerType == @replicasetControllerType
       corednsMetricsKeepListRegex = @regexHash["COREDNS_METRICS_KEEP_LIST_REGEX"]
+      corednsScrapeInterval = @intervalHash["COREDNS_SCRAPE_INTERVAL"]
       if !corednsMetricsKeepListRegex.nil? && !corednsMetricsKeepListRegex.empty?
         AppendMetricRelabelConfig(@corednsDefaultFile, corednsMetricsKeepListRegex)
+        UpdateScrapeIntervalConfig(@corednsDefaultFile, corednsScrapeInterval)
       end
       defaultConfigs.push(@corednsDefaultFile)
     end
     if !ENV["AZMON_PROMETHEUS_CADVISOR_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_CADVISOR_SCRAPING_ENABLED"].downcase == "true"
       cadvisorMetricsKeepListRegex = @regexHash["CADVISOR_METRICS_KEEP_LIST_REGEX"]
+      cadvisorScrapeInterval = @intervalHash["CADVISOR_SCRAPE_INTERVAL"]
       if currentControllerType == @replicasetControllerType
         if advancedMode == false
           if !cadvisorMetricsKeepListRegex.nil? && !cadvisorMetricsKeepListRegex.empty?
             AppendMetricRelabelConfig(@cadvisorDefaultFileRsSimple, cadvisorMetricsKeepListRegex)
+            UpdateScrapeIntervalConfig(@cadvisorDefaultFileRsSimple, cadvisorScrapeInterval)
           end
           defaultConfigs.push(@cadvisorDefaultFileRsSimple)
         elsif @sendDSUpMetric == true
+          UpdateScrapeIntervalConfig(@cadvisorDefaultFileRsAdvanced, cadvisorScrapeInterval)
           defaultConfigs.push(@cadvisorDefaultFileRsAdvanced)
         end
       else
         if advancedMode == true && ENV["OS_TYPE"].downcase == "linux"
           if !cadvisorMetricsKeepListRegex.nil? && !cadvisorMetricsKeepListRegex.empty?
             AppendMetricRelabelConfig(@cadvisorDefaultFileDs, cadvisorMetricsKeepListRegex)
+            UpdateScrapeIntervalConfig(@cadvisorDefaultFileDs, cadvisorScrapeInterval)
           end
           contents = File.read(@cadvisorDefaultFileDs)
           contents = contents.gsub("$$NODE_IP$$", ENV["NODE_IP"])
@@ -175,22 +219,28 @@ def populateDefaultPrometheusConfig
     end
     if !ENV["AZMON_PROMETHEUS_KUBEPROXY_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_KUBEPROXY_SCRAPING_ENABLED"].downcase == "true" && currentControllerType == @replicasetControllerType
       kubeproxyMetricsKeepListRegex = @regexHash["KUBEPROXY_METRICS_KEEP_LIST_REGEX"]
+      kubeproxyScrapeInterval = @intervalHash["KUBEPROXY_SCRAPE_INTERVAL"]
       if !kubeproxyMetricsKeepListRegex.nil? && !kubeproxyMetricsKeepListRegex.empty?
         AppendMetricRelabelConfig(@kubeproxyDefaultFile, kubeproxyMetricsKeepListRegex)
+        UpdateScrapeIntervalConfig(@kubeproxyDefaultFile, kubeproxyScrapeInterval)
       end
       defaultConfigs.push(@kubeproxyDefaultFile)
     end
     if !ENV["AZMON_PROMETHEUS_APISERVER_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_APISERVER_SCRAPING_ENABLED"].downcase == "true" && currentControllerType == @replicasetControllerType
       apiserverMetricsKeepListRegex = @regexHash["APISERVER_METRICS_KEEP_LIST_REGEX"]
+      apiserverScrapeInterval = @intervalHash["APISERVER_SCRAPE_INTERVAL"]
       if !apiserverMetricsKeepListRegex.nil? && !apiserverMetricsKeepListRegex.empty?
         AppendMetricRelabelConfig(@apiserverDefaultFile, apiserverMetricsKeepListRegex)
+        UpdateScrapeIntervalConfig(@apiserverDefaultFile, apiserverScrapeInterval)
       end
       defaultConfigs.push(@apiserverDefaultFile)
     end
     if !ENV["AZMON_PROMETHEUS_KUBESTATE_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_KUBESTATE_SCRAPING_ENABLED"].downcase == "true" && currentControllerType == @replicasetControllerType
       kubestateMetricsKeepListRegex = @regexHash["KUBESTATE_METRICS_KEEP_LIST_REGEX"]
+      kubestateScrapeInterval = @intervalHash["KUBESTATE_SCRAPE_INTERVAL"]
       if !kubestateMetricsKeepListRegex.nil? && !kubestateMetricsKeepListRegex.empty?
         AppendMetricRelabelConfig(@kubestateDefaultFile, kubestateMetricsKeepListRegex)
+        UpdateScrapeIntervalConfig(@kubestateDefaultFile, kubestateScrapeInterval)
       end
       contents = File.read(@kubestateDefaultFile)
       contents = contents.gsub("$$KUBE_STATE_NAME$$", ENV["KUBE_STATE_NAME"])
@@ -200,7 +250,7 @@ def populateDefaultPrometheusConfig
     end
     if !ENV["AZMON_PROMETHEUS_NODEEXPORTER_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_NODEEXPORTER_SCRAPING_ENABLED"].downcase == "true"
       nodeexporterMetricsKeepListRegex = @regexHash["NODEEXPORTER_METRICS_KEEP_LIST_REGEX"]
-
+      nodeexporterScrapeInterval = @intervalHash["NODEEXPORTER_SCRAPE_INTERVAL"]
       if currentControllerType == @replicasetControllerType
         if advancedMode == true && @sendDSUpMetric == true
           contents = File.read(@nodeexporterDefaultFileRsAdvanced)
@@ -211,6 +261,7 @@ def populateDefaultPrometheusConfig
         elsif advancedMode == false
           if !nodeexporterMetricsKeepListRegex.nil? && !nodeexporterMetricsKeepListRegex.empty?
             AppendMetricRelabelConfig(@nodeexporterDefaultFileRsSimple, nodeexporterMetricsKeepListRegex)
+            UpdateScrapeIntervalConfig(@nodeexporterDefaultFileRsSimple, nodeexporterScrapeInterval)
           end
           contents = File.read(@nodeexporterDefaultFileRsSimple)
           contents = contents.gsub("$$NODE_EXPORTER_NAME$$", ENV["NODE_EXPORTER_NAME"])
@@ -222,6 +273,7 @@ def populateDefaultPrometheusConfig
         if advancedMode == true && ENV["OS_TYPE"].downcase == "linux"
           if !nodeexporterMetricsKeepListRegex.nil? && !nodeexporterMetricsKeepListRegex.empty?
             AppendMetricRelabelConfig(@nodeexporterDefaultFileDs, nodeexporterMetricsKeepListRegex)
+            UpdateScrapeIntervalConfig(@nodeexporterDefaultFileDs, nodeexporterScrapeInterval)
           end
           contents = File.read(@nodeexporterDefaultFileDs)
           contents = contents.gsub("$$NODE_IP$$", ENV["NODE_IP"])
@@ -235,14 +287,18 @@ def populateDefaultPrometheusConfig
 
     # Collector health config should be enabled or disabled for both replicaset and daemonset
     if !ENV["AZMON_PROMETHEUS_COLLECTOR_HEALTH_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_COLLECTOR_HEALTH_SCRAPING_ENABLED"].downcase == "true"
+      prometheusCollectorHealthInterval = @intervalHash["PROMETHEUS_COLLECTOR_HEALTH_SCRAPE_INTERVAL"]
+      UpdateScrapeIntervalConfig(@prometheusCollectorHealthDefaultFile, prometheusCollectorHealthInterval)
       defaultConfigs.push(@prometheusCollectorHealthDefaultFile)
     end
 
     if !ENV["AZMON_PROMETHEUS_WINDOWSEXPORTER_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_WINDOWSEXPORTER_SCRAPING_ENABLED"].downcase == "true"
       winexporterMetricsKeepListRegex = @regexHash["WINDOWSEXPORTER_METRICS_KEEP_LIST_REGEX"]
+      windowsexporterScrapeInterval = @intervalHash["WINDOWSEXPORTER_SCRAPE_INTERVAL"]
       if currentControllerType == @replicasetControllerType && advancedMode == false && ENV["OS_TYPE"].downcase == "linux"
         if !winexporterMetricsKeepListRegex.nil? && !winexporterMetricsKeepListRegex.empty?
           AppendMetricRelabelConfig(@windowsexporterDefaultRsSimpleFile, winexporterMetricsKeepListRegex)
+          UpdateScrapeIntervalConfig(@windowsexporterDefaultRsSimpleFile, windowsexporterScrapeInterval)
         end
         contents = File.read(@windowsexporterDefaultRsSimpleFile)
         contents = contents.gsub("$$NODE_IP$$", ENV["NODE_IP"])
@@ -252,6 +308,7 @@ def populateDefaultPrometheusConfig
       elsif currentControllerType == @daemonsetControllerType && advancedMode == true && windowsDaemonset == true && ENV["OS_TYPE"].downcase == "windows"
         if !winexporterMetricsKeepListRegex.nil? && !winexporterMetricsKeepListRegex.empty?
           AppendMetricRelabelConfig(@windowsexporterDefaultDsFile, winexporterMetricsKeepListRegex)
+          UpdateScrapeIntervalConfig(@windowsexporterDefaultDsFile, windowsexporterScrapeInterval)
         end
         contents = File.read(@windowsexporterDefaultDsFile)
         contents = contents.gsub("$$NODE_IP$$", ENV["NODE_IP"])
@@ -261,12 +318,14 @@ def populateDefaultPrometheusConfig
 
         # If advanced mode and windows daemonset are enabled, only the up metric is needed from the replicaset
       elsif currentControllerType == @replicasetControllerType && advancedMode == true && windowsDaemonset == true && @sendDSUpMetric == true && ENV["OS_TYPE"].downcase == "linux"
+        UpdateScrapeIntervalConfig(@windowsexporterDefaultRsAdvancedFile, windowsexporterScrapeInterval)
         defaultConfigs.push(@windowsexporterDefaultRsAdvancedFile)
 
         # If advanced mode is enabled, but not the windows daemonset, scrape windows kubelet from the replicaset as if it's simple mode
       elsif currentControllerType == @replicasetControllerType && advancedMode == true && windowsDaemonset == false && ENV["OS_TYPE"].downcase == "linux"
         if !winexporterMetricsKeepListRegex.nil? && !winexporterMetricsKeepListRegex.empty?
           AppendMetricRelabelConfig(@windowsexporterDefaultRsSimpleFile, winexporterMetricsKeepListRegex)
+          UpdateScrapeIntervalConfig(@windowsexporterDefaultRsSimpleFile, windowsexporterScrapeInterval)
         end
         defaultConfigs.push(@windowsexporterDefaultRsSimpleFile)
       end
@@ -274,9 +333,11 @@ def populateDefaultPrometheusConfig
 
     if !ENV["AZMON_PROMETHEUS_WINDOWSKUBEPROXY_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_WINDOWSKUBEPROXY_SCRAPING_ENABLED"].downcase == "true"
       winkubeproxyMetricsKeepListRegex = @regexHash["WINDOWSKUBEPROXY_METRICS_KEEP_LIST_REGEX"]
+      windowskubeproxyScrapeInterval = @intervalHash["WINDOWSKUBEPROXY_SCRAPE_INTERVAL"]
       if currentControllerType == @replicasetControllerType && advancedMode == false && ENV["OS_TYPE"].downcase == "linux"
         if !winkubeproxyMetricsKeepListRegex.nil? && !winkubeproxyMetricsKeepListRegex.empty?
           AppendMetricRelabelConfig(@windowskubeproxyDefaultFileRsSimpleFile, winkubeproxyMetricsKeepListRegex)
+          UpdateScrapeIntervalConfig(@windowskubeproxyDefaultFileRsSimpleFile, windowskubeproxyScrapeInterval)
         end
         contents = File.read(@windowskubeproxyDefaultFileRsSimpleFile)
         contents = contents.gsub("$$NODE_IP$$", ENV["NODE_IP"])
@@ -286,6 +347,7 @@ def populateDefaultPrometheusConfig
       elsif currentControllerType == @daemonsetControllerType && advancedMode == true && windowsDaemonset == true && ENV["OS_TYPE"].downcase == "windows"
         if !winkubeproxyMetricsKeepListRegex.nil? && !winkubeproxyMetricsKeepListRegex.empty?
           AppendMetricRelabelConfig(@windowskubeproxyDefaultDsFile, winkubeproxyMetricsKeepListRegex)
+          UpdateScrapeIntervalConfig(@windowskubeproxyDefaultFileRsSimpleFile, windowskubeproxyScrapeInterval)
         end
         contents = File.read(@windowskubeproxyDefaultDsFile)
         contents = contents.gsub("$$NODE_IP$$", ENV["NODE_IP"])
@@ -295,12 +357,14 @@ def populateDefaultPrometheusConfig
 
       # If advanced mode and windows daemonset are enabled, only the up metric is needed from the replicaset
       elsif currentControllerType == @replicasetControllerType && advancedMode == true && windowsDaemonset == true && @sendDSUpMetric == true && ENV["OS_TYPE"].downcase == "linux"
+        UpdateScrapeIntervalConfig(@windowskubeproxyDefaultRsAdvancedFile, windowskubeproxyScrapeInterval)
         defaultConfigs.push(@windowskubeproxyDefaultRsAdvancedFile)
 
         # If advanced mode is enabled, but not the windows daemonset, scrape windows kubelet from the replicaset as if it's simple mode
       elsif currentControllerType == @replicasetControllerType && advancedMode == true && windowsDaemonset == false && ENV["OS_TYPE"].downcase == "linux"
         if !winkubeproxyMetricsKeepListRegex.nil? && !winkubeproxyMetricsKeepListRegex.empty?
           AppendMetricRelabelConfig(@windowskubeproxyDefaultRsSimpleFile, winkubeproxyMetricsKeepListRegex)
+          UpdateScrapeIntervalConfig(@windowskubeproxyDefaultRsSimpleFile, windowskubeproxyScrapeInterval)
         end
         defaultConfigs.push(@windowskubeproxyDefaultFileRsSimpleFile)
       end

--- a/otelcollector/configmapparser/tomlparser-scrape-interval.rb
+++ b/otelcollector/configmapparser/tomlparser-scrape-interval.rb
@@ -1,0 +1,165 @@
+#!/usr/local/bin/ruby
+# frozen_string_literal: true
+
+require "tomlrb"
+if (!ENV["OS_TYPE"].nil? && ENV["OS_TYPE"].downcase == "linux")
+  require "re2"
+end
+require "yaml"
+require_relative "ConfigParseErrorLogger"
+
+LOGGING_PREFIX = "default-scrape-interval-list"
+
+@configMapMountPath = "/etc/config/settings/default-targets-scrape-interval-list"
+@configVersion = ""
+@configSchemaVersion = ""
+
+@kubeletScrapeInterval = 30
+@corednsScrapeInterval = 30
+@cadvisorScrapeInterval = 30
+@kubeproxyScrapeInterval = 30
+@apiserverScrapeInterval = 30
+@kubestateScrapeInterval = 30
+@nodeexporterScrapeInterval = 30
+@windowsexporterScrapeInterval = 30
+@windowskubeproxyScrapeInterval = 30
+@prometheusCollectorHealthInterval = 30
+
+# Use parser to parse the configmap toml file to a ruby structure
+def parseConfigMap
+  begin
+    # Check to see if config map is created
+    if (File.file?(@configMapMountPath))
+      parsedConfig = Tomlrb.load_file(@configMapMountPath, symbolize_keys: true)
+      return parsedConfig
+    else
+      ConfigParseErrorLogger.log(LOGGING_PREFIX, "configmap prometheus-collector-configmap for default-targets-scrape-interval-list not mounted, using defaults")
+      return nil
+    end
+  rescue => errorStr
+    ConfigParseErrorLogger.logError(LOGGING_PREFIX, "Exception while parsing config map for default-targets-scrape-interval-list: #{errorStr}, using defaults, please check config map for errors")
+    return nil
+  end
+end
+
+# Use the ruby structure created after config parsing to set the right values to be used for otel collector settings
+def populateSettingValuesFromConfigMap(parsedConfig)
+  begin
+    kubeletScrapeInterval = parsedConfig[:kubelet]
+    if !kubeletScrapeInterval.nil?
+        @kubeletScrapeInterval = kubeletScrapeInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for kubeletScrapeInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "kubeletScrapeInterval either not specified or not of type integer")
+    end
+
+    corednsScrapeInterval = parsedConfig[:coredns]
+    if !corednsScrapeInterval.nil?
+        @corednsScrapeInterval = corednsScrapeInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for corednsScrapeInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "corednsScrapeInterval either not specified or not of type integer")
+    end
+
+    cadvisorScrapeInterval = parsedConfig[:cadvisor]
+    if !cadvisorScrapeInterval.nil?
+        @cadvisorScrapeInterval = cadvisorScrapeInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for cadvisorScrapeInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "cadvisorScrapeInterval either not specified or not of type integer")
+    end
+
+    kubeproxyScrapeInterval = parsedConfig[:kubeproxy]
+    if !kubeproxyScrapeInterval.nil?
+        @kubeproxyScrapeInterval = kubeproxyScrapeInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for kubeproxyScrapeInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "kubeproxyScrapeInterval either not specified or not of type integer")
+    end
+
+    apiserverScrapeInterval = parsedConfig[:apiserver]
+    if !apiserverScrapeInterval.nil?
+        @apiserverScrapeInterval = apiserverScrapeInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for apiserverScrapeInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "apiserverScrapeInterval either not specified or not of type integer")
+    end
+
+    kubestateScrapeInterval = parsedConfig[:kubestate]
+    if !kubestateScrapeInterval.nil?
+        @kubestateScrapeInterval = kubestateScrapeInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for kubestateScrapeInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "kubestateScrapeInterval either not specified or not of type integer")
+    end
+
+    nodeexporterScrapeInterval = parsedConfig[:nodeexporter]
+    if !nodeexporterScrapeInterval.nil?
+        @nodeexporterScrapeInterval = nodeexporterScrapeInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for nodeexporterScrapeInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "nodeexporterScrapeInterval either not specified or not of type integer")
+    end
+
+    windowsexporterScrapeInterval = parsedConfig[:windowsexporter]
+    if !windowsexporterScrapeInterval.nil?
+        @windowsexporterScrapeInterval = windowsexporterScrapeInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for windowsexporterScrapeInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "windowsexporterScrapeInterval either not specified or not of type integer")
+    end
+
+    windowskubeproxyScrapeInterval = parsedConfig[:windowskubeproxy]
+    if !windowskubeproxyScrapeInterval.nil?
+        @windowskubeproxyScrapeInterval = windowskubeproxyScrapeInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for windowskubeproxyScrapeInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "windowskubeproxyScrapeInterval either not specified or not of type integer")
+    end
+
+    prometheusCollectorHealthInterval = parsedConfig[:prometheuscollectorhealth]
+    if !prometheusCollectorHealthInterval.nil?
+        @prometheusCollectorHealthInterval = prometheusCollectorHealthInterval
+        ConfigParseErrorLogger.log(LOGGING_PREFIX, "Using configmap scrape settings for prometheusCollectorHealthInterval")
+    else
+      ConfigParseErrorLogger.logError(LOGGING_PREFIX, "prometheusCollectorHealthInterval either not specified or not of type integer")
+    end
+end
+
+@configSchemaVersion = ENV["AZMON_AGENT_CFG_SCHEMA_VERSION"]
+ConfigParseErrorLogger.logSection(LOGGING_PREFIX, "Start default-targets-scrape-interval-list Processing")
+if !@configSchemaVersion.nil? && !@configSchemaVersion.empty? && @configSchemaVersion.strip.casecmp("v1") == 0 #note v1 is the only supported schema version, so hardcoding it
+  configMapSettings = parseConfigMap
+  if !configMapSettings.nil?
+    populateSettingValuesFromConfigMap(configMapSettings)
+  end
+else
+  if (File.file?(@configMapMountPath))
+    ConfigParseErrorLogger.logError(LOGGING_PREFIX, "Unsupported/missing config schema version - '#{@configSchemaVersion}' , using defaults, please use supported schema version")
+  end
+end
+
+# Write the settings to file, so that they can be set as environment variables
+file = File.open("/opt/microsoft/configmapparser/config_def_targets_scrape_intervals_hash", "w")
+
+intervalHash = {}
+intervalHash["KUBELET_SCRAPE_INTERVAL"] = @kubeletScrapeInterval
+intervalHash["COREDNS_SCRAPE_INTERVAL"] = @corednsScrapeInterval
+intervalHash["CADVISOR_SCRAPE_INTERVAL"] = @cadvisorScrapeInterval
+intervalHash["KUBEPROXY_SCRAPE_INTERVAL"] = @kubeproxyScrapeInterval
+intervalHash["APISERVER_SCRAPE_INTERVAL"] = @apiserverScrapeInterval
+intervalHash["KUBESTATE_SCRAPE_INTERVAL"] = @kubestateScrapeInterval
+intervalHash["NODEEXPORTER_SCRAPE_INTERVAL"] = @nodeexporterScrapeInterval
+intervalHash["WINDOWSEXPORTER_SCRAPE_INTERVAL"] = @windowsexporterScrapeInterval
+intervalHash["WINDOWSKUBEPROXY_SCRAPE_INTERVAL"] = @windowskubeproxyScrapeInterval
+intervalHash["PROMETHEUS_COLLECTOR_HEALTH_SCRAPE_INTERVAL"] = @prometheusCollectorHealthInterval
+
+if !file.nil?
+  # Close file after writing scrape interval list hash
+  # Writing it as yaml as it is easy to read and write hash
+  file.write(intervalHash.to_yaml)
+  file.close
+else
+  ConfigParseErrorLogger.logError(LOGGING_PREFIX, "Exception while opening file for writing default-targets-scrape-interval-list regex config hash")
+end
+ConfigParseErrorLogger.logSection(LOGGING_PREFIX, "End default-targets-scrape-interval-list Processing")

--- a/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
+++ b/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
@@ -31,6 +31,17 @@ data:
     windowsexporter = ""
     windowskubeproxy = ""
     minimalingestionprofile = true
+  default-targets-scrape-interval-list: |-
+    kubelet = 30
+    coredns = 30
+    cadvisor = 30
+    kubeproxy = 30
+    apiserver = 30
+    kubestate = 30
+    nodeexporter = 30
+    windowsexporter = 30
+    windowskubeproxy = 30
+    prometheusCollectorHealth = 30
   debug-mode: |-
     enabled = false
 metadata:

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-settings-configmap.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-settings-configmap.yaml
@@ -37,6 +37,17 @@ data:
     windowskubeproxy = {{ .Values.keepListRegexes.windowsKubeProxy | toString | quote }}
   debug-mode: |-
     enabled = {{ .Values.debugMode.enabled }}
+  default-targets-scrape-interval-list: |-
+    kubelet = {{ .Values.scrapeIntervalTargets.kubelet }}
+    coredns = {{ .Values.scrapeIntervalTargets.coreDns }}
+    cadvisor = {{ .Values.scrapeIntervalTargets.cAdvisor }}
+    kubeproxy = {{ .Values.scrapeIntervalTargets.kubeProxy }}
+    apiserver = {{ .Values.scrapeIntervalTargets.apiServer }}
+    kubestate = {{ .Values.scrapeIntervalTargets.kubeState }}
+    nodeexporter = {{ .Values.scrapeIntervalTargets.nodeExporter }}
+    prometheuscollectorhealth = {{ .Values.scrapeIntervalTargets.prometheusCollectorHealth }}
+    windowsexporter = {{ .Values.scrapeIntervalTargets.windowsExporter }}
+    windowskubeproxy = {{ .Values.scrapeIntervalTargets.windowsKubeProxy }}
 metadata:
   name: {{ template "prometheus-collector.fullname" . }}-settings-configmap
   namespace: {{ .Release.Namespace }}

--- a/otelcollector/deploy/chart/prometheus-collector/values-template.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/values-template.yaml
@@ -39,6 +39,19 @@ scrapeTargets:
   # -- when true, automatically scrape info about the Prometheus-Collector such as the amount and size of timeseries scraped
   prometheusCollectorHealth: true
 
+# The following setting will set the scrape interval of each target
+  scrapeIntervalTargets:
+    coreDns: 30
+    kubelet: 30
+    cAdvisor: 30
+    kubeProxy: 30
+    apiServer: 30
+    kubeState: 30
+    nodeExporter: 30
+    windowsExporter: 30
+    windowsKubeProxy: 30
+    prometheusCollectorHealth: 30
+    
 # when minimalIngestionProfile is enabled, we will ingest only hand-picked/selected metrics per default target. see the list of metrics included per default target in our docs.
 minimalIngestionProfile: true
   

--- a/otelcollector/scripts/main.sh
+++ b/otelcollector/scripts/main.sh
@@ -97,7 +97,10 @@ fi
 # Parse the settings for default targets metrics keep list config
 ruby /opt/microsoft/configmapparser/tomlparser-default-targets-metrics-keep-list.rb
 
-# Merge default anf custom prometheus config
+# Parse the settings for  default-targets-scrape-interval-list config
+ruby /opt/microsoft/configmapparser/tomlparser-scrape-interval.rb
+
+# Merge default and custom prometheus config
 ruby /opt/microsoft/configmapparser/prometheus-config-merger.rb
 
 echo "export AZMON_INVALID_CUSTOM_PROMETHEUS_CONFIG=false" >> ~/.bashrc


### PR DESCRIPTION
This image was used for testing: 5.2.0-testScrapeIntervlsSetting-10-03-2022-c9d993ab

The scrape interval targets were set in the helm command using flags --set scrapeIntervalTargets.kubelet=30 --set scrapeIntervalTargets.coreDns=30 --set scrapeIntervalTargets.cAdvisor=30 --set scrapeIntervalTargets.kubeProxy=30 --set scrapeIntervalTargets.apiServer=30 --set scrapeIntervalTargets.kubeState=30 --set scrapeIntervalTargets.nodeExporter=30 --set scrapeIntervalTargets.prometheusCollectorHealth=30 --set scrapeIntervalTargets.windowsExporter=30 --set scrapeIntervalTargets.windowsKubeProxy=30 and then checking the [soham-test-chart-8-prometheus-collector-settings-configmap](https://ms.portal.azure.com/#view/Microsoft_Azure_ContainerService/AksK8ResourceMenuBlade/~/overview-ConfigMap/aksClusterId/%2Fsubscriptions%2Fce4d1293-71c0-4c72-bc55-133553ee9e50%2FresourceGroups%2Fsohamtestkv%2Fproviders%2FMicrosoft.ContainerService%2FmanagedClusters%2FSohamCluster/resource~/%7B%22kind%22%3A%22ConfigMap%22%2C%22metadata%22%3A%7B%22name%22%3A%22soham-test-chart-8-prometheus-collector-settings-configmap%22%2C%22namespace%22%3A%22default%22%2C%22uid%22%3A%22d1185d7d-7ec9-45ce-977d-f8a86efd4c8b%22%7D%7D) config. Also updated the flag values and checked the config map in portal.