### PR TITLE
Remove windows nodes from Kubernetes compute (nodes) dashboard

### DIFF
--- a/mixins/kubernetes/dashboards/resources/node.libsonnet
+++ b/mixins/kubernetes/dashboards/resources/node.libsonnet
@@ -20,7 +20,7 @@ local template = grafana.template;
       template.new(
         name='node',
         datasource='$datasource',
-        query='label_values(kube_node_info{%(clusterLabel)s="$cluster"}, node)' % $._config,
+        query='label_values(kube_node_info{%(clusterLabel)s="$cluster", os_image!~"windows.*"}, node)' % $._config,
         current='',
         hide='',
         refresh=2,

--- a/otelcollector/deploy/dashboard/k8s/Kubernetes_ComputeResources_Node(Pods).json
+++ b/otelcollector/deploy/dashboard/k8s/Kubernetes_ComputeResources_Node(Pods).json
@@ -950,7 +950,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(kube_node_info{cluster=\"$cluster\"}, node)",
+          "query": "label_values(kube_node_info{cluster=\"$cluster\", os_image!~\"windows.*\"}, node)",
           "refId": "Prometheus-INT-Cluster-node-Variable-Query"
         },
         "refresh": 2,


### PR DESCRIPTION
Link to updated test dashboard - https://sohamgrafanaworkspace-g9gubfd8dneqczdk.eus.grafana.azure.com/d/200ac8fdbfbb74b39aff88118e4d6738/kubernetes-compute-resources-node-pods?orgId=1&refresh=1m&var-datasource=Prometheus-sohamwinbackdoor&var-cluster=sohamwincluster&var-node=aks-agentpool-10974444-vmss000000


This PR removes the windows nodes from Kubernetes compute resources (Nodes) dashboard.
There are 2 more dashboards kubernetes-compute-resources-namespace-pods and kubernetes-compute-resources-namespace-workloads which shows windows pods, I have tested using updated variable(similarly to exclude "win" keyword) but they require a more complex change.  I will continue to work on fixing those two dashboards, we can discuss in scrum for ways to fix those dashboards.