### PR TITLE
update addon token adapter image to latest from last week

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -27,11 +27,13 @@ CVE-2022-27664
 CVE-2019-3826
 # /bin/node_exporter
 CVE-2021-44716
+CVE-2022-46146
 # kube-state-metrics
 CVE-2022-29526
 CVE-2022-29189
 CVE-2022-31030
 CVE-2022-29526
+CVE-2022-46146
 # opt/microsoft/otelcollector/otelcollector
 # opt/promconfigvalidator
 # opt/telegraf/telegraf

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -43,7 +43,7 @@ AzureMonitorMetrics:
   # ImageTag: https://msazure.visualstudio.com/CloudNativeCompute/_git/aks-rp?path=/ccp/charts/kube-control-plane/templates/_images.tpl&version=GBrashmi/prom-addon-arm64&line=530&lineEnd=530&lineStartColumn=28&lineEndColumn=53&lineStyle=plain&_a=contents
   AddonTokenAdapter:
     ImageRepository: "/aks/msi/addon-token-adapter"
-    ImageTag: "master.220916.1"
+    ImageTag: "master.221118.2"
 global:
   commonGlobals:
     CloudEnvironment: "AzureCloud"

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
@@ -173,7 +173,7 @@ spec:
             - --secret-name=aad-msi-auth-token
             - --token-server-listening-port=7777
             - --health-server-listening-port=9999
-          image: "mcr.microsoft.com/aks/msi/addon-token-adapter:master.220415.2"
+          image: "mcr.microsoft.com/aks/msi/addon-token-adapter:master.221118.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: AZMON_COLLECT_ENV

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
@@ -187,7 +187,7 @@ spec:
             - --secret-name=aad-msi-auth-token
             - --token-server-listening-port=7777
             - --health-server-listening-port=9999
-          image: "mcr.microsoft.com/aks/msi/addon-token-adapter:master.220415.2"
+          image: "mcr.microsoft.com/aks/msi/addon-token-adapter:master.221118.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: AZMON_COLLECT_ENV


### PR DESCRIPTION
Updated for backdoor chart from: `master.220916.1` to `master.221118.2`.

Also in prom-collector chart (used for 3p private preview , which is not used anymore), it was older image, updated that as well to `master.221118.2` 