### PR TITLE
Alerts and dashboards prod ci cd clusters

### DIFF
--- a/internal/alerts/ci-prod-aks-mac-weu.json
+++ b/internal/alerts/ci-prod-aks-mac-weu.json
@@ -1,277 +1,413 @@
-Uncomment and deploy below when alerts are available in westeurope
-
-// {
-//     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-//     "contentVersion": "1.0.0.0",
-//     "parameters": {},
-//     "variables": {},
-//     "resources": [
-//         {
-//             "name": "containerinsights_mac_alerts",
-//             "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
-//             "apiVersion": "2021-07-22-preview",
-//             "location": "eastus2euap",
-//             "properties": {
-//                 "description": "rule group for cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu in MAC: /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourceGroups/ci-prod-aks-mac-weu-rg/providers/Microsoft.Monitor/accounts/ci-prod-aks-weu-mac",
-//                 "scopes": [
-//                     "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourceGroups/ci-prod-aks-mac-weu-rg/providers/Microsoft.Monitor/accounts/ci-prod-aks-weu-mac"
-//                 ],
-//                 "rules": [
-//                     {
-//                         "alert": "up metric missing for target = node in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"node\"}) == 1",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "up metric is not flowing for target = node in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "up metric missing for target = kubelet in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kubelet\"}) == 1",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "up metric is not flowing for target = kubelet in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "up metric missing for target = windows-exporter in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"windows-exporter\"}) == 1",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "up metric is not flowing for target = windows-exporter in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "up metric missing for target = kube-proxy in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-proxy\"}) == 1",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "up metric is not flowing for target = kube-proxy in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "up metric missing for target = kube-apiserver in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-apiserver\"}) == 1",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "up metric is not flowing for target = kube-apiserver in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "up metric missing for target = kube-proxy-windows in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-proxy-windows\"}) == 1",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "up metric is not flowing for target = kube-proxy-windows in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "up metric missing for target = kube-state-metrics in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-state-metrics\"}) == 1",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "up metric is not flowing for target = kube-proxy-windows in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "up metric missing for target = cadvisor in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"cadvisor\"}) == 1",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "up metric is not flowing for target = cadvisor in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "up metric missing for target = kube-dns in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-dns\"}) == 1",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "up metric is not flowing for target = kube-dns in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "CPU usage % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "sum(sum by (cluster, namespace, pod, container) ( rate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\", namespace=\"monitoring\", cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", container=\"prometheus-collector\"}[5m]) ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) ( 1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\", namespace=\"monitoring\", cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\"}) )) by (container, pod) > 0.9",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "CPU usage greater than 90% for prometheus-collector on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     },
-//                     {
-//                         "alert": "Memory usage % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
-//                         "expression": "(sum(container_memory_working_set_bytes{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", namespace=\"monitoring\", container=\"prometheus-collector\", image!=\"\"}) by (container, pod) / sum(kube_pod_container_resource_requests{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", namespace=\"monitoring\", container=\"prometheus-collector\", resource=\"memory\"}) by (container, pod)) > 0.9",
-//                         "for": "PT3M",
-//                         "labels": {
-//                             "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "annotations": {
-//                             "description": "Memory usage % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
-//                         },
-//                         "severity": 4,
-//                         "resolveConfiguration": {
-//                             "autoResolved": true,
-//                             "timeToResolve": "PT10M"
-//                         },
-//                         "actions": [
-//                             {
-//                                 "ActionProperties": {
-//                                     "Icm.Enabled": "True"
-//                                 }
-//                             }
-//                         ]
-//                     }
-//                 ]
-//             }
-//         }
-//     ]
-// }
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "variables": {},
+    "resources": [
+        {
+            "name": "containerinsights_mac_alerts",
+            "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+            "apiVersion": "2021-07-22-preview",
+            "location": "westeurope",
+            "properties": {
+                "description": "rule group for cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu in MAC: /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourceGroups/ci-prod-aks-mac-weu-rg/providers/Microsoft.Monitor/accounts/ci-prod-aks-weu-mac",
+                "scopes": [
+                    "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourceGroups/ci-prod-aks-mac-weu-rg/providers/Microsoft.Monitor/accounts/ci-prod-aks-weu-mac"
+                ],
+                "rules": [
+                    {
+                        "alert": "up metric missing for target = node in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"node\"}) == 1",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "up metric is not flowing for target = node in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "up metric missing for target = kubelet in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kubelet\"}) == 1",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "up metric is not flowing for target = kubelet in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "up metric missing for target = windows-exporter in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"windows-exporter\"}) == 1",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "up metric is not flowing for target = windows-exporter in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "up metric missing for target = kube-proxy in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-proxy\"}) == 1",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "up metric is not flowing for target = kube-proxy in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "up metric missing for target = kube-apiserver in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-apiserver\"}) == 1",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "up metric is not flowing for target = kube-apiserver in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "up metric missing for target = kube-proxy-windows in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-proxy-windows\"}) == 1",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "up metric is not flowing for target = kube-proxy-windows in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "up metric missing for target = kube-state-metrics in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-state-metrics\"}) == 1",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "up metric is not flowing for target = kube-proxy-windows in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "up metric missing for target = cadvisor in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"cadvisor\"}) == 1",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "up metric is not flowing for target = cadvisor in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "up metric missing for target = kube-dns in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "absent(up{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", job=\"kube-dns\"}) == 1",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "up metric is not flowing for target = kube-dns in cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "CPU usage % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "sum(sum by (cluster, namespace, pod, container) ( rate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\", namespace=\"monitoring\", cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", container=\"prometheus-collector\"}[5m]) ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) ( 1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\", namespace=\"monitoring\", cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\"}) )) by (container, pod) > 0.9",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "CPU usage greater than 90% for prometheus-collector on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Memory usage % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "(sum(container_memory_working_set_bytes{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", namespace=\"monitoring\", container=\"prometheus-collector\", image!=\"\"}) by (container, pod) / sum(kube_pod_container_resource_requests{cluster=\"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu\", namespace=\"monitoring\", container=\"prometheus-collector\", resource=\"memory\"}) by (container, pod)) > 0.9",
+                        "for": "PT3M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "Memory usage % greater than 90 for prometheus-collector containers on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - CPU usage % exceeded for ama-metrics replicaset on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "(sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", container!=\"\", pod=~\"ama-metrics.*\"}) - sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", pod=~\"ama-metrics-node.*\"}) - sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", pod=~\"ama-metrics-ksm.*\"}))/ sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"cpu\"}) > 0.000200",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "CPU usage % exceeded for ama-metrics replicaset on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - CPU usage % exceeded for ama-metrics daemonset on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", container!=\"\", pod=~\"ama-metrics-node.*\"})  / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"cpu\"}) > 0.000510",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "CPU usage % exceeded for ama-metrics daemonset on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - CPU usage % exceeded for ama-metrics kube state metrics on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", container!=\"\", pod=~\"ama-metrics-ksm.*\"})/ sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"cpu\"}) > 0.00000953",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": " CPU usage % exceeded for ama-metrics kube state metrics on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - Memory usage % exceeded for ama-metrics kube state metrics on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics-ksm.*\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"memory\"}) > 0.000230",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": " Memory usage % exceeded for ama-metrics kube state metrics on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - Memory usage % exceeded for ama-metrics daemonset on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics-node.*\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"memory\"}) > 0.00740",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "Memory usage % exceeded for ama-metrics daemonset on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - Memory usage % exceeded for ama-metrics replicaset on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu",
+                        "expression": "(sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics.*\"}) - sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics-node.*\"}) - sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics-ksm.*\"})) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"memory\"}) > 0.00265",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "annotations": {
+                            "description": "Memory usage % exceeded for ama-metrics replicaset on cluster /subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourcegroups/ci-prod-aks-mac-weu-rg/providers/microsoft.containerservice/managedclusters/ci-prod-aks-mac-weu"
+                        },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/internal/alerts/ci_prod_aks_eus.json
+++ b/internal/alerts/ci_prod_aks_eus.json
@@ -290,6 +290,144 @@
                                 }
                             }
                         ]
+                    },
+                    {
+                        "alert": "Build over build alert - CPU usage % exceeded for replicaset on cluster ci-prod-aks-eus",
+                        "expression": "sum(sum by (cluster, namespace, pod, container) (  irate(container_cpu_usage_seconds_total{image!=\"\",cluster=\"cimon-aks-wcus\", pod=~\".*prometheus-collector.*\"}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""}))) - sum(sum by (cluster, namespace, pod, container) (  irate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\",cluster=\"cimon-aks-wcus\", pod=~\".*prometheus-collector-node.*\"}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""}))) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"cpu\"}) > 0.0824",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "ci-prod-aks-eus"
+                        },
+                        "annotations": {
+                            "description": "Build over build alert - CPU usage % exceeded for replicaset on cluster ci-prod-aks-eus"
+                         },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - CPU usage % exceeded for daemonset on cluster ci-prod-aks-eus",
+                        "expression": "sum(sum by (cluster, namespace, pod, container) (  irate(container_cpu_usage_seconds_total{image!="",cluster=\"cimon-aks-wcus\", pod=~\".*prometheus-collector-node.*\"}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""}))) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"cpu\"}) > 0.00944",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "ci-prod-aks-eus"
+                        },
+                        "annotations": {
+                            "description": "Build over build alert - CPU usage % exceeded for daemonset on cluster ci-prod-aks-eus"
+                         },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - CPU usage % exceeded for k-s-m on cluster ci-prod-aks-eus",
+                        "expression": "sum(sum by (cluster, namespace, pod, container) (  irate(container_cpu_usage_seconds_total{ image!=\"\",cluster=\"cimon-aks-wcus\", pod=~\".*kube-state-metrics.*\"}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""}))) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"cpu\"}) > 0.000238",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "ci-prod-aks-eus"
+                        },
+                        "annotations": {
+                            "description": "Build over build alert - CPU usage % exceeded for kube state metrics on cluster ci-prod-aks-eus"
+                         },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - Memory usage % exceeded for k-s-m on cluster ci-prod-aks-eus",
+                        "expression": "sum(container_memory_working_set_bytes{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\",container!="", image!="", pod=~\".*kube-state-metrics.*\"}) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"memory\"}) > 0.00364",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "ci-prod-aks-eus"
+                        },
+                        "annotations": {
+                            "description": "Build over build alert - Memory usage % exceeded for kube state metrics on cluster ci-prod-aks-eus"
+                         },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - Memory usage % exceeded for replicaset on cluster ci-prod-aks-eus",
+                        "expression": "(sum(container_memory_working_set_bytes{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\",container!="", image!="", pod=~\".*prometheus-collector.*\"}) - sum(container_memory_working_set_bytes{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\",container!="", image!="", pod=~\".*prometheus-collector-node.*\"})) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"memory\"}) > 0.0362",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "ci-prod-aks-eus"
+                        },
+                        "annotations": {
+                            "description": "Build over build alert - Memory usage % exceeded for replicaset on cluster ci-prod-aks-eus"
+                         },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Build over build alert - Memory usage % exceeded for daemonset on cluster ci-prod-aks-eus",
+                        "expression": "sum(container_memory_working_set_bytes{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\",container!="", image!="", pod=~\".*prometheus-collector-node.*\"}) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"memory\"}) > 0.0445",
+                        "for": "PT15M",
+                        "labels": {
+                            "cluster": "ci-prod-aks-eus"
+                        },
+                        "annotations": {
+                            "description": "Build over build alert - Memory usage % exceeded for daemonset on cluster ci-prod-aks-eus"
+                         },
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "ActionProperties": {
+                                    "Icm.Enabled": "True"
+                                }
+                            }
+                        ]
                     }
                 ]
             }

