### PR TITLE
Fix default scrape configs for default targets

### DIFF
--- a/otelcollector/configmapparser/prometheus-config-merger.rb
+++ b/otelcollector/configmapparser/prometheus-config-merger.rb
@@ -160,10 +160,10 @@ def populateDefaultPrometheusConfig
             AppendMetricRelabelConfig(@kubeletDefaultFileRsSimple, kubeletMetricsKeepListRegex)
           end
           defaultConfigs.push(@kubeletDefaultFileRsSimple)
-        elsif windowsDaemonset == true && @sendDSUpMetric == true
+        elsif windowsDaemonset == true
           UpdateScrapeIntervalConfig(@kubeletDefaultFileRsAdvancedWindowsDaemonset, kubeletScrapeInterval)
           defaultConfigs.push(@kubeletDefaultFileRsAdvancedWindowsDaemonset)
-        elsif @sendDSUpMetric == true
+        else
           UpdateScrapeIntervalConfig(@kubeletDefaultFileRsAdvanced, kubeletScrapeInterval)
           defaultConfigs.push(@kubeletDefaultFileRsAdvanced)
         end
@@ -201,7 +201,7 @@ def populateDefaultPrometheusConfig
             AppendMetricRelabelConfig(@cadvisorDefaultFileRsSimple, cadvisorMetricsKeepListRegex)
           end
           defaultConfigs.push(@cadvisorDefaultFileRsSimple)
-        elsif @sendDSUpMetric == true
+        else
           UpdateScrapeIntervalConfig(@cadvisorDefaultFileRsAdvanced, cadvisorScrapeInterval)
           defaultConfigs.push(@cadvisorDefaultFileRsAdvanced)
         end
@@ -254,7 +254,7 @@ def populateDefaultPrometheusConfig
       nodeexporterMetricsKeepListRegex = @regexHash["NODEEXPORTER_METRICS_KEEP_LIST_REGEX"]
       nodeexporterScrapeInterval = @intervalHash["NODEEXPORTER_SCRAPE_INTERVAL"]
       if currentControllerType == @replicasetControllerType
-        if advancedMode == true && @sendDSUpMetric == true
+        if advancedMode == true
           UpdateScrapeIntervalConfig(@nodeexporterDefaultFileRsAdvanced, nodeexporterScrapeInterval)
           contents = File.read(@nodeexporterDefaultFileRsAdvanced)
           contents = contents.gsub("$$NODE_EXPORTER_NAME$$", ENV["NODE_EXPORTER_NAME"])


### PR DESCRIPTION
Currently, default scrape targets are:
```
export AZMON_PROMETHEUS_KUBELET_SCRAPING_ENABLED=true
export AZMON_PROMETHEUS_COREDNS_SCRAPING_ENABLED=true
export AZMON_PROMETHEUS_CADVISOR_SCRAPING_ENABLED=true
export AZMON_PROMETHEUS_KUBEPROXY_SCRAPING_ENABLED=false
export AZMON_PROMETHEUS_APISERVER_SCRAPING_ENABLED=true
export AZMON_PROMETHEUS_KUBESTATE_SCRAPING_ENABLED=true
export AZMON_PROMETHEUS_NODEEXPORTER_SCRAPING_ENABLED=true
export AZMON_PROMETHEUS_NO_DEFAULT_SCRAPING_ENABLED=false
export AZMON_PROMETHEUS_COLLECTOR_HEALTH_SCRAPING_ENABLED=true
export AZMON_PROMETHEUS_WINDOWSEXPORTER_SCRAPING_ENABLED=false
export AZMON_PROMETHEUS_WINDOWSKUBEPROXY_SCRAPING_ENABLED=false
```

#249 introduces a new hardcoded variable that has a side-effect to bypass entirely the default scrape config generation where it's used: kubelet, cadvisor and node exporter. Other scrape config jobs are not affected.
Bug hits all AKS cluster with AMA add-on

fixes #411