### PR TITLE
Reduce telemetry for prometheus ingestion metrics

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - vishwa/tel
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - vishwa/tel
 
 pr:
   autoCancel: true

--- a/otelcollector/fluent-bit/src/out_appinsights.go
+++ b/otelcollector/fluent-bit/src/out_appinsights.go
@@ -47,6 +47,8 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 		go SendKsmCpuMemoryToAppInsightsMetrics()
 	}
 
+	go PushMEProcessedAndReceivedCountToAppInsightsMetrics
+
 	return output.FLB_OK
 }
 
@@ -74,9 +76,9 @@ func FLBPluginFlush(data unsafe.Pointer, length C.int, tag *C.char) int {
 	// Metrics Extension logs with metrics received, dropped, and processed counts
 	switch incomingTag {
 	case fluentbitEventsProcessedLastPeriodTag:
-		return PushReceivedMetricsCountToAppInsightsMetrics(records)
+		return UpdateMEReceivedMetricsCount(records)
 	case fluentbitProcessedCountTag:
-		return PushProcessedCountToAppInsightsMetrics(records)
+		return UpdateMEMetricsProcessedCount(records)
 	case fluentbitDiagnosticHeartbeatTag:
 		return PushMetricsDroppedCountToAppInsightsMetrics(records)
 	case fluentbitInfiniteMetricTag:

--- a/otelcollector/fluent-bit/src/out_appinsights.go
+++ b/otelcollector/fluent-bit/src/out_appinsights.go
@@ -47,7 +47,7 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 		go SendKsmCpuMemoryToAppInsightsMetrics()
 	}
 
-	go PushMEProcessedAndReceivedCountToAppInsightsMetrics
+	go PushMEProcessedAndReceivedCountToAppInsightsMetrics()
 
 	return output.FLB_OK
 }

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -677,8 +677,6 @@ func UpdateMEReceivedMetricsCount(records []map[interface{}]interface{}) int {
 					TimeseriesVolumeMutex.Unlock()
 				}
 
-				//metric := appinsights.NewMetricTelemetry("meMetricsReceivedCount", metricsReceivedCount)
-				//TelemetryClient.Track(metric)
 			}
 		}
 	}

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"sync"
 
 	"github.com/fluent/fluent-bit-go/output"
 	"github.com/microsoft/ApplicationInsights-Go/appinsights"
