### PR TITLE
Fix build error - add back name label

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - fixksmlabel
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - fixksmlabel
 
 pr:
   autoCancel: true

--- a/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
+++ b/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
@@ -26,7 +26,7 @@ param grafanaSku string
 @description('A new GUID used to identify the role assignment')
 param roleNameGuid string = newGuid()
 
-var azureMonitorWorkspaceId = split(azureMonitorWorkspaceResourceId, '/')[2]
+var azureMonitorWorkspaceSubscriptionId = split(azureMonitorWorkspaceResourceId, '/')[2]
 var clusterSubscriptionId = split(clusterResourceId, '/')[2]
 var clusterResourceGroup = split(clusterResourceId, '/')[4]
 var clusterName = split(clusterResourceId, '/')[8]
@@ -284,7 +284,7 @@ resource kubernetesRecordingRuleGroup 'Microsoft.AlertsManagement/prometheusRule
 resource roleNameGuid_resource 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: roleNameGuid
   properties: {
-    roleDefinitionId: '/subscriptions/${azureMonitorWorkspaceId}/providers/Microsoft.Authorization/roleDefinitions/b0d8363b-8ddd-447d-831f-62ca05bff136'
+    roleDefinitionId: '/subscriptions/${azureMonitorWorkspaceSubscriptionId}/providers/Microsoft.Authorization/roleDefinitions/b0d8363b-8ddd-447d-831f-62ca05bff136'
     principalId: reference(grafanaResourceId_8.id, '2022-08-01', 'Full').identity.principalId
   }
 }

--- a/otelcollector/deploy/dependentcharts/kube-state-metrics/templates/_helpers.tpl
+++ b/otelcollector/deploy/dependentcharts/kube-state-metrics/templates/_helpers.tpl
@@ -77,7 +77,7 @@ release: {{ .Release.Name }}
 Selector labels
 */}}
 {{- define "kube-state-metrics.selectorLabels" }}
-app: {{ template "kube-state-metrics.name" . }}
+app.kubernetes.io/name: {{ include "kube-state-metrics.name" . }}
 release: {{.Release.Name }}
 {{- end }}
 


### PR DESCRIPTION
This change adds back app.kubernetes.io/name label to fix build error (deploy to dev cluster) for backward compatibility. It was removed in the last change since this is an immutable label and we do not pull this and the other immutable label app.kubernetes.io/instance (from helm charts repo) for node exporter chart. But since removing this breaks the existing chart, I am adding this back. I have built the latest image(https://github-private.visualstudio.com/azure/_build/results?buildId=60057&view=results)  and data is flowing in.

This change also corrects the parameter name for AMW sub id.