### PR TITLE
Reduce image tag length to docker limit of 128

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -47,8 +47,8 @@ jobs:
         # Truncating to 128 characters as it is required by docker
         LINUX_IMAGE_TAG=$(echo "${LINUX_IMAGE_TAG}" | cut -c1-128)
         WINDOWS_IMAGE_TAG=$SEMVER-win
-        # Truncating to 120 characters as it is required by docker (8 characters used in lts2019/ltsc2022)
-        WINDOWS_IMAGE_TAG=$(echo "${WINDOWS_IMAGE_TAG}" | cut -c1-120)
+        # Truncating to 119 characters as it is required by docker (9 characters used in -ltsc2019/-ltsc2022)
+        WINDOWS_IMAGE_TAG=$(echo "${WINDOWS_IMAGE_TAG}" | cut -c1-119)
         WINDOWS_2019_BASE_IMAGE_VERSION=ltsc2019
         WINDOWS_2022_BASE_IMAGE_VERSION=ltsc2022
 


### PR DESCRIPTION
Windows image tags take an extra 9 characters because of the '-ltsc2019' or '-ltsc2022' at the end of the image name. So reducing the image tag length by 9 characters to 119 so that the docker build command can run successfullly.