### PR TITLE
Fix pod annotation namespaces spelling in configmap and make backwards-compatible

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,7 @@ trigger:
   branches:
     include:
     - main
-    - grace/podannotationmispelled
+    - grace/podannotationsmispelled
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - grace/podannotationmispelled
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - grace/podannotationsmispelled
 
 pr:
   autoCancel: true

--- a/otelcollector/configmapparser/tomlparser-pod-annotation-based-scraping.rb
+++ b/otelcollector/configmapparser/tomlparser-pod-annotation-based-scraping.rb
@@ -30,7 +30,11 @@ end
 # Use the ruby structure created after config parsing to set the right values to be used for otel collector settings
 def populateSettingValuesFromConfigMap(parsedConfig)
   begin
-    podannotationRegex = parsedConfig[:podannotationnamepsaceregex]
+    podannotationRegex = parsedConfig[:podannotationnamespaceregex]
+    # Make backwards compatible
+    if podannotationRegex.nil? || podannotationRegex.empty?
+      podannotationRegex = parsedConfig[:podannotationnamepsaceregex]
+    end
     if !podannotationRegex.nil? && podannotationRegex.kind_of?(String) && !podannotationRegex.empty?
       if isValidRegex(podannotationRegex) == true
         @podannotationNamespaceRegex = podannotationRegex

--- a/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
+++ b/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
@@ -24,7 +24,7 @@ data:
   # Regex for which namespaces to scrape through pod annotation based scraping.
   # This is none by default. Use '.*' to scrape all namespaces of annotated pods.
   pod-annotation-based-scraping: |-
-    podannotationnamepsaceregex = ""
+    podannotationnamespaceregex = ""
   default-targets-metrics-keep-list: |-
     kubelet = ""
     coredns = ""


### PR DESCRIPTION
- Tested with the old naming and the new naming
- Tested with either being empty