### PR TITLE
Fix linux builds failing

### DIFF
--- a/otelcollector/build/linux/Dockerfile
+++ b/otelcollector/build/linux/Dockerfile
@@ -72,6 +72,7 @@ COPY ./build/linux/rpm-repos/ /etc/yum.repos.d/
 
 ARG TARGETARCH
 RUN tdnf repolist --refresh
+RUN tdnf update
 RUN tdnf install -y wget sudo net-tools cronie vim ruby-devel logrotate procps-ng busybox diffutils curl
 RUN mkdir /busybin && busybox --install /busybin
 RUN chmod 775 /etc/cron.daily/logrotate


### PR DESCRIPTION
Mariner updated their gpg keys for their repos yesterday. tdnf update needs to be added to the Dockerfile to refresh these