### PR TITLE
Adding Bicep template to monitoring addon

### DIFF
--- a/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
+++ b/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
@@ -1,0 +1,288 @@
+param azureMonitorWorkspaceResourceId string
+
+@allowed([
+  'eastus2euap'
+  'centraluseuap'
+  'centralus'
+  'eastus'
+  'eastus2'
+  'northeurope'
+  'southcentralus'
+  'southeastasia'
+  'uksouth'
+  'westeurope'
+  'westus'
+  'westus2'
+])
+param azureMonitorWorkspaceLocation string
+param clusterResourceId string
+param clusterLocation string
+param metricLabelsAllowlist string
+param metricAnnotationsAllowList string
+param grafanaResourceId string
+param grafanaLocation string
+param grafanaSku string
+
+var clusterSubscriptionId = split(clusterResourceId, '/')[2]
+var clusterResourceGroup = split(clusterResourceId, '/')[4]
+var clusterName = split(clusterResourceId, '/')[8]
+var dceName = 'MSProm-${azureMonitorWorkspaceLocation}-${clusterName}'
+var dcrName = 'MSProm-${azureMonitorWorkspaceLocation}-${clusterName}'
+var dcraName = 'MSProm-${clusterLocation}-${clusterName}'
+var nodeRecordingRuleGroup_var = 'NodeRecordingRulesRuleGroup-'
+var nodeRecordingRuleGroupName = concat(nodeRecordingRuleGroup_var, clusterName)
+var nodeRecordingRuleGroupDescription = 'Node Recording Rules RuleGroup'
+var kubernetesRecordingRuleGroup_var = 'KubernetesReccordingRulesRuleGroup-'
+var kubernetesRecordingRuleGroupName = concat(kubernetesRecordingRuleGroup_var, clusterName)
+var kubernetesRecordingRuleGroupDescription = 'Kubernetes Recording Rules RuleGroup'
+var version = ' - 0.1'
+
+resource dce 'Microsoft.Insights/dataCollectionEndpoints@2021-09-01-preview' = {
+  name: dceName
+  location: azureMonitorWorkspaceLocation
+  kind: 'Linux'
+  properties: {
+  }
+}
+
+resource dcr 'Microsoft.Insights/dataCollectionRules@2021-09-01-preview' = {
+  name: dcrName
+  location: azureMonitorWorkspaceLocation
+  kind: 'Linux'
+  properties: {
+    dataCollectionEndpointId: dce.id
+    dataFlows: [
+      {
+        destinations: [
+          'MonitoringAccount1'
+        ]
+        streams: [
+          'Microsoft-PrometheusMetrics'
+        ]
+      }
+    ]
+    dataSources: {
+      prometheusForwarder: [
+        {
+          name: 'PrometheusDataSource'
+          streams: [
+            'Microsoft-PrometheusMetrics'
+          ]
+          labelIncludeFilter: {
+          }
+        }
+      ]
+    }
+    description: 'DCR for Azure Monitor Metrics Profile (Managed Prometheus)'
+    destinations: {
+      monitoringAccounts: [
+        {
+          accountResourceId: azureMonitorWorkspaceResourceId
+          name: 'MonitoringAccount1'
+        }
+      ]
+    }
+  }
+}
+
+module azuremonitormetrics_dcra_clusterResourceId '../AddonBicepTemplate/nested_azuremonitormetrics_dcra_clusterResourceId.bicep' = {
+  name: 'azuremonitormetrics-dcra-${uniqueString(clusterResourceId)}'
+  scope: resourceGroup(clusterSubscriptionId, clusterResourceGroup)
+  params: {
+    resourceId_Microsoft_Insights_dataCollectionRules_variables_dcrName: dcr.id
+    variables_clusterName: clusterName
+    variables_dcraName: dcraName
+    clusterLocation: clusterLocation
+  }
+}
+
+module azuremonitormetrics_profile_clusterResourceId '../AddonBicepTemplate/nested_azuremonitormetrics_profile_clusterResourceId.bicep' = {
+  name: 'azuremonitormetrics-profile--${uniqueString(clusterResourceId)}'
+  scope: resourceGroup(clusterSubscriptionId, clusterResourceGroup)
+  params: {
+    variables_clusterName: clusterName
+    clusterLocation: clusterLocation
+    clusterResourceId: clusterResourceId
+    metricLabelsAllowlist: metricLabelsAllowlist
+    metricAnnotationsAllowList: metricAnnotationsAllowList
+  }
+}
+
+resource nodeRecordingRuleGroup 'Microsoft.AlertsManagement/prometheusRuleGroups@2021-07-22-preview' = {
+  name: nodeRecordingRuleGroupName
+  location: azureMonitorWorkspaceLocation
+  properties: {
+    description: concat(nodeRecordingRuleGroupDescription, version)
+    scopes: [
+      azureMonitorWorkspaceResourceId
+    ]
+    clusterName: clusterName
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'instance:node_num_cpu:sum'
+        expression: 'count without (cpu, mode) (  node_cpu_seconds_total{job="node",mode="idle"})'
+      }
+      {
+        record: 'instance:node_cpu_utilisation:rate5m'
+        expression: '1 - avg without (cpu) (  sum without (mode) (rate(node_cpu_seconds_total{job="node", mode=~"idle|iowait|steal"}[5m])))'
+      }
+      {
+        record: 'instance:node_load1_per_cpu:ratio'
+        expression: '(  node_load1{job="node"}/  instance:node_num_cpu:sum{job="node"})'
+      }
+      {
+        record: 'instance:node_memory_utilisation:ratio'
+        expression: '1 - (  (    node_memory_MemAvailable_bytes{job="node"}    or    (      node_memory_Buffers_bytes{job="node"}      +      node_memory_Cached_bytes{job="node"}      +      node_memory_MemFree_bytes{job="node"}      +      node_memory_Slab_bytes{job="node"}    )  )/  node_memory_MemTotal_bytes{job="node"})'
+      }
+      {
+        record: 'instance:node_vmstat_pgmajfault:rate5m'
+        expression: 'rate(node_vmstat_pgmajfault{job="node"}[5m])'
+      }
+      {
+        record: 'instance_device:node_disk_io_time_seconds:rate5m'
+        expression: 'rate(node_disk_io_time_seconds_total{job="node", device!=""}[5m])'
+      }
+      {
+        record: 'instance_device:node_disk_io_time_weighted_seconds:rate5m'
+        expression: 'rate(node_disk_io_time_weighted_seconds_total{job="node", device!=""}[5m])'
+      }
+      {
+        record: 'instance:node_network_receive_bytes_excluding_lo:rate5m'
+        expression: 'sum without (device) (  rate(node_network_receive_bytes_total{job="node", device!="lo"}[5m]))'
+      }
+      {
+        record: 'instance:node_network_transmit_bytes_excluding_lo:rate5m'
+        expression: 'sum without (device) (  rate(node_network_transmit_bytes_total{job="node", device!="lo"}[5m]))'
+      }
+      {
+        record: 'instance:node_network_receive_drop_excluding_lo:rate5m'
+        expression: 'sum without (device) (  rate(node_network_receive_drop_total{job="node", device!="lo"}[5m]))'
+      }
+      {
+        record: 'instance:node_network_transmit_drop_excluding_lo:rate5m'
+        expression: 'sum without (device) (  rate(node_network_transmit_drop_total{job="node", device!="lo"}[5m]))'
+      }
+    ]
+  }
+}
+
+resource kubernetesRecordingRuleGroup 'Microsoft.AlertsManagement/prometheusRuleGroups@2021-07-22-preview' = {
+  name: kubernetesRecordingRuleGroupName
+  location: azureMonitorWorkspaceLocation
+  properties: {
+    description: concat(kubernetesRecordingRuleGroupDescription, version)
+    scopes: [
+      azureMonitorWorkspaceResourceId
+    ]
+    clusterName: clusterName
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate'
+        expression: 'sum by (cluster, namespace, pod, container) (  irate(container_cpu_usage_seconds_total{job="cadvisor", image!=""}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""}))'
+      }
+      {
+        record: 'node_namespace_pod_container:container_memory_working_set_bytes'
+        expression: 'container_memory_working_set_bytes{job="cadvisor", image!=""}* on (namespace, pod) group_left(node) topk by(namespace, pod) (1,  max by(namespace, pod, node) (kube_pod_info{node!=""}))'
+      }
+      {
+        record: 'node_namespace_pod_container:container_memory_rss'
+        expression: 'container_memory_rss{job="cadvisor", image!=""}* on (namespace, pod) group_left(node) topk by(namespace, pod) (1,  max by(namespace, pod, node) (kube_pod_info{node!=""}))'
+      }
+      {
+        record: 'node_namespace_pod_container:container_memory_cache'
+        expression: 'container_memory_cache{job="cadvisor", image!=""}* on (namespace, pod) group_left(node) topk by(namespace, pod) (1,  max by(namespace, pod, node) (kube_pod_info{node!=""}))'
+      }
+      {
+        record: 'node_namespace_pod_container:container_memory_swap'
+        expression: 'container_memory_swap{job="cadvisor", image!=""}* on (namespace, pod) group_left(node) topk by(namespace, pod) (1,  max by(namespace, pod, node) (kube_pod_info{node!=""}))'
+      }
+      {
+        record: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_requests'
+        expression: 'kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}  * on (namespace, pod, cluster)group_left() max by (namespace, pod, cluster) (  (kube_pod_status_phase{phase=~"Pending|Running"} == 1))'
+      }
+      {
+        record: 'namespace_memory:kube_pod_container_resource_requests:sum'
+        expression: 'sum by (namespace, cluster) (    sum by (namespace, pod, cluster) (        max by (namespace, pod, container, cluster) (          kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}        ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (          kube_pod_status_phase{phase=~"Pending|Running"} == 1        )    ))'
+      }
+      {
+        record: 'cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests'
+        expression: 'kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"}  * on (namespace, pod, cluster)group_left() max by (namespace, pod, cluster) (  (kube_pod_status_phase{phase=~"Pending|Running"} == 1))'
+      }
+      {
+        record: 'namespace_cpu:kube_pod_container_resource_requests:sum'
+        expression: 'sum by (namespace, cluster) (    sum by (namespace, pod, cluster) (        max by (namespace, pod, container, cluster) (          kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"}        ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (          kube_pod_status_phase{phase=~"Pending|Running"} == 1        )    ))'
+      }
+      {
+        record: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits'
+        expression: 'kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"}  * on (namespace, pod, cluster)group_left() max by (namespace, pod, cluster) (  (kube_pod_status_phase{phase=~"Pending|Running"} == 1))'
+      }
+      {
+        record: 'namespace_memory:kube_pod_container_resource_limits:sum'
+        expression: 'sum by (namespace, cluster) (    sum by (namespace, pod, cluster) (        max by (namespace, pod, container, cluster) (          kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"}        ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (          kube_pod_status_phase{phase=~"Pending|Running"} == 1        )    ))'
+      }
+      {
+        record: 'cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits'
+        expression: 'kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}  * on (namespace, pod, cluster)group_left() max by (namespace, pod, cluster) ( (kube_pod_status_phase{phase=~"Pending|Running"} == 1) )'
+      }
+      {
+        record: 'namespace_cpu:kube_pod_container_resource_limits:sum'
+        expression: 'sum by (namespace, cluster) (    sum by (namespace, pod, cluster) (        max by (namespace, pod, container, cluster) (          kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}        ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (          kube_pod_status_phase{phase=~"Pending|Running"} == 1        )    ))'
+      }
+      {
+        record: 'namespace_workload_pod:kube_pod_owner:relabel'
+        expression: 'max by (cluster, namespace, workload, pod) (  label_replace(    label_replace(      kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},      "replicaset", "$1", "owner_name", "(.*)"    ) * on(replicaset, namespace) group_left(owner_name) topk by(replicaset, namespace) (      1, max by (replicaset, namespace, owner_name) (        kube_replicaset_owner{job="kube-state-metrics"}      )    ),    "workload", "$1", "owner_name", "(.*)"  ))'
+        labels: {
+          workload_type: 'deployment'
+        }
+      }
+      {
+        record: 'namespace_workload_pod:kube_pod_owner:relabel'
+        expression: 'max by (cluster, namespace, workload, pod) (  label_replace(    kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},    "workload", "$1", "owner_name", "(.*)"  ))'
+        labels: {
+          workload_type: 'daemonset'
+        }
+      }
+      {
+        record: 'namespace_workload_pod:kube_pod_owner:relabel'
+        expression: 'max by (cluster, namespace, workload, pod) (  label_replace(    kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},    "workload", "$1", "owner_name", "(.*)"  ))'
+        labels: {
+          workload_type: 'statefulset'
+        }
+      }
+      {
+        record: 'namespace_workload_pod:kube_pod_owner:relabel'
+        expression: 'max by (cluster, namespace, workload, pod) (  label_replace(    kube_pod_owner{job="kube-state-metrics", owner_kind="Job"},    "workload", "$1", "owner_name", "(.*)"  ))'
+        labels: {
+          workload_type: 'job'
+        }
+      }
+      {
+        record: ':node_memory_MemAvailable_bytes:sum'
+        expression: 'sum(  node_memory_MemAvailable_bytes{job="node"} or  (    node_memory_Buffers_bytes{job="node"} +    node_memory_Cached_bytes{job="node"} +    node_memory_MemFree_bytes{job="node"} +    node_memory_Slab_bytes{job="node"}  )) by (cluster)'
+      }
+      {
+        record: 'cluster:node_cpu:ratio_rate5m'
+        expression: 'sum(rate(node_cpu_seconds_total{job="node",mode!="idle",mode!="iowait",mode!="steal"}[5m])) by (cluster) /count(sum(node_cpu_seconds_total{job="node"}) by (cluster, instance, cpu)) by (cluster)'
+      }
+    ]
+  }
+}
+
+resource grafanaResourceId_8 'Microsoft.Dashboard/grafana@2022-08-01' = {
+  name: split(grafanaResourceId, '/')[8]
+  sku: {
+    name: grafanaSku
+  }
+  location: grafanaLocation
+  properties: {
+    grafanaIntegrations: {
+      azureMonitorWorkspaceIntegrations: [
+        {
+          azureMonitorWorkspaceResourceId: azureMonitorWorkspaceResourceId
+        }
+      ]
+    }
+  }
+}

