### PR TITLE
Fix bug: add scrape interval for 2 targets

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,7 @@ trigger:
   branches:
     include:
     - main
-
+    - scarpeintervalbugfix
 pr:
   autoCancel: true
   branches:
@@ -104,7 +104,7 @@ jobs:
 
     - task: CredScan@3
       displayName: "SDL : Run credscan"
-    
+
     - task: CopyFiles@2
       displayName: "Ev2: copy Ev2 deployment artifacts to staging directory"
       inputs:
@@ -549,7 +549,7 @@ jobs:
       else
         echo "-e error failed to login to az with managed identity credentials"
         exit 1
-      fi    
+      fi
 
       ACCESS_TOKEN=$(az account get-access-token --resource $RESOURCE_AUDIENCE --query accessToken -o json)
       if [ $? -eq 0 ]; then
@@ -557,7 +557,7 @@ jobs:
       else
         echo "-e error get access token from resource:$RESOURCE_AUDIENCE failed."
         exit 1
-      fi   
+      fi
       ACCESS_TOKEN=$(echo $ACCESS_TOKEN | tr -d '"' | tr -d '"\r\n')
 
       ARC_API_URL="https://eastus2euap.dp.kubernetesconfiguration.azure.com"
@@ -578,7 +578,7 @@ jobs:
     inputs:
       azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
       scriptType: 'bash'
-      scriptLocation: 'inlineScript' 
+      scriptLocation: 'inlineScript'
       inlineScript: |
         az config set extension.use_dynamic_install=yes_without_prompt
         az k8s-extension update --name azuremonitor-metrics --resource-group ci-dev-arc-wcus --cluster-name ci-dev-arc-wcus --cluster-type connectedClusters --version $HELM_SEMVER --release-train pipeline

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - scarpeintervalbugfix
 pr:
   autoCancel: true
   branches:

--- a/otelcollector/configmapparser/default-prom-configs/podannotationsDefault.yml
+++ b/otelcollector/configmapparser/default-prom-configs/podannotationsDefault.yml
@@ -1,5 +1,6 @@
   scrape_configs:
   - job_name: 'kubernetes-pods'
+    scrape_interval: $$SCRAPE_INTERVAL$$
     kubernetes_sd_configs:
     - role: pod
     relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/prometheusCollectorHealth.yml
+++ b/otelcollector/configmapparser/default-prom-configs/prometheusCollectorHealth.yml
@@ -1,5 +1,6 @@
   scrape_configs:
   - job_name: prometheus_collector_health
+    scrape_interval: $$SCRAPE_INTERVAL$$
     label_limit: 63
     label_name_length_limit: 511
     label_value_length_limit: 1023

--- a/otelcollector/configmapparser/prometheus-config-merger.rb
+++ b/otelcollector/configmapparser/prometheus-config-merger.rb
@@ -530,7 +530,7 @@ def setDefaultFileScrapeInterval(scrapeInterval)
     @corednsDefaultFile, @cadvisorDefaultFileRsSimple, @cadvisorDefaultFileRsAdvanced, @cadvisorDefaultFileDs, @kubeproxyDefaultFile,
     @apiserverDefaultFile, @kubestateDefaultFile, @nodeexporterDefaultFileRsSimple, @nodeexporterDefaultFileRsAdvanced, @nodeexporterDefaultFileDs,
     @prometheusCollectorHealthDefaultFile, @windowsexporterDefaultRsSimpleFile, @windowsexporterDefaultDsFile,
-    @windowskubeproxyDefaultFileRsSimpleFile, @windowskubeproxyDefaultDsFile
+    @windowskubeproxyDefaultFileRsSimpleFile, @windowskubeproxyDefaultDsFile, @podannotationsDefaultFile
   ]
 
   defaultFilesArray.each { |currentFile|


### PR DESCRIPTION
This change fixes the bug and adds scrape interval for 2 targets(pod annotations and collector health).

I have tested this by updating configmap to 32s for these two targets here https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/1a3fd8b1-7a92-4730-8e47-dec9e67f49a9/resourceGroups/sohamtestalertvol/providers/Microsoft.ContainerService/managedClusters/sohamtestalertvol/workloads

Image for testing: 6.7.2-scarpeintervalbugfix-07-07-2023-8958e249