### PR TITLE
Add support to custom endpoints for Arc Autonomous in azure-monitor-metrics-addon

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
@@ -57,9 +57,21 @@ spec:
             - name: AZMON_COLLECT_ENV
               value: "false"
             - name: customEnvironment
+              {{- if not .Values.AzureMonitorMetrics.isArcACluster }}
               value: "azurepubliccloud"
+              {{- else }}
+              value: "arcautonomous"
+              {{- end }}
             - name: OMS_TLD
               value: "opinsights.azure.com"
+            {{- if .Values.AzureMonitorMetrics.isArcACluster }}
+            - name: customRegionalEndpoint
+              value: {{ required "customRegionalEndpoint is required in Arc Autonomous" .Values.AzureMonitorMetrics.arcAutonomousSettings.customRegionalEndpoint | toString | trim | quote }}
+            - name: customGlobalEndpoint
+              value: {{ required "customGlobalEndpoint is required in Arc Autonomous" .Values.AzureMonitorMetrics.arcAutonomousSettings.customGlobalEndpoint | toString | trim | quote }}
+            - name: customResourceEndpoint
+              value: {{ required "customResourceEndpoint is required in Arc Autonomous" .Values.AzureMonitorMetrics.arcAutonomousSettings.customResourceEndpoint | toString | trim | quote }}
+            {{- end }}
             - name: CONTROLLER_TYPE
               value: "DaemonSet"
             - name: NODE_IP

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
@@ -60,9 +60,21 @@ spec:
             - name: AZMON_COLLECT_ENV
               value: "false"
             - name: customEnvironment
+              {{- if not .Values.AzureMonitorMetrics.isArcACluster }}
               value: "azurepubliccloud"
+              {{- else }}
+              value: "arcautonomous"
+              {{- end }}
             - name: OMS_TLD
               value: "opinsights.azure.com"
+            {{- if .Values.AzureMonitorMetrics.isArcACluster }}
+            - name: customRegionalEndpoint
+              value: {{ required "customRegionalEndpoint is required in Arc Autonomous" .Values.AzureMonitorMetrics.arcAutonomousSettings.customRegionalEndpoint | toString | trim | quote }}
+            - name: customGlobalEndpoint
+              value: {{ required "customGlobalEndpoint is required in Arc Autonomous" .Values.AzureMonitorMetrics.arcAutonomousSettings.customGlobalEndpoint | toString | trim | quote }}
+            - name: customResourceEndpoint
+              value: {{ required "customResourceEndpoint is required in Arc Autonomous" .Values.AzureMonitorMetrics.arcAutonomousSettings.customResourceEndpoint | toString | trim | quote }}
+            {{- end }}
             - name: CONTROLLER_TYPE
               value: "ReplicaSet"
             - name: NODE_IP

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-extensionIdentity.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-extensionIdentity.yaml
@@ -26,6 +26,8 @@ spec:
   audience: https://monitoring.azure.cn/
   {{- else if eq (.Values.Azure.Cluster.Cloud | lower) "azureusgovernmentcloud" }}
   audience: https://monitoring.azure.us/
+  {{- else if .Values.AzureMonitorMetrics.isArcACluster }}
+  audience: {{ required "customResourceEndpoint is required in Arc Autonomous" .Values.AzureMonitorMetrics.arcAutonomousSettings.customResourceEndpoint | toString | trim | quote }}
   {{- else }}
   audience: https://monitoring.azure.com/
   {{- end }}

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -48,6 +48,12 @@ AzureMonitorMetrics:
     ImageRepositoryWin: "/aks/hcp/addon-token-adapter"
     ImageTagWin: "20230120winbeta"
   ArcExtension: false
+  # Do not change the below settings. They are reserved for Arc Autonomous
+  isArcACluster: false
+  arcAutonomousSettings:
+    customRegionalEndpoint: ""
+    customGlobalEndpoint: ""
+    customResourceEndpoint: ""
 global:
   commonGlobals:
     CloudEnvironment: "AzureCloud"


### PR DESCRIPTION
Re-applying #218 in azure-monitor-metrics-addon with some new change including:
1. Add new flag to indicate Arc Autonomous.
2. Update the audience used in cluster identity request.