### PR TITLE
Increase publication size to include compression

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - incpubsizesoham
 pr:
   autoCancel: true
   branches:

--- a/otelcollector/metricextension/me.config
+++ b/otelcollector/metricextension/me.config
@@ -13,7 +13,7 @@
    },
    "publicationIntervalInSec":20,
    "maxPublicationAttemptsPerMinute":12,
-   "maxPublicationPackageSizeInBytes":2000000,
+   "maxPublicationPackageSizeInBytes":5000000,
    "maxPublicationBytesPerMinute":200000000,
    "maxPublicationMetricsPerMinute":10000000,
    "maxAggregationQueueSize":7000000,

--- a/otelcollector/metricextension/me_ds.config
+++ b/otelcollector/metricextension/me_ds.config
@@ -13,7 +13,7 @@
    },
    "publicationIntervalInSec":20,
    "maxPublicationAttemptsPerMinute":12,
-   "maxPublicationPackageSizeInBytes":2000000,
+   "maxPublicationPackageSizeInBytes":5000000,
    "maxPublicationBytesPerMinute":200000000,
    "maxPublicationMetricsPerMinute":10000000,
    "maxAggregationQueueSize":7000000,

--- a/otelcollector/metricextension/me_ds_internal.config
+++ b/otelcollector/metricextension/me_ds_internal.config
@@ -13,7 +13,7 @@
    },
    "publicationIntervalInSec":20,
    "maxPublicationAttemptsPerMinute":12,
-   "maxPublicationPackageSizeInBytes":2000000,
+   "maxPublicationPackageSizeInBytes":5000000,
    "maxPublicationBytesPerMinute":200000000,
    "maxPublicationMetricsPerMinute":10000000,
    "maxAggregationQueueSize":7000000,

--- a/otelcollector/metricextension/me_internal.config
+++ b/otelcollector/metricextension/me_internal.config
@@ -13,7 +13,7 @@
    },
    "publicationIntervalInSec":20,
    "maxPublicationAttemptsPerMinute":12,
-   "maxPublicationPackageSizeInBytes":2000000,
+   "maxPublicationPackageSizeInBytes":5000000,
    "maxPublicationBytesPerMinute":200000000,
    "maxPublicationMetricsPerMinute":10000000,
    "maxAggregationQueueSize":7000000,


### PR DESCRIPTION
This change pessimistically sets limit of maxPublicationPackageSizeInBytes to 5000000 to include compression in order to support higher cardinality metrics.

I have deployed the image in scale cluster and have tested the replicaset. There are no restarts, errors in the logs, metrics are flowing in Grafana. I am attaching the CPU and memory usage metrics for the replicaset at the deployment, workload and pod level for evidence. They look good.

Below are the old and new images and their corresponding CPU and Memory stats, they are identical.


New image: 6.7.2-soham-incpubsizebytes-07-11-2023-5e35a9f3

![32072d6a-22bd-4746-a0cf-c542a790c7ef](https://github.com/Azure/prometheus-collector/assets/31517098/9b822f3a-042b-41ce-a098-aa59e54130f0)
![2aae4743-cf05-40eb-9650-d1c595543318](https://github.com/Azure/prometheus-collector/assets/31517098/cd703974-225c-461b-939b-6e18b12d3f84)

![fbcb73ce-f7f5-4a50-8185-e3962a2d921d](https://github.com/Azure/prometheus-collector/assets/31517098/08ea234a-d200-4cf2-9e56-4bdbfe01a7f7)
![9de4c9b6-499e-456c-9910-80578ff81c9f](https://github.com/Azure/prometheus-collector/assets/31517098/d6b02f4e-513c-4d30-b44d-6c62ba03ccce)

Old image: 6.7.2-main-06-26-2023-6ee07896

![61dd8d85-ca08-47b5-8a25-2b7ce84e2388](https://github.com/Azure/prometheus-collector/assets/31517098/a65f9d7c-f084-46de-92b6-acd7645fac07)
![d89ff2ed-b484-4649-8e83-8e73f73ef81b](https://github.com/Azure/prometheus-collector/assets/31517098/317c1658-30e8-43f4-b4b6-9ba147731bb9)
![ebb1b93f-91c1-4172-88d0-11287d720560](https://github.com/Azure/prometheus-collector/assets/31517098/2c76d859-eed6-4c5d-9667-47d927ef21c3)