--- a/AddonBicepTemplate/FullAzureMonitorMetricsProfileParameters.json
+++ b/AddonBicepTemplate/FullAzureMonitorMetricsProfileParameters.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "azureMonitorWorkspaceResourceId": {
+      "value": "/subscriptions/{sub_id}/resourceGroups/{rg_name}/providers/microsoft.monitor/accounts/{cluster_name}"
+    },
+    "azureMonitorWorkspaceLocation": {
+      "value": "{amwLocation}"
+    },
+    "clusterResourceId": {
+      "value": "/subscriptions/{sub_id}/resourcegroups/{rg_name}/providers/Microsoft.ContainerService/managedClusters/{cluster_name}"
+    },
+    "clusterLocation": {
+      "value": "{clusterLocation}"
+    },
+    "metricLabelsAllowlist": {
+      "value": ""
+    },
+    "metricAnnotationsAllowList": {
+      "value": ""
+    },
+    "grafanaResourceId": {
+      "value": "/subscriptions/{sub_id}/resourceGroups/{rg_name}/providers/Microsoft.Dashboard/grafana/{cluster_name}"
+    },
+    "grafanaLocation": {
+      "value": "{grafanaLocation}"
+    },
+    "grafanaSku": {
+      "value": "Standard"
+    }
+  }
+}

