### PR TITLE
Fix pipeline deploy error for ci-dev-aks-mac-eus cluster

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -405,7 +405,7 @@ jobs:
       azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
       azureResourceGroup: 'ci-dev-aks-mac-eus-rg'
       kubernetesCluster: 'ci-dev-aks-mac-eus'
-      namespace: 'kube-system'
+      namespace: 'default'
       command: 'upgrade'
       chartType: 'FilePath'
       chartPath: '$(Build.SourcesDirectory)/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/'


### PR DESCRIPTION
This change is to fix the pipeline deploy [error](https://github-private.visualstudio.com/azure/_build/results?buildId=53147&view=logs&j=e07742bd-189a-5079-918b-43f8b2f94b89&t=388f0a64-9341-5aac-bb89-d3b9f7f738e5&l=12) for ci-dev-aks-mac-eus cluster.