### PR TITLE
Fix: pod annotations bug

### DIFF
--- a/otelcollector/configmapparser/prometheus-config-merger.rb
+++ b/otelcollector/configmapparser/prometheus-config-merger.rb
@@ -410,7 +410,7 @@ def populateDefaultPrometheusConfig
       end
     end
 
-    if !ENV["AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX"].nil? && currentControllerType == @replicasetControllerType
+    if !ENV["AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED"].downcase == "true"  && currentControllerType == @replicasetControllerType
       podannotationNamespacesRegex = ENV["AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX"]
       podannotationMetricsKeepListRegex = @regexHash["POD_ANNOTATION_METRICS_KEEP_LIST_REGEX"]
       podannotationScrapeInterval = @intervalHash["POD_ANNOTATION_SCRAPE_INTERVAL"]

--- a/otelcollector/configmapparser/tomlparser-default-scrape-settings.rb
+++ b/otelcollector/configmapparser/tomlparser-default-scrape-settings.rb
@@ -168,7 +168,7 @@ if !file.nil?
   file.write($export + "AZMON_PROMETHEUS_WINDOWSEXPORTER_SCRAPING_ENABLED=#{@windowsexporterEnabled}\n")
   file.write($export + "AZMON_PROMETHEUS_WINDOWSKUBEPROXY_SCRAPING_ENABLED=#{@windowskubeproxyEnabled}\n")
   file.write($export + "AZMON_PROMETHEUS_KAPPIEBASIC_SCRAPING_ENABLED=#{@kappiebasicEnabled}\n")
-  file.write($export + "AZMON_PROMETHEUS_POD_ANNOTAION_SCRAPING_ENABLED=#{@podannotationEnabled}\n")
+  file.write($export + "AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED=#{@podannotationEnabled}\n")
   # Close file after writing all metric collection setting environment variables
   file.close
 else


### PR DESCRIPTION
AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX was not nil but was empty so check was true. Using AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED which has both checks instead now