--- a/AddonBicepTemplate/README.md
+++ b/AddonBicepTemplate/README.md
@@ -1,0 +1,11 @@
+You can deploy the templates using a command like :
+
+```az deployment group create -g <resource_group> -n <deployment_name> --template-file ./FullAzureMonitorMetricsProfile.bicep --parameters ./FullAzureMonitorMetricsProfileParameters.json```
+
+**NOTE**
+
+- Please edit the FullAzureMonitorMetricsProfileParameters.json file appropriately before running the Bicep template
+- Please add in any existing azureMonitorWorkspaceIntegrations values to the grafana resource before running the template otherwise the older values will get deleted and replaced with what is there in the template at the time of deployment
+- Please edit the grafanaSku parameter if you are using a non standard SKU.
+- Please assign the role 'Monitoring Data Reader' to the Grafana MSI on the Azure Monitor Workspace resource so that it can read data for displaying the charts
+- Please run this template in the Grafana Resources RG.

--- a/AddonBicepTemplate/nested_azuremonitormetrics_dcra_clusterResourceId.bicep
+++ b/AddonBicepTemplate/nested_azuremonitormetrics_dcra_clusterResourceId.bicep
@@ -1,0 +1,13 @@
+param resourceId_Microsoft_Insights_dataCollectionRules_variables_dcrName string
+param variables_clusterName string
+param variables_dcraName string
+param clusterLocation string
+
+resource variables_clusterName_microsoft_insights_variables_dcra 'Microsoft.ContainerService/managedClusters/providers/dataCollectionRuleAssociations@2021-09-01-preview' = {
+  name: '${variables_clusterName}/microsoft.insights/${variables_dcraName}'
+  location: clusterLocation
+  properties: {
+    description: 'Association of data collection rule. Deleting this association will break the data collection for this AKS Cluster.'
+    dataCollectionRuleId: resourceId_Microsoft_Insights_dataCollectionRules_variables_dcrName
+  }
+}

