### PR TITLE
Wait for token adapter to be healthy before starting our dependencies

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - vishwa/startup
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - vishwa/startup
 
 pr:
   autoCancel: true

--- a/otelcollector/build/linux/Dockerfile
+++ b/otelcollector/build/linux/Dockerfile
@@ -142,7 +142,7 @@ COPY --from=builder /usr/local/lib/libtcmalloc_minimal.so.4 /usr/local/lib/
 # logrotate dependencies
 COPY --from=builder /lib/libselinux.so.1 /lib/libpopt.so.0 /lib/libpcre.so.1 /lib/
 # curl dependencies
-COPY --from=builder /lib/libcurl.so.4 lib/libz.so.1 /lib/libc.so.6 /lib/
+COPY --from=builder /lib/libcurl.so.4 lib/libz.so.1 /lib/libc.so.6 /lib/libssh2.so.1 /lib/
 
 RUN [ "/bin/bash", "-c", "chmod 644 /etc/crontab" ]
 RUN [ "/bin/bash", "-c", "chown root.root /etc/crontab" ]

--- a/otelcollector/telegraf/telegraf-prometheus-collector.conf
+++ b/otelcollector/telegraf/telegraf-prometheus-collector.conf
@@ -177,6 +177,8 @@
     kubestatemetriclabelsallowlist = "$KUBE_STATE_METRIC_LABELS_ALLOWLIST"
     kubestatemetricannotationsallowlist = "$KUBE_STATE_METRIC_ANNOTATIONS_ALLOWLIST"
     httpproxyenabled = "$HTTP_PROXY_ENABLED"
+    tadapterh="$tokenadapterHealthyAfterSecs"
+    tadapterf="$tokenadapterUnhealthyAfterSecs"
   
 [[inputs.procstat]]
    exe = "MetricsExtension"


### PR DESCRIPTION
* we will wait upto 45 secs for token adapter to get healthy during start up
* telemetry dashboards for time its taking for token adapter to startup are added to our dashboards
* fix is for linux only, after rolling this out, we will look at telemetry and do the same for windows
* fix will work for ARC (linux) as well -- assuming readiness probe is at port 9999 for ARC adapter
* tested around 100 times scaling nodes in and out with 100% success rate 