### PR TITLE
Removing duplicate alerts from ci recommended alerts

### DIFF
--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
@@ -47,44 +47,6 @@
                 "interval": "PT5M",
                 "rules": [
                     {
-                        "alert": "Average CPU usage per container is greater than 95%",
-                        "expression": "sum (rate(container_cpu_usage_seconds_total{image!=\"\", container!=\"POD\"}[5m])) by (pod,cluster,container,namespace) / sum(container_spec_cpu_quota{image!=\"\", container!=\"POD\"}/container_spec_cpu_period{image!=\"\", container!=\"POD\"}) by (pod,cluster,container,namespace) > .95",
-                        "for": "PT5M",
-                        "annotations": {
-                            "description": "Average CPU usage per container is greater than 95%"
-                        },
-                        "enabled": true,
-                        "severity": 4,
-                        "resolveConfiguration": {
-                            "autoResolved": true,
-                            "timeToResolve": "PT15M"
-                        },
-                        "actions": [
-                            {
-                                "actionGroupId": "[parameters('actionGroupResourceId')]"
-                            }
-                        ]
-                    },
-                    {
-                        "alert": "Average Memory usage per container is greater than 95%.",
-                        "expression": "(container_memory_working_set_bytes{container!=\"\", image!=\"\", container!=\"POD\"} / on(namespace,cluster,pod,container) group_left kube_pod_container_resource_limits{resource=\"memory\", node!=\"\"}) > .95 ",
-                        "for": "PT10M",
-                        "annotations": {
-                            "description": "Average Memory usage per container is greater than 95%"
-                        },
-                        "enabled": true,
-                        "severity": 4,
-                        "resolveConfiguration": {
-                            "autoResolved": true,
-                            "timeToResolve": "PT10M"
-                        },
-                        "actions": [
-                            {
-                                "actionGroupId": "[parameters('actionGroupResourceId')]"
-                            }
-                        ]
-                    },
-                    {
                         "alert": "Number of OOM killed containers is greater than 0",
                         "expression": "sum by (cluster,container,namespace)(kube_pod_container_status_last_terminated_reason{reason=\"OOMKilled\"}) > 0",
                         "for": "PT5M",

--- a/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
+++ b/mixins/kubernetes/rules/recording_and_alerting_rules/templates/ci_recommended_alerts.json
@@ -47,6 +47,44 @@
                 "interval": "PT5M",
                 "rules": [
                     {
+                        "alert": "Average CPU usage per container is greater than 95%",
+                        "expression": "sum (rate(container_cpu_usage_seconds_total{image!=\"\", container!=\"POD\"}[5m])) by (pod,cluster,container,namespace) / sum(container_spec_cpu_quota{image!=\"\", container!=\"POD\"}/container_spec_cpu_period{image!=\"\", container!=\"POD\"}) by (pod,cluster,container,namespace) > .95",
+                        "for": "PT5M",
+                        "annotations": {
+                            "description": "Average CPU usage per container is greater than 95%"
+                        },
+                        "enabled": true,
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT15M"
+                        },
+                        "actions": [
+                            {
+                                "actionGroupId": "[parameters('actionGroupResourceId')]"
+                            }
+                        ]
+                    },
+                    {
+                        "alert": "Average Memory usage per container is greater than 95%.",
+                        "expression": "(container_memory_working_set_bytes{container!=\"\", image!=\"\", container!=\"POD\"} / on(namespace,cluster,pod,container) group_left kube_pod_container_resource_limits{resource=\"memory\", node!=\"\"}) > .95 ",
+                        "for": "PT10M",
+                        "annotations": {
+                            "description": "Average Memory usage per container is greater than 95%"
+                        },
+                        "enabled": true,
+                        "severity": 4,
+                        "resolveConfiguration": {
+                            "autoResolved": true,
+                            "timeToResolve": "PT10M"
+                        },
+                        "actions": [
+                            {
+                                "actionGroupId": "[parameters('actionGroupResourceId')]"
+                            }
+                        ]
+                    },
+                    {
                         "alert": "Number of OOM killed containers is greater than 0",
                         "expression": "sum by (cluster,container,namespace)(kube_pod_container_status_last_terminated_reason{reason=\"OOMKilled\"}) > 0",
                         "for": "PT5M",
@@ -147,44 +185,6 @@
                         "for": "PT360M",
                         "annotations": {
                             "description": "Number of stale jobs older than six hours is greater than 0"
-                        },
-                        "enabled": true,
-                        "severity": 4,
-                        "resolveConfiguration": {
-                            "autoResolved": true,
-                            "timeToResolve": "PT15M"
-                        },
-                        "actions": [
-                            {
-                                "actionGroupId": "[parameters('actionGroupResourceId')]"
-                            }
-                        ]
-                    },
-                    {
-                        "alert": "Average node CPU utilization is greater than 80%",
-                        "expression": "(  (1 - rate(node_cpu_seconds_total{job=\"node\", mode=\"idle\"}[5m]) ) / ignoring(cpu) group_left count without (cpu)( node_cpu_seconds_total{job=\"node\", mode=\"idle\"}) ) > .8 ",
-                        "for": "PT5M",
-                        "annotations": {
-                            "description": "Average node CPU utilization is greater than 80%"
-                        },
-                        "enabled": true,
-                        "severity": 4,
-                        "resolveConfiguration": {
-                            "autoResolved": true,
-                            "timeToResolve": "PT15M"
-                        },
-                        "actions": [
-                            {
-                                "actionGroupId": "[parameters('actionGroupResourceId')]"
-                            }
-                        ]
-                    },
-                    {
-                        "alert": "Working set memory for a node is greater than 80%.",
-                        "expression": "1 - avg by (namespace,cluster,job,instance)(node_memory_MemAvailable_bytes{job=\"node\"}) / avg by (namespace,cluster,job,instance)(node_memory_MemTotal_bytes{job=\"node\"}) > .8",
-                        "for": "PT5M",
-                        "annotations": {
-                            "description": "Working set memory for node {{ $labels.instance }} is greater than 80%."
                         },
                         "enabled": true,
                         "severity": 4,


### PR DESCRIPTION
These alerts are duplicate with the platform metric alerts which get created OOB while creating AKS cluster. 

These are node based CPU and memory alerts for containers. This update was confirmed by alerts team.

Platform metric alerts: https://dev.azure.com/msazure/CloudNativeCompute/_search?action=contents&text=node_memory_working_set_percentage&type=code&lp=code-Project&filters=ProjectFilters%7BCloudNativeCompute%7DRepositoryFilters%7Baks-operator%7D&pageSize=25&result=DefaultCollection/CloudNativeCompute/aks-operator/GBmaster//config/metrics/profiles/default/recording_rules.yml

![MicrosoftTeams-image (1)](https://github.com/Azure/prometheus-collector/assets/31517098/08e8e0a1-cba8-488a-8994-a2a969419e8c)
