### PR TITLE
Arc extension: do not mount ubuntu ca-certs if k8s distro is AKS Edge Essentials

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
@@ -149,14 +149,16 @@ spec:
             - mountPath: /anchors/mariner
               name: anchors-mariner
               readOnly: true
+            {{- if and (not eq .Values.AzureMonitorMetrics.ArcExtension "true") (not eq .Values.Azure.Distribution "aks_edge_k3s") }}
             - mountPath: /anchors/ubuntu
               name: anchors-ubuntu
               readOnly: true
+            {{- end }}
             {{- if .Values.AzureMonitorMetrics.ArcExtension }}
             - mountPath: /anchors/proxy
               name: ama-metrics-proxy-cert
               readOnly: true
-            {{- end}}
+            {{- end }}
           livenessProbe:
             exec:
               command:
@@ -260,10 +262,12 @@ spec:
           hostPath:
             path: /etc/pki/ca-trust/anchors/
             type: DirectoryOrCreate
+        {{- if and (not eq .Values.AzureMonitorMetrics.ArcExtension "true") (not eq .Values.Azure.Distribution "aks_edge_k3s") }}
         - name: anchors-ubuntu
           hostPath:
             path: /usr/local/share/ca-certificates/
             type: DirectoryOrCreate
+        {{- end }}
         {{- if .Values.AzureMonitorMetrics.ArcExtension }}
         - name: ama-metrics-proxy-cert
           secret:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
@@ -160,9 +160,11 @@ spec:
             - mountPath: /anchors/mariner
               name: anchors-mariner
               readOnly: true
+            {{- if and (not eq .Values.AzureMonitorMetrics.ArcExtension "true") (not eq .Values.Azure.Distribution "aks_edge_k3s") }}
             - mountPath: /anchors/ubuntu
               name: anchors-ubuntu
               readOnly: true
+            {{- end }}
             {{- if .Values.AzureMonitorMetrics.ArcExtension }}
             - mountPath: /anchors/proxy
               name: ama-metrics-proxy-cert
@@ -287,10 +289,12 @@ spec:
           hostPath:
             path: /etc/pki/ca-trust/anchors/
             type: DirectoryOrCreate
+        {{- if and (not eq .Values.AzureMonitorMetrics.ArcExtension "true") (not eq .Values.Azure.Distribution "aks_edge_k3s") }}
         - name: anchors-ubuntu
           hostPath:
             path: /usr/local/share/ca-certificates/
             type: DirectoryOrCreate
+        {{-end }}
         {{- if .Values.AzureMonitorMetrics.ArcExtension }}
         - name: ama-metrics-proxy-cert
           secret:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -68,6 +68,8 @@ Azure:
   Cluster:
     ResourceId: "${ARC_RESOURCE_ID}"
     Region: "${ARC_REGION}"
+    Cloud: "azurepubliccloud"
+    Distribution: ""
   proxySettings:
     isProxyEnabled: "false"
     httpProxy: ""


### PR DESCRIPTION
AKS Edge Essentials clusters always use Mariner nodes, but have read-only host filesystems, so mounting an empty ubuntu ca-cert directory fails. Arc will provide the k8s distro as a chart value, so we will only mount the Mariner ca-certs if the distro is AKS EE.