### PR TITLE
fix: Upgrades Kube state - image from: `v2.8.1` to:`v2.9.2`; chart from:`4.32.0` to `5.7.0`

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - kaveesh/update_ksm
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - kaveesh/update_ksm
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -19,7 +19,7 @@ variables:
   MCR_REPOSITORY: '/azuremonitor/containerinsights/cidev/prometheus-collector/images'
   MCR_REPOSITORY_HELM: '/azuremonitor/containerinsights/cidev/prometheus-collector'
   MCR_REPOSITORY_HELM_DEPENDENCIES: '/azuremonitor/containerinsights/cidev'
-  KUBE_STATE_METRICS_IMAGE: 'mcr.microsoft.com/oss/kubernetes/kube-state-metrics:v2.8.1'
+  KUBE_STATE_METRICS_IMAGE: 'mcr.microsoft.com/oss/kubernetes/kube-state-metrics:v2.9.2'
   NODE_EXPORTER_IMAGE: 'mcr.microsoft.com/oss/prometheus/node-exporter:v1.5.0'
   IS_PR: $[eq(variables['Build.Reason'], 'PullRequest')]
   IS_MAIN_BRANCH: $[eq(variables['Build.SourceBranchName'], 'main')]

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,9 @@
 # Azure Monitor Metrics for AKS clusters
 
+## Pending
+
+* fix: Upgrades Kube state - image from: `v2.8.1` to:`v2.9.2`; chart from:`4.32.0` to `5.7.0`
+
 ## Release 06-02-2023
 * Linux image - `mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/images:6.7.1-main-06-02-2023-d384b035`
 * Windows image - `mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/images:6.7.1-main-06-02-2023-d384b035-win`

--- a/internal/docs/UpgradeDependencies.md
+++ b/internal/docs/UpgradeDependencies.md
@@ -4,8 +4,9 @@ Example PR: https://github.com/Azure/prometheus-collector/pull/418
 
 Updating KSM and NE charts
 1. For updating the charts for KSM and NE, replace the respective folders from here respectively under dependentcharts, [KSM](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) and [NE](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter).
-2. Update the Version and Appversion in all the yaml files for both 1p and addon charts from the example PR above. (Note : The appversion corresponds to the Version in the kube-state-metrics chart and the version to the appversion)
+2. Update the Version and Appversion in all the yaml files for both 1p and addon charts from the example PR above. (Note: The version and appversion values can be found [here](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/Chart.yaml))
 3. Update both the images in our pipeline build file : azure-pipeline-build.yml
+4. Run the Github Action [build-and-push-dependent-helm-chart](https://github.com/Azure/prometheus-collector/actions/workflows/build-and-push-dependent-helm-charts.yml) for getting PR build to succeed.
 
 For upgrading all other dependencies, update them in setup.sh (for linux) and setup.ps1(for win).
 

--- a/internal/docs/UpgradeDependencies.md
+++ b/internal/docs/UpgradeDependencies.md
@@ -4,7 +4,7 @@ Example PR: https://github.com/Azure/prometheus-collector/pull/418
 
 Updating KSM and NE charts
 1. For updating the charts for KSM and NE, replace the respective folders from here respectively under dependentcharts, [KSM](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) and [NE](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter).
-2. Update the Version and Appversion in all the yaml files for both 1p and addon charts from the example PR above.
+2. Update the Version and Appversion in all the yaml files for both 1p and addon charts from the example PR above. (Note : The appversion corresponds to the Version in the kube-state-metrics chart and the version to the appversion)
 3. Update both the images in our pipeline build file : azure-pipeline-build.yml
 
 For upgrading all other dependencies, update them in setup.sh (for linux) and setup.ps1(for win).

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-clusterrolebinding.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.8.1
+    app.kubernetes.io/version: 2.9.2
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
   name: ama-metrics-ksm
 roleRef:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.8.1
+    app.kubernetes.io/version: 2.9.2
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: ama-metrics
         app.kubernetes.io/name: ama-metrics-ksm
         app.kubernetes.io/part-of: ama-metrics-ksm
-        app.kubernetes.io/version: 2.8.1
+        app.kubernetes.io/version: 2.9.2
         helm.sh/chart: azure-monitor-metrics-addon-0.1.0
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-role.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.8.1
+    app.kubernetes.io/version: 2.9.2
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
   name: ama-metrics-ksm
 rules:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-service.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.8.1
+    app.kubernetes.io/version: 2.9.2
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
   annotations:
     prometheus.io/scrape: 'true'

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-serviceaccount.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.8.1
+    app.kubernetes.io/version: 2.9.2
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
   name: ama-metrics-ksm
   namespace: kube-system

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -4,8 +4,8 @@ AzureMonitorMetrics:
     #MetricLabelsAllowlist: "testlabel=[.*]"
     #MetricAnnotationsAllowList: ""
     ImageRepository: "/oss/kubernetes/kube-state-metrics"
-# Kube-state-metrics ImageTag - 2.8.1, corresponds to chart version - 4.32.0
-    ImageTag: "v2.8.1"
+# Kube-state-metrics ImageTag - 2.9.2, corresponds to chart version - 5.7.0
+    ImageTag: "v2.9.2"
     Collectors:
       - certificatesigningrequests
       - configmaps

--- a/otelcollector/deploy/chart/prometheus-collector/Chart-template.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/Chart-template.yaml
@@ -25,7 +25,7 @@ appVersion: "${IMAGE_TAG}"
 kubeVersion: ">=1.16.0-0"
 dependencies:
 - name: kube-state-metrics
-  version: "4.32.0"
+  version: "5.7.0"
   repository: oci://${MCR_REGISTRY}${MCR_REPOSITORY_HELM_DEPENDENCIES}
   condition: scrapeTargets.kubeState
 - name: prometheus-node-exporter

--- a/otelcollector/deploy/dependentcharts/kube-state-metrics/Chart.yaml
+++ b/otelcollector/deploy/dependentcharts/kube-state-metrics/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.32.0
-appVersion: 2.8.1
+version: 5.7.0
+appVersion: 2.9.2
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/otelcollector/deploy/dependentcharts/kube-state-metrics/values.yaml
+++ b/otelcollector/deploy/dependentcharts/kube-state-metrics/values.yaml
@@ -2,7 +2,7 @@
 prometheusScrape: true
 image:
   repository: mcr.microsoft.com/oss/kubernetes/kube-state-metrics
-  tag: v2.8.1
+  tag: v2.9.2
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Link to bug this is fixing : https://github.com/influxdata/telegraf/issues/12749 ( happens when you try to scrape ksm from tha ama-logs prometheus side car container ) using : 
```
prometheus-data-collection-settings: |-
    [prometheus_data_collection_settings.cluster]
        interval = "2m"
        monitor_kubernetes_pods = true
        kubernetes_services = ["http://ama-metrics-ksm.kube-system.svc.cluster.local:8080/metrics"]
```