### PR TITLE
Enable using workload identities for accessing key vault secrets

### DIFF
--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
@@ -14,7 +14,7 @@ spec:
   parameters:
     {{- if ne (index .Values.azureKeyVault "aad-pod-identity") ""}}
     usePodIdentity: "true"
-    {{- else }}
+    {{- else if ne .Values.azureKeyVault.userAssignedIdentityID "" }}
     usePodIdentity: "false"                    # [OPTIONAL] if not provided, will default to "false"
     useVMManagedIdentity: {{ .Values.azureKeyVault.useManagedIdentity | toString | quote }}           # [OPTIONAL available for version > 0.0.4] if not provided, will default to "false"
     {{- if .Values.azureKeyVault.userAssignedIdentityID }}
@@ -22,6 +22,8 @@ spec:
     {{- else }}
     userAssignedIdentityID: ""
     {{- end }}
+    {{- else if .Values.azureKeyVault.useManagedIdentity }}
+    clientID: {{ required "azureKeyVault.clientId is required if azureKeyVault.aad-pod-identity and azureKeyVault.userAssignedIdentityID are not provided" .Values.azureKeyVault.clientId | toString | quote }}
     {{- end }}
     keyvaultName: {{ required "azureKeyVault.name is required" .Values.azureKeyVault.name | toString | quote }} # [CHANGE AS APPROPRIATE][REQUIRED] the name of the KeyVault (also provide tenantid of this KeyVault in the 'tanantId' field below)
     cloudName: {{ .Values.azureKeyVault.cloudName | toString | quote }}   # [OPTIONAL available for version > 0.0.4] if not provided, azure environment will default to AzurePublicCloud

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
@@ -14,7 +14,9 @@ spec:
   parameters:
     {{- if ne (index .Values.azureKeyVault "aad-pod-identity") ""}}
     usePodIdentity: "true"
-    {{- else if ne .Values.azureKeyVault.userAssignedIdentityID "" }}
+    {{- else if and .Values.azureKeyVault.useManagedIdentity (ne .Values.azureKeyVault.clientId "") }}
+    clientID: {{ .Values.azureKeyVault.clientId }}
+    {{- else }}
     usePodIdentity: "false"                    # [OPTIONAL] if not provided, will default to "false"
     useVMManagedIdentity: {{ .Values.azureKeyVault.useManagedIdentity | toString | quote }}           # [OPTIONAL available for version > 0.0.4] if not provided, will default to "false"
     {{- if .Values.azureKeyVault.userAssignedIdentityID }}
@@ -22,8 +24,6 @@ spec:
     {{- else }}
     userAssignedIdentityID: ""
     {{- end }}
-    {{- else if .Values.azureKeyVault.useManagedIdentity }}
-    clientID: {{ required "azureKeyVault.clientId is required if azureKeyVault.aad-pod-identity and azureKeyVault.userAssignedIdentityID are not provided" .Values.azureKeyVault.clientId | toString | quote }}
     {{- end }}
     keyvaultName: {{ required "azureKeyVault.name is required" .Values.azureKeyVault.name | toString | quote }} # [CHANGE AS APPROPRIATE][REQUIRED] the name of the KeyVault (also provide tenantid of this KeyVault in the 'tanantId' field below)
     cloudName: {{ .Values.azureKeyVault.cloudName | toString | quote }}   # [OPTIONAL available for version > 0.0.4] if not provided, azure environment will default to AzurePublicCloud

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-secretProviderClass.yaml
@@ -41,5 +41,5 @@ spec:
           objectFormat: pfx                                  # [REQUIRED] DO NOT CHANGE FROM 'pfx'
           objectVersion: ""                                  # [OPTIONAL] object versions, default to latest if empty
       {{- end}}
-    tenantId: {{ required "azureKeyVault.tenantId is required" .Values.azureKeyVault.tenantId | toString | quote }}       # [CHANGE AS APPROPRIATE][REQUIRED] the tenant ID of the KeyVault specified above
+    tenantID: {{ required "azureKeyVault.tenantId is required" .Values.azureKeyVault.tenantId | toString | quote }}       # [CHANGE AS APPROPRIATE][REQUIRED] the tenant ID of the KeyVault specified above
 {{- end }}

--- a/otelcollector/deploy/chart/prometheus-collector/values-template.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/values-template.yaml
@@ -80,7 +80,7 @@ azureKeyVault:
   # -- cloudName for the azure key vault resource
   cloudName: "" # optional for public cloud.
   # -- clientid for a service principal that has access to read the Pfx certificates from keyvault specified above
-  clientId: "" #required when using service principal to access keyvault
+  clientId: "" #required when using service principal or workload identities to access keyvault
   # -- client secret for the above service principal
   clientSecret: "" #required when using service principal to access keyvault
   # -- name of the Pfx certificate(s) - one per metric account


### PR DESCRIPTION
This PR adds support for workload identities into the prometheus collector chart. When `azureKeyVault.useManagedIdentity` is `true`, users can use `azureKeyVault.clientId` to provide the client id for an identity that is configured to use workload identities.

If multiple identity properties are specified, it will use `aad-pod-identity`, then `clientId`, then `userAssignedIdentityID`, and finally the system assigned managed identity.