@@ -656,7 +657,7 @@ func UpdateMEReceivedMetricsCount(records []map[interface{}]interface{}) int {
 				//update map
 				meMetricsReceivedCountMapMutex.Lock()
 
-				ref, ok := meMetricsProcessedCountMap["na"]
+				ref, ok := meMetricsReceivedCountMap["na"]
 
 				if ok {
 					ref.Value += metricsReceivedCount
@@ -665,7 +666,7 @@ func UpdateMEReceivedMetricsCount(records []map[interface{}]interface{}) int {
 					m := &meMetricsReceivedCount { 
 													Value: metricsReceivedCount, 
 												  }
-					meMetricsProcessedCountMap["na"] = m
+					meMetricsReceivedCountMap["na"] = m
 				}
 				meMetricsReceivedCountMapMutex.Unlock()
 				

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -481,6 +481,7 @@ func UpdateMEMetricsProcessedCount(records []map[interface{}]interface{}) int {
 	for _, record := range records {
 		var logEntry = ToString(record["message"])
 		var metricScrapeInfoRegex = regexp.MustCompile(`\s*([^\s]+)\s*([^\s]+)\s*([^\s]+).*ProcessedCount: ([\d]+).*ProcessedBytes: ([\d]+).*SentToPublicationCount: ([\d]+).*SentToPublicationBytes: ([\d]+).*`)
+		var bytesProcessedCount float64
 		groupMatches := metricScrapeInfoRegex.FindStringSubmatch(logEntry)
 
 		if len(groupMatches) > 7 {

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -481,7 +481,6 @@ func UpdateMEMetricsProcessedCount(records []map[interface{}]interface{}) int {
 	for _, record := range records {
 		var logEntry = ToString(record["message"])
 		var metricScrapeInfoRegex = regexp.MustCompile(`\s*([^\s]+)\s*([^\s]+)\s*([^\s]+).*ProcessedCount: ([\d]+).*ProcessedBytes: ([\d]+).*SentToPublicationCount: ([\d]+).*SentToPublicationBytes: ([\d]+).*`)
-		var bytesProcessedCount float64
 		groupMatches := metricScrapeInfoRegex.FindStringSubmatch(logEntry)
 
 		if len(groupMatches) > 7 {
@@ -491,16 +490,18 @@ func UpdateMEMetricsProcessedCount(records []map[interface{}]interface{}) int {
 				metricsAccountName := groupMatches[3]
 				
 				bytesProcessedCount, e := strconv.ParseFloat(groupMatches[5], 64)
-				if e != nil
+				if e != nil{
 					bytesProcessedCount = 0.0
+				}
 			
 				metricsSentToPubCount,e := strconv.ParseFloat(groupMatches[6], 64)
-				if e != nil
+				if e != nil {
 					metricsSentToPubCount = 0.0
-
+				}
 				bytesSentToPubCount,e := strconv.ParseFloat(groupMatches[7], 64)
-				if e != nil
+				if e != nil {
 					bytesSentToPubCount = 0.0
+				}
 				
 				//update map
 				meMetricsProcessedCountMapMutex.Lock()

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -72,7 +72,7 @@ var (
 	meMetricsProcessedCountMapMutex = &sync.Mutex{}
 	// meMetricsReceivedCount map, which holds references to metrics per metric account
 	meMetricsReceivedCountMap = make(map[string]*meMetricsReceivedCount)
-	// meMetricsDroppedCountMapMutex -- used for reading & writing locks on meMetricsReceivedCountMap
+	// meMetricsReceivedCountMapMutex -- used for reading & writing locks on meMetricsReceivedCountMap
 	meMetricsReceivedCountMapMutex = &sync.Mutex{}
 )
 

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -491,15 +491,15 @@ func UpdateMEMetricsProcessedCount(records []map[interface{}]interface{}) int {
 				
 				bytesProcessedCount, e := strconv.ParseFloat(groupMatches[5], 64)
 				if e != nil
-					bytesProcessedCount = 0
+					bytesProcessedCount = 0.0
 			
 				metricsSentToPubCount,e := strconv.ParseFloat(groupMatches[6], 64)
 				if e != nil
-					metricsSentToPubCount = 0
+					metricsSentToPubCount = 0.0
 
 				bytesSentToPubCount,e := strconv.ParseFloat(groupMatches[7], 64)
 				if e != nil
-					bytesSentToPubCount = 0
+					bytesSentToPubCount = 0.0
 				
 				//update map
 				meMetricsProcessedCountMapMutex.Lock()
@@ -517,7 +517,7 @@ func UpdateMEMetricsProcessedCount(records []map[interface{}]interface{}) int {
 													DimBytesProcessedCount: bytesProcessedCount,
 													DimBytesSentToPubCount: bytesSentToPubCount,
 													DimMetricsSentToPubCount: metricsSentToPubCount,
-													Value: metricsProcessedCount
+													Value: metricsProcessedCount, 
 												  }
 					meMetricsProcessedCountMap[metricsAccountName] = m
 				}
@@ -661,7 +661,7 @@ func UpdateMEReceivedMetricsCount(records []map[interface{}]interface{}) int {
 
 				} else {
 					m := &meMetricsReceivedCount { 
-													Value: metricsReceivedCount
+													Value: metricsReceivedCount, 
 												  }
 					meMetricsProcessedCountMap["na"] = m
 				}

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -25,6 +25,19 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+type meMetricsProcessedCount struct {
+	DimBytesProcessedCount	float64
+	DimBytesSentToPubCount float64
+	DimMetricsSentToPubCount	float64
+	Value	float64
+}
+
+type meMetricsReceivedCount struct {
+	Value	float64
+}
+
+
+
 var (
 	// CommonProperties indicates the dimensions that are sent with every event/metric
 	CommonProperties map[string]string
@@ -52,11 +65,20 @@ var (
 	WinExporterKeepListRegex string
 	// Windows KubeProxy metrics keep list regex
 	WinKubeProxyKeepListRegex string
+	// meMetricsProcessedCount map, which holds references to metrics per metric account
+	meMetricsProcessedCountMap = make(map[string]*meMetricsProcessedCount)
+	// meMetricsProcessedCountMapMutex -- used for reading & writing locks on meMetricsProcessedCountMap
+	meMetricsProcessedCountMapMutex = &sync.Mutex{}
+	// meMetricsReceivedCount map, which holds references to metrics per metric account
+	meMetricsReceivedCountMap = make(map[string]*meMetricsReceivedCount)
+	// meMetricsDroppedCountMapMutex -- used for reading & writing locks on meMetricsReceivedCountMap
+	meMetricsReceivedCountMapMutex = &sync.Mutex{}
 )
 
 const (
 	coresAttachedTelemetryIntervalSeconds = 600
 	ksmAttachedTelemetryIntervalSeconds   = 600
+	meMetricsTelemetryIntervalSeconds	  = 300
 	coresAttachedTelemetryName            = "ClusterCoreCapacity"
 	linuxCpuCapacityTelemetryName         = "LiCapacity"
 	linuxNodeCountTelemetryName           = "LiNodeCnt"
@@ -455,9 +477,7 @@ func PushLogErrorsToAppInsightsTraces(records []map[interface{}]interface{}, sev
 	return output.FLB_OK
 }
 
-// Get the account name, metrics/bytes processed count, and metrics/bytes sent count from metrics extension log line
-// that was filtered by fluent-bit
-func PushProcessedCountToAppInsightsMetrics(records []map[interface{}]interface{}) int {
+func UpdateMEMetricsProcessedCount(records []map[interface{}]interface{}) int {
 	for _, record := range records {
 		var logEntry = ToString(record["message"])
 		var metricScrapeInfoRegex = regexp.MustCompile(`\s*([^\s]+)\s*([^\s]+)\s*([^\s]+).*ProcessedCount: ([\d]+).*ProcessedBytes: ([\d]+).*SentToPublicationCount: ([\d]+).*SentToPublicationBytes: ([\d]+).*`)
@@ -466,45 +486,42 @@ func PushProcessedCountToAppInsightsMetrics(records []map[interface{}]interface{
 		if len(groupMatches) > 7 {
 			metricsProcessedCount, err := strconv.ParseFloat(groupMatches[4], 64)
 			if err == nil {
-				metric := appinsights.NewMetricTelemetry("meMetricsProcessedCount", metricsProcessedCount)
-				metric.Properties["metricsAccountName"] = groupMatches[3]
-				metric.Properties["bytesProcessedCount"] = groupMatches[5]
-				metric.Properties["metricsSentToPubCount"] = groupMatches[6]
-				metric.Properties["bytesSentToPubCount"] = groupMatches[7]
-				if InvalidCustomPrometheusConfig != "" {
-					metric.Properties["InvalidCustomPrometheusConfig"] = InvalidCustomPrometheusConfig
+
+				metricsAccountName := groupMatches[3]
+				
+				bytesProcessedCount, e := strconv.ParseFloat(groupMatches[5], 64)
+				if e != nil
+					bytesProcessedCount = 0
+			
+				metricsSentToPubCount,e := strconv.ParseFloat(groupMatches[6], 64)
+				if e != nil
+					metricsSentToPubCount = 0
+
+				bytesSentToPubCount,e := strconv.ParseFloat(groupMatches[7], 64)
+				if e != nil
+					bytesSentToPubCount = 0
+				
+				//update map
+				meMetricsProcessedCountMapMutex.Lock()
+
+				ref, ok := meMetricsProcessedCountMap[metricsAccountName]
+
+				if ok {
+					ref.DimBytesProcessedCount += bytesProcessedCount
+					ref.DimBytesSentToPubCount += bytesSentToPubCount
+					ref.DimMetricsSentToPubCount += metricsSentToPubCount
+					ref.Value += metricsProcessedCount
+
+				} else {
+					m := &meMetricsProcessedCount { 
+													DimBytesProcessedCount: bytesProcessedCount,
+													DimBytesSentToPubCount: bytesSentToPubCount,
+													DimMetricsSentToPubCount: metricsSentToPubCount,
+													Value: metricsProcessedCount
+												  }
+					meMetricsProcessedCountMap[metricsAccountName] = m
 				}
-				if DefaultPrometheusConfig != "" {
-					metric.Properties["DefaultPrometheusConfig"] = DefaultPrometheusConfig
-				}
-				if KubeletKeepListRegex != "" {
-					metric.Properties["KubeletKeepListRegex"] = KubeletKeepListRegex
-				}
-				if CoreDNSKeepListRegex != "" {
-					metric.Properties["CoreDNSKeepListRegex"] = CoreDNSKeepListRegex
-				}
-				if CAdvisorKeepListRegex != "" {
-					metric.Properties["CAdvisorKeepListRegex"] = CAdvisorKeepListRegex
-				}
-				if KubeProxyKeepListRegex != "" {
-					metric.Properties["KubeProxyKeepListRegex"] = KubeProxyKeepListRegex
-				}
-				if ApiServerKeepListRegex != "" {
-					metric.Properties["ApiServerKeepListRegex"] = ApiServerKeepListRegex
-				}
-				if KubeStateKeepListRegex != "" {
-					metric.Properties["KubeStateKeepListRegex"] = KubeStateKeepListRegex
-				}
-				if NodeExporterKeepListRegex != "" {
-					metric.Properties["NodeExporterKeepListRegex"] = NodeExporterKeepListRegex
-				}
-				if WinExporterKeepListRegex != "" {
-					metric.Properties["WinExporterKeepListRegex"] = WinExporterKeepListRegex
-				}
-				if WinKubeProxyKeepListRegex != "" {
-					metric.Properties["WinKubeProxyKeepListRegex"] = WinKubeProxyKeepListRegex
-				}
-				TelemetryClient.Track(metric)
+				meMetricsProcessedCountMapMutex.Unlock()
 			}
 
 			if strings.ToLower(os.Getenv(envPrometheusCollectorHealth)) == "true" {
@@ -525,9 +542,83 @@ func PushProcessedCountToAppInsightsMetrics(records []map[interface{}]interface{
 				}
 			}
 		}
-	}
 
+	}
 	return output.FLB_OK
+}
+
+// Get the account name, metrics/bytes processed count, and metrics/bytes sent count from metrics extension log line
+// that was filtered by fluent-bit
+func PushMEProcessedAndReceivedCountToAppInsightsMetrics() {
+
+	ticker := time.NewTicker(time.Second * time.Duration(meMetricsTelemetryIntervalSeconds))
+	for ; true; <-ticker.C {
+
+		meMetricsProcessedCountMapMutex.Lock()
+		for k,v := range meMetricsProcessedCountMap {
+			metric := appinsights.NewMetricTelemetry("meMetricsProcessedCount", v.Value)
+			metric.Properties["metricsAccountName"] = k
+			metric.Properties["bytesProcessedCount"] = fmt.Sprintf("%.2f",v.DimBytesProcessedCount)
+			metric.Properties["metricsSentToPubCount"] = fmt.Sprintf("%.2f",v.DimMetricsSentToPubCount)
+			metric.Properties["bytesSentToPubCount"] = fmt.Sprintf("%.2f",v.DimBytesSentToPubCount)
+
+			if InvalidCustomPrometheusConfig != "" {
+				metric.Properties["InvalidCustomPrometheusConfig"] = InvalidCustomPrometheusConfig
+			}
+			if DefaultPrometheusConfig != "" {
+				metric.Properties["DefaultPrometheusConfig"] = DefaultPrometheusConfig
+			}
+			if KubeletKeepListRegex != "" {
+				metric.Properties["KubeletKeepListRegex"] = KubeletKeepListRegex
+			}
+			if CoreDNSKeepListRegex != "" {
+				metric.Properties["CoreDNSKeepListRegex"] = CoreDNSKeepListRegex
+			}
+			if CAdvisorKeepListRegex != "" {
+				metric.Properties["CAdvisorKeepListRegex"] = CAdvisorKeepListRegex
+			}
+			if KubeProxyKeepListRegex != "" {
+				metric.Properties["KubeProxyKeepListRegex"] = KubeProxyKeepListRegex
+			}
+			if ApiServerKeepListRegex != "" {
+				metric.Properties["ApiServerKeepListRegex"] = ApiServerKeepListRegex
+			}
+			if KubeStateKeepListRegex != "" {
+				metric.Properties["KubeStateKeepListRegex"] = KubeStateKeepListRegex
+			}
+			if NodeExporterKeepListRegex != "" {
+				metric.Properties["NodeExporterKeepListRegex"] = NodeExporterKeepListRegex
+			}
+			if WinExporterKeepListRegex != "" {
+				metric.Properties["WinExporterKeepListRegex"] = WinExporterKeepListRegex
+			}
+			if WinKubeProxyKeepListRegex != "" {
+				metric.Properties["WinKubeProxyKeepListRegex"] = WinKubeProxyKeepListRegex
+			}
+			
+			TelemetryClient.Track(metric)
+
+		}
+
+		meMetricsProcessedCountMap = make(map[string]*meMetricsProcessedCount)
+
+		meMetricsProcessedCountMapMutex.Unlock()
+
+		//send meMetricsReceivedCount
+
+		ref, ok := meMetricsReceivedCountMap["na"]
+
+		if ok {
+			meMetricsReceivedCountMapMutex.Lock()
+
+			metric := appinsights.NewMetricTelemetry("meMetricsReceivedCount", ref.Value)
+			TelemetryClient.Track(metric)
+			meMetricsReceivedCountMap = make(map[string]*meMetricsReceivedCount)
+
+			meMetricsReceivedCountMapMutex.Unlock()
+		}
+
+	}
 }
 
 func PushMetricsDroppedCountToAppInsightsMetrics(records []map[interface{}]interface{}) int {
@@ -550,7 +641,7 @@ func PushMetricsDroppedCountToAppInsightsMetrics(records []map[interface{}]inter
 	return output.FLB_OK
 }
 
-func PushReceivedMetricsCountToAppInsightsMetrics(records []map[interface{}]interface{}) int {
+func UpdateMEReceivedMetricsCount(records []map[interface{}]interface{}) int {
 	for _, record := range records {
 		var logEntry = ToString(record["message"])
 		var metricScrapeInfoRegex = regexp.MustCompile(`.*EventsProcessedLastPeriod: (\d+).*`)
@@ -560,6 +651,22 @@ func PushReceivedMetricsCountToAppInsightsMetrics(records []map[interface{}]inte
 			metricsReceivedCount, err := strconv.ParseFloat(groupMatches[1], 64)
 			if err == nil {
 
+				//update map
+				meMetricsReceivedCountMapMutex.Lock()
+
+				ref, ok := meMetricsProcessedCountMap["na"]
+
+				if ok {
+					ref.Value += metricsReceivedCount
+
+				} else {
+					m := &meMetricsReceivedCount { 
+													Value: metricsReceivedCount
+												  }
+					meMetricsProcessedCountMap["na"] = m
+				}
+				meMetricsReceivedCountMapMutex.Unlock()
+				
 				// Add to the total that PublishTimeseriesVolume() uses
 				if strings.ToLower(os.Getenv(envPrometheusCollectorHealth)) == "true" {
 					TimeseriesVolumeMutex.Lock()
@@ -567,8 +674,8 @@ func PushReceivedMetricsCountToAppInsightsMetrics(records []map[interface{}]inte
 					TimeseriesVolumeMutex.Unlock()
 				}
 
-				metric := appinsights.NewMetricTelemetry("meMetricsReceivedCount", metricsReceivedCount)
-				TelemetryClient.Track(metric)
+				//metric := appinsights.NewMetricTelemetry("meMetricsReceivedCount", metricsReceivedCount)
+				//TelemetryClient.Track(metric)
 			}
 		}
 	}


### PR DESCRIPTION
* meprocessed and mereceived are the 2 voluminous metrics we had , as we are tailing ME log everytime ME processes a batch of metrics and emits as logs, and we generate metrics per log line
* dropped metric is third voluminous, but we dont get much value by aggregating them as we want the queue size, bytes sizes when we drop, and there is no poit in agg-ing them. So i left the dropped metric unchanged
* We now send one datapoint per metric (processed, received) every 5 mins by aggregating in memory
* Processed metric is by metric account (if there are multiple DCRs it will be per account)
* Below shows the before and after volume for these 2 metrics every 10 min for a 3 node cluster -- some 10x improvement
<img width="1375" alt="image" src="https://user-images.githubusercontent.com/10353076/222323288-44e4b566-62ed-4801-bde6-ab2ca6b5fecc.png">

* Below shows the MB of telemetry data ingested into app insights by these 2 metrics every hour for a 3 node cluster -- some 10x improvement
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/10353076/222323506-21875927-eeab-4d24-a92b-0710bd61a6f1.png">

No change in the structure of dimensions of these metrics. so no changes required for dashboard queries, except we can change binning to not less than 5 mins, as these are collected every 5 mins.