--- a/AddonBicepTemplate/nested_azuremonitormetrics_profile_clusterResourceId.bicep
+++ b/AddonBicepTemplate/nested_azuremonitormetrics_profile_clusterResourceId.bicep
@@ -1,0 +1,23 @@
+param variables_clusterName string
+param clusterLocation string
+param clusterResourceId string
+param metricLabelsAllowlist string
+param metricAnnotationsAllowList string
+
+resource variables_cluster 'Microsoft.ContainerService/managedClusters@2022-07-02-preview' = {
+  name: variables_clusterName
+  location: clusterLocation
+  properties: {
+    mode: 'Incremental'
+    id: clusterResourceId
+    azureMonitorProfile: {
+      metrics: {
+        enabled: true
+        kubeStateMetrics: {
+          metricLabelsAllowlist: metricLabelsAllowlist
+          metricAnnotationsAllowList: metricAnnotationsAllowList
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change adds Bicep template to monitoring addon.

I deployed the template using a new AMW and data is flowing in grafana [ Kubernetes / Compute Resources / Cluster - Dashboards - Dashboards - Grafana (azure.com)](https://sohamgrafanaworkspace-g9gubfd8dneqczdk.eus.grafana.azure.com/d/efa86fd1d0c121a26444b636a3f56738/kubernetes-compute-resources-cluster?orgId=1&refresh=1m&var-datasource=Prometheus-sohambiceptemplate&var-cluster=sohamwincluster).
