### PR TITLE
Remove $ to $$ replacement since the otelcollector does this now

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - grace/fix-env-sub-issue
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - grace/fix-env-sub-issue
 
 pr:
   autoCancel: true

--- a/otelcollector/prom-config-validator-builder/main.go
+++ b/otelcollector/prom-config-validator-builder/main.go
@@ -114,21 +114,19 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 				relabelConfigs := scrapeConfig["relabel_configs"].([]interface{})
 				for _, relabelConfig := range relabelConfigs {
 					relabelConfig := relabelConfig.(map[interface{}]interface{})
-					//replace $ with $$ for regex field
+					//replace $$ with $ for regex field for backwards compatibility
 					if relabelConfig["regex"] != nil {
 						// Adding this check here since regex can be boolean and the conversion will fail
 						if _, isString := relabelConfig["regex"].(string); isString {
 							regexString := relabelConfig["regex"].(string)
 							modifiedRegexString := strings.ReplaceAll(regexString, "$$", "$")
-							//modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$", "$$")
 							relabelConfig["regex"] = modifiedRegexString
 						}
 					}
-					//replace $ with $$ for replacement field
+					//replace $$ with $ for replacement field for backwards compatibility
 					if relabelConfig["replacement"] != nil {
 						replacement := relabelConfig["replacement"].(string)
 						modifiedReplacementString := strings.ReplaceAll(replacement, "$$", "$")
-						//modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$", "$$")
 						relabelConfig["replacement"] = modifiedReplacementString
 					}
 				}

--- a/otelcollector/prom-config-validator-builder/main.go
+++ b/otelcollector/prom-config-validator-builder/main.go
@@ -120,7 +120,7 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 						if _, isString := relabelConfig["regex"].(string); isString {
 							regexString := relabelConfig["regex"].(string)
 							modifiedRegexString := strings.ReplaceAll(regexString, "$$", "$")
-							modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$", "$$")
+							//modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$", "$$")
 							relabelConfig["regex"] = modifiedRegexString
 						}
 					}
@@ -128,7 +128,7 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 					if relabelConfig["replacement"] != nil {
 						replacement := relabelConfig["replacement"].(string)
 						modifiedReplacementString := strings.ReplaceAll(replacement, "$$", "$")
-						modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$", "$$")
+						//modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$", "$$")
 						relabelConfig["replacement"] = modifiedReplacementString
 					}
 				}
@@ -144,7 +144,7 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 						if _, isString := metricRelabelConfig["regex"].(string); isString {
 							regexString := metricRelabelConfig["regex"].(string)
 							modifiedRegexString := strings.ReplaceAll(regexString, "$$", "$")
-							modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$", "$$")
+							//modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$", "$$")
 							metricRelabelConfig["regex"] = modifiedRegexString
 						}
 					}
@@ -153,7 +153,7 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 					if metricRelabelConfig["replacement"] != nil {
 						replacement := metricRelabelConfig["replacement"].(string)
 						modifiedReplacementString := strings.ReplaceAll(replacement, "$$", "$")
-						modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$", "$$")
+						//modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$", "$$")
 						metricRelabelConfig["replacement"] = modifiedReplacementString
 					}
 				}

--- a/otelcollector/prom-config-validator-builder/main.go
+++ b/otelcollector/prom-config-validator-builder/main.go
@@ -136,22 +136,20 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 				metricRelabelConfigs := scrapeConfig["metric_relabel_configs"].([]interface{})
 				for _, metricRelabelConfig := range metricRelabelConfigs {
 					metricRelabelConfig := metricRelabelConfig.(map[interface{}]interface{})
-					//replace $ with $$ for regex field
+					//replace $$ with $ for regex field for backwards compatibility
 					if metricRelabelConfig["regex"] != nil {
 						// Adding this check here since regex can be boolean and the conversion will fail
 						if _, isString := metricRelabelConfig["regex"].(string); isString {
 							regexString := metricRelabelConfig["regex"].(string)
 							modifiedRegexString := strings.ReplaceAll(regexString, "$$", "$")
-							//modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$", "$$")
 							metricRelabelConfig["regex"] = modifiedRegexString
 						}
 					}
 
-					//replace $ with $$ for replacement field
+					//replace $$ with $ for replacement field for backwards compatibility
 					if metricRelabelConfig["replacement"] != nil {
 						replacement := metricRelabelConfig["replacement"].(string)
 						modifiedReplacementString := strings.ReplaceAll(replacement, "$$", "$")
-						//modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$", "$$")
 						metricRelabelConfig["replacement"] = modifiedReplacementString
 					}
 				}


### PR DESCRIPTION
- Tested that it still works for customers who have $$ in their config because we still replace that with $
- Tested that it works for customer who only have a single $ and that we don't need to add the $$ anymore

This fixes the current issue where the env sub does not work for custom configs because the otelcollector is doing it for us now