--- a/internal/monitoring/dashboards/ci-prod-aks-eus-db.json
+++ b/internal/monitoring/dashboards/ci-prod-aks-eus-db.json
@@ -1,0 +1,564 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 58,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus-mdm"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-mdm"
+            },
+            "expr": "sum(sum by (cluster, namespace, pod, container) (  irate(container_cpu_usage_seconds_total{ image!=\"\",cluster=\"cimon-aks-wcus\", pod=~\".*kube-state-metrics.*\"}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"cpu\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "K-S-M CPU%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus-mdm"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-mdm"
+            },
+            "expr": "sum(container_memory_working_set_bytes{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\",container!=\"\", image!=\"\", pod=~\".*prometheus-collector-node.*\"}) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"memory\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "Daemonset Memory%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus-mdm"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-mdm"
+            },
+            "expr": "sum(sum by (cluster, namespace, pod, container) (  irate(container_cpu_usage_seconds_total{image!=\"\",cluster=\"cimon-aks-wcus\", pod=~\".*prometheus-collector-node.*\"}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"cpu\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "Daemonset CPU%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus-mdm"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-mdm"
+            },
+            "expr": "sum(container_memory_working_set_bytes{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\",container!=\"\", image!=\"\", pod=~\".*kube-state-metrics.*\"}) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"memory\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "K-S-M Memory%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus-mdm"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-mdm"
+            },
+            "expr": "sum(sum by (cluster, namespace, pod, container) (  irate(container_cpu_usage_seconds_total{image!=\"\",cluster=\"cimon-aks-wcus\", pod=~\".*prometheus-collector.*\"}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))) - sum(sum by (cluster, namespace, pod, container) (  irate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\",cluster=\"cimon-aks-wcus\", pod=~\".*prometheus-collector-node.*\"}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"cpu\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "Replicaset CPU %",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus-mdm"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 16
+        },
+        "id": 12,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-mdm"
+            },
+            "expr": "(sum(container_memory_working_set_bytes{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\",container!=\"\", image!=\"\", pod=~\".*prometheus-collector.*\"}) - sum(container_memory_working_set_bytes{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\",container!=\"\", image!=\"\", pod=~\".*prometheus-collector-node.*\"})) / sum(kube_pod_container_resource_limits{cluster=\"cimon-aks-wcus\", namespace=\"monitoring\", resource=\"memory\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "Replicaset Memory%",
+        "type": "timeseries"
+      }
+    ],
+    "schemaVersion": 36,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "CPU and Memory utilization k-s-m, replicaset and daemonset",
+    "uid": "dmzAODN4k",
+    "version": 12,
+    "weekStart": ""
+  }

