### PR TITLE
fix: update windows recording rules to remove duplicate entries for non running containers

### DIFF
--- a/AddonArmTemplate/FullAzureMonitorMetricsProfile.json
+++ b/AddonArmTemplate/FullAzureMonitorMetricsProfile.json
@@ -483,7 +483,7 @@
           },
           {
             "record": "windows_pod_container_available",
-            "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}, container_id != \"\") by(container, container_id, pod, namespace)"
+            "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_total_runtime",

--- a/AddonArmTemplate/FullAzureMonitorMetricsProfile.json
+++ b/AddonArmTemplate/FullAzureMonitorMetricsProfile.json
@@ -483,27 +483,27 @@
           },
           {
             "record": "windows_pod_container_available",
-            "expression": "windows_container_available{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_total_runtime",
-            "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_memory_usage",
-            "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_private_working_set_usage",
-            "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_network_received_bytes_total",
-            "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_network_transmitted_bytes_total",
-            "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "kube_pod_windows_container_resource_memory_request",

--- a/AddonArmTemplate/FullAzureMonitorMetricsProfile.json
+++ b/AddonArmTemplate/FullAzureMonitorMetricsProfile.json
@@ -483,27 +483,27 @@
           },
           {
             "record": "windows_pod_container_available",
-            "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}, container_id != \"\") by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_total_runtime",
-            "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_memory_usage",
-            "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_private_working_set_usage",
-            "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_network_received_bytes_total",
-            "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_network_transmitted_bytes_total",
-            "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "kube_pod_windows_container_resource_memory_request",

--- a/AddonArmTemplate/WindowsRecordingRuleGroupTemplate/WindowsRecordingRules.json
+++ b/AddonArmTemplate/WindowsRecordingRuleGroupTemplate/WindowsRecordingRules.json
@@ -154,27 +154,27 @@
           },
           {
             "record": "windows_pod_container_available",
-            "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_total_runtime",
-            "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_memory_usage",
-            "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_private_working_set_usage",
-            "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_network_received_bytes_total",
-            "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_network_transmitted_bytes_total",
-            "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "kube_pod_windows_container_resource_memory_request",

--- a/AddonArmTemplate/WindowsRecordingRuleGroupTemplate/WindowsRecordingRules.json
+++ b/AddonArmTemplate/WindowsRecordingRuleGroupTemplate/WindowsRecordingRules.json
@@ -154,27 +154,27 @@
           },
           {
             "record": "windows_pod_container_available",
-            "expression": "windows_container_available{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_total_runtime",
-            "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_memory_usage",
-            "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_private_working_set_usage",
-            "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_network_received_bytes_total",
-            "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "windows_container_network_transmitted_bytes_total",
-            "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+            "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
           },
           {
             "record": "kube_pod_windows_container_resource_memory_request",

--- a/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
+++ b/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
@@ -403,27 +403,27 @@ resource nodeAndKubernetesRecordingRuleGroupNameWin 'Microsoft.AlertsManagement/
       }
       {
         record: 'windows_pod_container_available'
-        expression: 'windows_container_available{job="windows-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_available{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_total_runtime'
-        expression: 'windows_container_cpu_usage_seconds_total{job="windows-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_cpu_usage_seconds_total{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_memory_usage'
-        expression: 'windows_container_memory_usage_commit_bytes{job="windows-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_memory_usage_commit_bytes{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_private_working_set_usage'
-        expression: 'windows_container_memory_usage_private_working_set_bytes{job="windows-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_memory_usage_private_working_set_bytes{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_network_received_bytes_total'
-        expression: 'windows_container_network_receive_bytes_total{job="windows-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_network_receive_bytes_total{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_network_transmitted_bytes_total'
-        expression: 'windows_container_network_transmit_bytes_total{job="windows-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_network_transmit_bytes_total{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'kube_pod_windows_container_resource_memory_request'

--- a/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
+++ b/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
@@ -403,27 +403,27 @@ resource nodeAndKubernetesRecordingRuleGroupNameWin 'Microsoft.AlertsManagement/
       }
       {
         record: 'windows_pod_container_available'
-        expression: 'windows_container_available{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_available{job="windows-exporter", container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics", container_id != ""}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_total_runtime'
-        expression: 'windows_container_cpu_usage_seconds_total{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_cpu_usage_seconds_total{job="windows-exporter", container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics", container_id != ""}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_memory_usage'
-        expression: 'windows_container_memory_usage_commit_bytes{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_memory_usage_commit_bytes{job="windows-exporter", container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics", container_id != ""}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_private_working_set_usage'
-        expression: 'windows_container_memory_usage_private_working_set_bytes{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_memory_usage_private_working_set_bytes{job="windows-exporter", container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics", container_id != ""}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_network_received_bytes_total'
-        expression: 'windows_container_network_receive_bytes_total{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_network_receive_bytes_total{job="windows-exporter", container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics", container_id != ""}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'windows_container_network_transmitted_bytes_total'
-        expression: 'windows_container_network_transmit_bytes_total{job="windows-exporter", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)'
+        expression: 'windows_container_network_transmit_bytes_total{job="windows-exporter", container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics", container_id != ""}) by(container, container_id, pod, namespace)'
       }
       {
         record: 'kube_pod_windows_container_resource_memory_request'

--- a/AddonPolicyTemplate/AddonPolicyMetricsProfile.rules.json
+++ b/AddonPolicyTemplate/AddonPolicyMetricsProfile.rules.json
@@ -482,27 +482,27 @@
 						},
 						{
 						  "record": "windows_pod_container_available",
-						  "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_total_runtime",
-						  "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_memory_usage",
-						  "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_private_working_set_usage",
-						  "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_network_received_bytes_total",
-						  "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_network_transmitted_bytes_total",
-						  "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "kube_pod_windows_container_resource_memory_request",

--- a/AddonPolicyTemplate/AddonPolicyMetricsProfile.rules.json
+++ b/AddonPolicyTemplate/AddonPolicyMetricsProfile.rules.json
@@ -482,27 +482,27 @@
 						},
 						{
 						  "record": "windows_pod_container_available",
-						  "expression": "windows_container_available{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_total_runtime",
-						  "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_memory_usage",
-						  "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_private_working_set_usage",
-						  "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_network_received_bytes_total",
-						  "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "windows_container_network_transmitted_bytes_total",
-						  "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+						  "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
 						},
 						{
 						  "record": "kube_pod_windows_container_resource_memory_request",

--- a/GeneratedMonitoringArtifacts/Default/DefaultRecordingRules.json
+++ b/GeneratedMonitoringArtifacts/Default/DefaultRecordingRules.json
@@ -309,27 +309,27 @@
                     },
                     {
                         "record": "windows_pod_container_available",
-                        "expression": "windows_container_available{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_total_runtime",
-                        "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_memory_usage",
-                        "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_private_working_set_usage",
-                        "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_network_received_bytes_total",
-                        "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_network_transmitted_bytes_total",
-                        "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "kube_pod_windows_container_resource_memory_request",

--- a/GeneratedMonitoringArtifacts/Default/DefaultRecordingRules.json
+++ b/GeneratedMonitoringArtifacts/Default/DefaultRecordingRules.json
@@ -309,27 +309,27 @@
                     },
                     {
                         "record": "windows_pod_container_available",
-                        "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_available{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_total_runtime",
-                        "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_cpu_usage_seconds_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_memory_usage",
-                        "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_memory_usage_commit_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_private_working_set_usage",
-                        "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_memory_usage_private_working_set_bytes{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_network_received_bytes_total",
-                        "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_network_receive_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "windows_container_network_transmitted_bytes_total",
-                        "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\"}) by(container, container_id, pod, namespace)"
+                        "expression": "windows_container_network_transmit_bytes_total{job=\"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job=\"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace)"
                     },
                     {
                         "record": "kube_pod_windows_container_resource_memory_request",

--- a/mixins/kubernetes/README.md
+++ b/mixins/kubernetes/README.md
@@ -82,6 +82,15 @@ There are separate dashboards for windows resources.
 
 These dashboards are based on metrics populated by [windows-exporter](https://github.com/prometheus-community/windows_exporter) from each Windows node.
 
+### Recording Rules
+
+The recording rules where taken from the default [kubernetes mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/rules) and incorporated into our repo for the default dashboards that the Azure Monitor Metrics addon provides. If there is a need to update any of them then please note that the following places need to be updated too:
+
+1) OSS Communityu kuberenetes mixin - [link to rules](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/rules)
+2) Azure Monitor Metrics UX Extension
+3) Alerts RP (stores recording rules for CLI)
+4) Prometheus collector repo - [Sample PR](https://github.com/Azure/prometheus-collector/pull/470/)
+
 ## Running the tests
 
 ```sh

--- a/mixins/kubernetes/README.md
+++ b/mixins/kubernetes/README.md
@@ -84,7 +84,7 @@ These dashboards are based on metrics populated by [windows-exporter](https://gi
 
 ### Recording Rules
 
-The recording rules where taken from the default [kubernetes mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/rules) and incorporated into our repo for the default dashboards that the Azure Monitor Metrics addon provides. If there is a need to update any of them then please note that the following places need to be updated too:
+The recording rules were taken from the default [kubernetes mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/rules) and incorporated into our repo for the default dashboards that the Azure Monitor Metrics addon provides. If there is a need to update any of them then please note that the following places need to be updated too:
 
 1) OSS Communityu kuberenetes mixin - [link to rules](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/rules)
 2) Azure Monitor Metrics UX Extension

--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-1.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-1.json
@@ -21,7 +21,7 @@
                     },
                     {
                         "record": "windows_pod_container_available",
-                        "expression": "windows_container_available{job = \"windows-exporter\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
+                        "expression": "windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
                     },
                     {
                         "record": "kube_pod_windows_container_resource_cpu_cores_request",

--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-1.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-1.json
@@ -21,7 +21,7 @@
                     },
                     {
                         "record": "windows_pod_container_available",
-                        "expression": "windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
+                        "expression": "windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace, cluster)"
                     },
                     {
                         "record": "kube_pod_windows_container_resource_cpu_cores_request",

--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-2.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-2.json
@@ -17,7 +17,7 @@
                 "rules": [
                     {
                         "record": "windows_pod_container_available_2",
-                        "expression": "windows_container_available{job = \"windows-exporter\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
+                        "expression": "windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
                     },
                     {
                         "record": ":windows_node_memory_MemTotal_bytes_2:sum",
@@ -29,7 +29,7 @@
                     },
                     {
                         "record": "memory_requests_commitment",
-                        "expression": "sum( max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{resource = \"memory\",job = \"kube-state-metrics\"}) * on (container, pod, namespace, cluster) (windows_container_available{job = \"windows-exporter\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster))) / sum(sum(windows_os_visible_memory_bytes{job = \"windows-exporter\" }))"
+                        "expression": "sum( max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{resource = \"memory\",job = \"kube-state-metrics\"}) * on (container, pod, namespace, cluster) (windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster))) / sum(sum(windows_os_visible_memory_bytes{job = \"windows-exporter\" }))"
                     },
                     {
                         "record": "kube_pod_windows_container_resource_memory_limit",
@@ -37,7 +37,7 @@
                     },
                     {
                         "record": "memory_limits_commitment",
-                        "expression": "sum(kube_pod_container_resource_limits{resource = \"memory\", job = \"kube-state-metrics\"} * on(container, pod, namespace, cluster) (windows_container_available{job = \"windows-exporter\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster))) / sum(sum(windows_os_visible_memory_bytes{job = \"windows-exporter\" }))"
+                        "expression": "sum(kube_pod_container_resource_limits{resource = \"memory\", job = \"kube-state-metrics\"} * on(container, pod, namespace, cluster) (windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster))) / sum(sum(windows_os_visible_memory_bytes{job = \"windows-exporter\" }))"
                     },
                     {
                         "record": "windows_container_total_runtime",
@@ -69,7 +69,7 @@
                     },
                     {
                         "record": "windows_container_private_working_set_usage",
-                        "expression": "windows_container_memory_usage_private_working_set_bytes{job = \"windows-exporter\", } * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
+                        "expression": "windows_container_memory_usage_private_working_set_bytes{job = \"windows-exporter\", , container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
                     },
                     {
                         "record": "memory_usage_private_working_set",

--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-2.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-2.json
@@ -17,7 +17,7 @@
                 "rules": [
                     {
                         "record": "windows_pod_container_available_2",
-                        "expression": "windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
+                        "expression": "windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace, cluster)"
                     },
                     {
                         "record": ":windows_node_memory_MemTotal_bytes_2:sum",
@@ -29,7 +29,7 @@
                     },
                     {
                         "record": "memory_requests_commitment",
-                        "expression": "sum( max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{resource = \"memory\",job = \"kube-state-metrics\"}) * on (container, pod, namespace, cluster) (windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster))) / sum(sum(windows_os_visible_memory_bytes{job = \"windows-exporter\" }))"
+                        "expression": "sum( max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{resource = \"memory\",job = \"kube-state-metrics\"}) * on (container, pod, namespace, cluster) (windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace, cluster))) / sum(sum(windows_os_visible_memory_bytes{job = \"windows-exporter\" }))"
                     },
                     {
                         "record": "kube_pod_windows_container_resource_memory_limit",
@@ -37,7 +37,7 @@
                     },
                     {
                         "record": "memory_limits_commitment",
-                        "expression": "sum(kube_pod_container_resource_limits{resource = \"memory\", job = \"kube-state-metrics\"} * on(container, pod, namespace, cluster) (windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster))) / sum(sum(windows_os_visible_memory_bytes{job = \"windows-exporter\" }))"
+                        "expression": "sum(kube_pod_container_resource_limits{resource = \"memory\", job = \"kube-state-metrics\"} * on(container, pod, namespace, cluster) (windows_container_available{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace, cluster))) / sum(sum(windows_os_visible_memory_bytes{job = \"windows-exporter\" }))"
                     },
                     {
                         "record": "windows_container_total_runtime",

--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-3.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-3.json
@@ -17,7 +17,7 @@
                 "rules": [
                     {
                         "record": "windows_container_network_received_bytes_total",
-                        "expression": "windows_container_network_receive_bytes_total{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
+                        "expression": "windows_container_network_receive_bytes_total{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace, cluster)"
                     },
                     {
                         "record": "network_io_1",
@@ -25,7 +25,7 @@
                     },
                     {
                         "record": "windows_container_network_transmitted_bytes_total",
-                        "expression": "windows_container_network_transmit_bytes_total{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
+                        "expression": "windows_container_network_transmit_bytes_total{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\", container_id != \"\"}) by(container, container_id, pod, namespace, cluster)"
                     },
                     {
                         "record": "network_io_2",

--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-3.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/k8s-resource-windows-cluster-rules-group-3.json
@@ -17,7 +17,7 @@
                 "rules": [
                     {
                         "record": "windows_container_network_received_bytes_total",
-                        "expression": "windows_container_network_receive_bytes_total{job = \"windows-exporter\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
+                        "expression": "windows_container_network_receive_bytes_total{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
                     },
                     {
                         "record": "network_io_1",
@@ -25,7 +25,7 @@
                     },
                     {
                         "record": "windows_container_network_transmitted_bytes_total",
-                        "expression": "windows_container_network_transmit_bytes_total{job = \"windows-exporter\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
+                        "expression": "windows_container_network_transmit_bytes_total{job = \"windows-exporter\", container_id != \"\"} * on(container_id) group_left(container, pod, namespace, cluster) max(kube_pod_container_info{job = \"kube-state-metrics\"}) by(container, container_id, pod, namespace, cluster)"
                     },
                     {
                         "record": "network_io_2",

--- a/mixins/kubernetes/rules/windows.libsonnet
+++ b/mixins/kubernetes/rules/windows.libsonnet
@@ -180,37 +180,37 @@
           {
             record: 'windows_pod_container_available',
             expr: |||
-              windows_container_available{%(windowsExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_available{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_total_runtime',
             expr: |||
-              windows_container_cpu_usage_seconds_total{%(windowsExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_cpu_usage_seconds_total{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_memory_usage',
             expr: |||
-              windows_container_memory_usage_commit_bytes{%(windowsExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_memory_usage_commit_bytes{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_private_working_set_usage',
             expr: |||
-              windows_container_memory_usage_private_working_set_bytes{%(windowsExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_memory_usage_private_working_set_bytes{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_network_received_bytes_total',
             expr: |||
-              windows_container_network_receive_bytes_total{%(windowsExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_network_receive_bytes_total{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_network_transmitted_bytes_total',
             expr: |||
-              windows_container_network_transmit_bytes_total{%(windowsExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_network_transmit_bytes_total{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {

--- a/mixins/kubernetes/rules/windows.libsonnet
+++ b/mixins/kubernetes/rules/windows.libsonnet
@@ -24,17 +24,17 @@
           },
           {
             // CPU utilisation is % CPU is not idle.
-            record: ':windows_node_cpu_utilisation:avg5m',
+            record: ':windows_node_cpu_utilisation:avg1m',
             expr: |||
-              1 - avg(rate(windows_cpu_time_total{%(windowsExporterSelector)s,mode="idle"}[5m]))
+              1 - avg(rate(windows_cpu_time_total{%(windowsExporterSelector)s,mode="idle"}[1m]))
             ||| % $._config,
           },
           {
             // CPU utilisation is % CPU is not idle.
-            record: 'node:windows_node_cpu_utilisation:avg5m',
+            record: 'node:windows_node_cpu_utilisation:avg1m',
             expr: |||
               1 - avg by (instance) (
-                rate(windows_cpu_time_total{%(windowsExporterSelector)s,mode="idle"}[5m])
+                rate(windows_cpu_time_total{%(windowsExporterSelector)s,mode="idle"}[1m])
               )
             ||| % $._config,
           },
@@ -111,8 +111,8 @@
             // Disk utilisation (ms spent, by rate() it's bound by 1 second)
             record: ':windows_node_disk_utilisation:avg_irate',
             expr: |||
-              avg(irate(windows_logical_disk_read_seconds_total{%(windowsExporterSelector)s}[5m]) +
-                  irate(windows_logical_disk_write_seconds_total{%(windowsExporterSelector)s}[5m])
+              avg(irate(windows_logical_disk_read_seconds_total{%(windowsExporterSelector)s}[1m]) +
+                  irate(windows_logical_disk_write_seconds_total{%(windowsExporterSelector)s}[1m])
                 )
             ||| % $._config,
           },
@@ -121,8 +121,8 @@
             record: 'node:windows_node_disk_utilisation:avg_irate',
             expr: |||
               avg by (instance) (
-                (irate(windows_logical_disk_read_seconds_total{%(windowsExporterSelector)s}[5m]) +
-                 irate(windows_logical_disk_write_seconds_total{%(windowsExporterSelector)s}[5m]))
+                (irate(windows_logical_disk_read_seconds_total{%(windowsExporterSelector)s}[1m]) +
+                 irate(windows_logical_disk_write_seconds_total{%(windowsExporterSelector)s}[1m]))
               )
             ||| % $._config,
           },
@@ -145,30 +145,30 @@
           {
             record: ':windows_node_net_utilisation:sum_irate',
             expr: |||
-              sum(irate(windows_net_bytes_total{%(windowsExporterSelector)s}[5m]))
+              sum(irate(windows_net_bytes_total{%(windowsExporterSelector)s}[1m]))
             ||| % $._config,
           },
           {
             record: 'node:windows_node_net_utilisation:sum_irate',
             expr: |||
               sum by (instance) (
-                (irate(windows_net_bytes_total{%(windowsExporterSelector)s}[5m]))
+                (irate(windows_net_bytes_total{%(windowsExporterSelector)s}[1m]))
               )
             ||| % $._config,
           },
           {
             record: ':windows_node_net_saturation:sum_irate',
             expr: |||
-              sum(irate(windows_net_packets_received_discarded_total{%(windowsExporterSelector)s}[5m])) +
-              sum(irate(windows_net_packets_outbound_discarded_total{%(windowsExporterSelector)s}[5m]))
+              sum(irate(windows_net_packets_received_discarded_total{%(windowsExporterSelector)s}[1m])) +
+              sum(irate(windows_net_packets_outbound_discarded_total{%(windowsExporterSelector)s}[1m]))
             ||| % $._config,
           },
           {
             record: 'node:windows_node_net_saturation:sum_irate',
             expr: |||
               sum by (instance) (
-                (irate(windows_net_packets_received_discarded_total{%(windowsExporterSelector)s}[5m]) +
-                irate(windows_net_packets_outbound_discarded_total{%(windowsExporterSelector)s}[5m]))
+                (irate(windows_net_packets_received_discarded_total{%(windowsExporterSelector)s}[1m]) +
+                irate(windows_net_packets_outbound_discarded_total{%(windowsExporterSelector)s}[1m]))
               )
             ||| % $._config,
           },

--- a/mixins/kubernetes/rules/windows.libsonnet
+++ b/mixins/kubernetes/rules/windows.libsonnet
@@ -24,17 +24,17 @@
           },
           {
             // CPU utilisation is % CPU is not idle.
-            record: ':windows_node_cpu_utilisation:avg1m',
+            record: ':windows_node_cpu_utilisation:avg5m',
             expr: |||
-              1 - avg(rate(windows_cpu_time_total{%(windowsExporterSelector)s,mode="idle"}[1m]))
+              1 - avg(rate(windows_cpu_time_total{%(windowsExporterSelector)s,mode="idle"}[5m]))
             ||| % $._config,
           },
           {
             // CPU utilisation is % CPU is not idle.
-            record: 'node:windows_node_cpu_utilisation:avg1m',
+            record: 'node:windows_node_cpu_utilisation:avg5m',
             expr: |||
               1 - avg by (instance) (
-                rate(windows_cpu_time_total{%(windowsExporterSelector)s,mode="idle"}[1m])
+                rate(windows_cpu_time_total{%(windowsExporterSelector)s,mode="idle"}[5m])
               )
             ||| % $._config,
           },
@@ -111,8 +111,8 @@
             // Disk utilisation (ms spent, by rate() it's bound by 1 second)
             record: ':windows_node_disk_utilisation:avg_irate',
             expr: |||
-              avg(irate(windows_logical_disk_read_seconds_total{%(windowsExporterSelector)s}[1m]) +
-                  irate(windows_logical_disk_write_seconds_total{%(windowsExporterSelector)s}[1m])
+              avg(irate(windows_logical_disk_read_seconds_total{%(windowsExporterSelector)s}[5m]) +
+                  irate(windows_logical_disk_write_seconds_total{%(windowsExporterSelector)s}[5m])
                 )
             ||| % $._config,
           },
@@ -121,8 +121,8 @@
             record: 'node:windows_node_disk_utilisation:avg_irate',
             expr: |||
               avg by (instance) (
-                (irate(windows_logical_disk_read_seconds_total{%(windowsExporterSelector)s}[1m]) +
-                 irate(windows_logical_disk_write_seconds_total{%(windowsExporterSelector)s}[1m]))
+                (irate(windows_logical_disk_read_seconds_total{%(windowsExporterSelector)s}[5m]) +
+                 irate(windows_logical_disk_write_seconds_total{%(windowsExporterSelector)s}[5m]))
               )
             ||| % $._config,
           },
@@ -145,30 +145,30 @@
           {
             record: ':windows_node_net_utilisation:sum_irate',
             expr: |||
-              sum(irate(windows_net_bytes_total{%(windowsExporterSelector)s}[1m]))
+              sum(irate(windows_net_bytes_total{%(windowsExporterSelector)s}[5m]))
             ||| % $._config,
           },
           {
             record: 'node:windows_node_net_utilisation:sum_irate',
             expr: |||
               sum by (instance) (
-                (irate(windows_net_bytes_total{%(windowsExporterSelector)s}[1m]))
+                (irate(windows_net_bytes_total{%(windowsExporterSelector)s}[5m]))
               )
             ||| % $._config,
           },
           {
             record: ':windows_node_net_saturation:sum_irate',
             expr: |||
-              sum(irate(windows_net_packets_received_discarded_total{%(windowsExporterSelector)s}[1m])) +
-              sum(irate(windows_net_packets_outbound_discarded_total{%(windowsExporterSelector)s}[1m]))
+              sum(irate(windows_net_packets_received_discarded_total{%(windowsExporterSelector)s}[5m])) +
+              sum(irate(windows_net_packets_outbound_discarded_total{%(windowsExporterSelector)s}[5m]))
             ||| % $._config,
           },
           {
             record: 'node:windows_node_net_saturation:sum_irate',
             expr: |||
               sum by (instance) (
-                (irate(windows_net_packets_received_discarded_total{%(windowsExporterSelector)s}[1m]) +
-                irate(windows_net_packets_outbound_discarded_total{%(windowsExporterSelector)s}[1m]))
+                (irate(windows_net_packets_received_discarded_total{%(windowsExporterSelector)s}[5m]) +
+                irate(windows_net_packets_outbound_discarded_total{%(windowsExporterSelector)s}[5m]))
               )
             ||| % $._config,
           },
@@ -180,37 +180,37 @@
           {
             record: 'windows_pod_container_available',
             expr: |||
-              windows_container_available{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_available{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s, container_id != ""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_total_runtime',
             expr: |||
-              windows_container_cpu_usage_seconds_total{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_cpu_usage_seconds_total{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s, container_id != ""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_memory_usage',
             expr: |||
-              windows_container_memory_usage_commit_bytes{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_memory_usage_commit_bytes{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s, container_id != ""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_private_working_set_usage',
             expr: |||
-              windows_container_memory_usage_private_working_set_bytes{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_memory_usage_private_working_set_bytes{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s, container_id != ""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_network_received_bytes_total',
             expr: |||
-              windows_container_network_receive_bytes_total{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_network_receive_bytes_total{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s, container_id != ""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_network_transmitted_bytes_total',
             expr: |||
-              windows_container_network_transmit_bytes_total{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_network_transmit_bytes_total{%(windowsExporterSelector)s, container_id != ""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s, container_id != ""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {


### PR DESCRIPTION
For e.g. The following query returned a many to many matching error: 
![image](https://user-images.githubusercontent.com/28612268/233724641-2ce1f075-0dc2-4506-a05f-13b6a109008f.png)

because there where multiple containers within the pod stuck in initizaling state and thus did not have container_id's set:
![image](https://user-images.githubusercontent.com/28612268/233724828-cc954685-fa52-402b-8ee9-3fe67a8ff1e1.png)

Hence our recording rule for them would fail. This fix eliminates those containers which are not running at all as there is no point in getting the cpu/memory usage for them.

Link to OSS community PR fix : https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/840