### PR TITLE
Update naming for dependencies dependabot should ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       time: "10:00"
       timezone: "America/Los_Angeles"
     ignore:
-    - dependency-name: "go.opentelemetry.io/collector"
+    - dependency-name: "go.opentelemetry.io/collector*"
     - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
     open-pull-requests-limit: 2
     rebase-strategy: "auto"
@@ -23,7 +23,7 @@ updates:
       time: "10:00"
       timezone: "America/Los_Angeles"
     ignore:
-    - dependency-name: "go.opentelemetry.io/collector"
+    - dependency-name: "go.opentelemetry.io/collector*"
     - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
     open-pull-requests-limit: 2
     rebase-strategy: "auto"


### PR DESCRIPTION
Add * to end of go.opentelemetry.io/collector since now each component is split into it's own go package