--- a/internal/monitoring/dashboards/ci-prod-aks-mac-weu-db.json
+++ b/internal/monitoring/dashboards/ci-prod-aks-mac-weu-db.json
@@ -1,0 +1,567 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 58,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ci-prod-aks-weu-mac"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ci-prod-aks-weu-mac"
+            },
+            "expr": "(sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", container!=\"\", pod=~\"ama-metrics.*\"}) - sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", pod=~\"ama-metrics-node.*\"}) - sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", pod=~\"ama-metrics-ksm.*\"}))/ sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"cpu\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "Replicaset CPU %",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ci-prod-aks-weu-mac"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ci-prod-aks-weu-mac"
+            },
+            "expr": "sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics-ksm.*\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"memory\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "K-S-M Memory%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ci-prod-aks-weu-mac"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ci-prod-aks-weu-mac"
+            },
+            "expr": "sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", container!=\"\", pod=~\"ama-metrics-node.*\"})  / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"cpu\"}) ",
+            "refId": "A"
+          }
+        ],
+        "title": "Daemonset CPU%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ci-prod-aks-weu-mac"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ci-prod-aks-weu-mac"
+            },
+            "expr": "sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics-node.*\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"memory\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "Daemonset Memory%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ci-prod-aks-weu-mac"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ci-prod-aks-weu-mac"
+            },
+            "editorMode": "code",
+            "expr": "sum ( node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", container!=\"\", pod=~\"ama-metrics-ksm.*\"})/ sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"cpu\"})",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "K-S-M CPU%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ci-prod-aks-weu-mac"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 16
+        },
+        "id": 12,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ci-prod-aks-weu-mac"
+            },
+            "expr": "(sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics.*\"}) - sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics-node.*\"}) - sum(container_memory_working_set_bytes{job=\"cadvisor\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\",container!=\"\", image!=\"\", pod=~\"ama-metrics-ksm.*\"})) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"ci-prod-aks-mac-weu\", namespace=\"kube-system\", resource=\"memory\"})",
+            "refId": "A"
+          }
+        ],
+        "title": "Replicaset Memory%",
+        "type": "timeseries"
+      }
+    ],
+    "schemaVersion": 36,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "CPU and Memory utilization k-s-m, replicaset and daemonset",
+    "uid": "gp9556IVz",
+    "version": 3,
+    "weekStart": ""
+  }


### PR DESCRIPTION
This change contains the alerts and dashboards templates for CI CD prod clusters. For Icm integration, these Mac accounts need to be recreated with 1p version, I will create the 2 new MACs with the instructions [here](https://eng.ms/docs/products/geneva/metrics/prometheus/mac) and update the templates. 

This is the new dashboard [link](https://ci-prod-aks-eus-graf-dueya5aadyd2ghef.eus.grafana.azure.com/d/dmzAODN4k/cpu-and-memory-utilization-k-s-m-replicaset-and-daemonset?orgId=1) for eus cluster with the build over build metrics.

This is the new dashboard [link](https://ci-prod-aks-weu-graf-fffvdrhqgkg6dxgm.weu.grafana.azure.com/d/gp9556IVz/cpu-and-memory-utilization-k-s-m-replicaset-and-daemonset?orgId=1) for weucluster with the build over build metrics.

The build-over-build alerts have been created with 10% increment over the maximum values of the current time-series of each metric.