### PR TITLE
Update node disk usage alert to 85% to account default garbage col

### DIFF
--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
@@ -237,6 +237,25 @@
                         ]
                     },
                     {
+                        "alert": "Disk space usage for a node is greater than 85%.",
+                        "expression": "1 - avg by (namespace,cluster,job)(node_filesystem_avail_bytes{job=\"node\"}) / avg by (namespace,cluster,job)(node_filesystem_size_bytes{job=\"node\"}) > .85",
+                        "for": "PT5M",
+                        "annotations": {
+                            "description": "Disk space usage for a node is greater than 85%."
+                        },
+                        "enabled": true,
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT15M"
+                        },
+                        "actions": [
+                            {
+                                "actionGroupId": "[parameters('actionGroupResourceId')]"
+                            }
+                        ]
+                    },
+                    {
                         "alert": "Number of pods in failed state are greater than 0.",
                         "expression": "sum by (cluster, namespace, pod) (kube_pod_status_phase{phase=\"failed\"}) > 0",
                         "for": "PT5M",

--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
@@ -218,11 +218,11 @@
                         ]
                     },
                     {
-                        "alert": "Working set memory for a node is greater than 85%.",
-                        "expression": "1 - avg by (namespace,cluster,job)(node_memory_MemAvailable_bytes{job=\"node\"}) / avg by (namespace,cluster,job)(node_memory_MemTotal_bytes{job=\"node\"}) > .85",
+                        "alert": "Working set memory for a node is greater than 80%.",
+                        "expression": "1 - avg by (namespace,cluster,job)(node_memory_MemAvailable_bytes{job=\"node\"}) / avg by (namespace,cluster,job)(node_memory_MemTotal_bytes{job=\"node\"}) > .8",
                         "for": "PT5M",
                         "annotations": {
-                            "description": "Working set memory for a node is greater than 85%."
+                            "description": "Working set memory for a node is greater than 80%."
                         },
                         "enabled": true,
                         "severity": 4,

--- a/otelcollector/build/windows/scripts/main.ps1
+++ b/otelcollector/build/windows/scripts/main.ps1
@@ -367,8 +367,15 @@ function Set-CertificateForME {
     Copy-Item -r /etc/config/settings/akv /opt/akv-copy
 
     Get-ChildItem "C:\etc\config\settings\akv\" |  Foreach-Object {
-        if (!($_.Name.startswith('..'))) {
-            Import-PfxCertificate -FilePath $_.FullName -CertStoreLocation Cert:\CurrentUser\My > $null
+        # check if child is a file and not a directory
+        $filePath = $_.FullName
+        if (Test-Path $filePath -PathType Leaf) {
+            $filePath = $_.FullName
+            $file = Get-Content $filePath -Encoding Byte
+            if (($null -ne $file)) {
+                Write-Output "Importing PFX cert : $filePath"
+                Import-PfxCertificate -FilePath $filePath -CertStoreLocation Cert:\CurrentUser\My > $null
+            }
         }
     }
 }


### PR DESCRIPTION

<img width="1871" alt="diskusage" src="https://user-images.githubusercontent.com/31517098/220811022-2ce5e651-4980-4259-9778-9f4f2d40601c.png">
This pr updates the recommended alerts disk usage at node level to 85% because kubelet uses garbage collection at a high threshold of 85% by default and lowers it to the low threshold of 80%. 

Ref: https://k8s-docs.netlify.app/en/docs/concepts/cluster-administration/kubelet-garbage-collection/#:~:text=Users%20can%20adjust%20the%20following%20thresholds%20to%20tune,which%20triggers%20image%20garbage%20collection.%20Default%20is%2085%25.