### PR TITLE
Update AddonPolicyMetricsProfile.parameters.json

### DIFF
--- a/AddonPolicyTemplate/AddonPolicyMetricsProfile.parameters.json
+++ b/AddonPolicyTemplate/AddonPolicyMetricsProfile.parameters.json
@@ -28,7 +28,7 @@
       }
     },
     "enableWindowsRecordingRules": {
-      "type": "bool",
+      "type": "boolean",
       "metadata": {
         "displayName": "Enable recording rule group for windows metrics",
         "description": "Enable recording rule group for windows metrics"


### PR DESCRIPTION
Updated `type = boolean` as with `bool` ARM was throwing error while apply.
 The policy '(Preview) Prometheus Metrics addon' has parameter(s) 'enableWindowsRecordingRules' with invalid types. The allowed parameter definition types are 'String,Array,Object,Boolean,Integer,Float,DateTime

After changing type, it worked fine.