### PR TITLE
Upgrade dependencies

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - vishwa/10022023-upgrade
 pr:
   autoCancel: true
   branches:

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - vishwa/10022023-upgrade
 pr:
   autoCancel: true
   branches:

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -357,6 +357,7 @@ jobs:
         fi
       workingDirectory: $(Build.SourcesDirectory)
       displayName: "Build: run trivy scan"
+      condition: eq(variables.IS_PR, false)
 
     - task: CodeQL3000Finalize@0
       displayName: 'SDL: run codeql'

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - vishwa/10022023-upgrade
 pr:
   autoCancel: true
   branches:
@@ -235,7 +236,7 @@ jobs:
     - task: GoTool@0
       displayName: "Build: specify golang version"
       inputs:
-        version: '1.19'
+        version: '1.21'
 
     - bash: |
         sudo apt-get install build-essential -y

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -344,8 +344,17 @@ jobs:
     - bash: |
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
         trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM --exit-code 1 $(LINUX_FULL_IMAGE_NAME)
+        if [ $? -ne 0 ]; then
+          exit 1
+        fi
         trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM --exit-code 1 $(KUBE_STATE_METRICS_IMAGE)
+        if [ $? -ne 0 ]; then
+          exit 1
+        fi
         trivy image --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM --exit-code 1 $(NODE_EXPORTER_IMAGE)
+        if [ $? -ne 0 ]; then
+          exit 1
+        fi
       workingDirectory: $(Build.SourcesDirectory)
       displayName: "Build: run trivy scan"
 

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -236,7 +236,7 @@ jobs:
     - task: GoTool@0
       displayName: "Build: specify golang version"
       inputs:
-        version: '1.21'
+        version: '1.20'
 
     - bash: |
         sudo apt-get install build-essential -y

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -424,7 +424,7 @@ jobs:
     - task: GoTool@0
       displayName: "Build: specify golang version"
       inputs:
-        version: '1.19'
+        version: '1.20'
 
     - powershell: |
         ./makefile_windows.ps1
@@ -462,7 +462,7 @@ jobs:
     - task: GoTool@0
       displayName: "Build: specify golang version"
       inputs:
-        version: '1.19'
+        version: '1.20'
 
     - powershell: |
         ./makefile_windows.ps1
@@ -505,7 +505,7 @@ jobs:
     - task: GoTool@0
       displayName: "Build: specify golang version"
       inputs:
-        version: '1.19'
+        version: '1.20'
 
     - powershell: |
         New-Item -Path "$(Build.ArtifactStagingDirectory)" -Name "windows" -ItemType "directory"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,29 +1,23 @@
 # Check for HIGH/CRITICAL & MEDIUM CVEs. HIGH/CRITICAL to be fixed asap, MEDIUM is best effort
 # ignore these CVEs, but continue scanning to catch other vulns. Note : this will ignore these cves globally
 
-# CRITICAL/HIGH
-# Ruby GEM
-#CVE-2021-33621
-# node-exporter
-#CVE-2021-38561
-#CVE-2021-44716
-#CVE-2022-21698
-#CVE-2022-27191
-# opt/telegraf/telegraf
-#CVE-2022-23471
-#CVE-2023-25153
-#CVE-2023-25173
+# CRITICAL
+# none
 
-# MEDIUM
-# opt/telegraf/telegraf
-#CVE-2019-3826
-# kube-state-metrics
-#CVE-2022-41723
-# opt/microsoft/otelcollector/otelcollector
-# opt/promconfigvalidator
-# opt/telegraf/telegraf
-# kube-state-metrics
-# bin/node_exporter
-#CVE-2022-41717
-#CVE-2022-46146
-#CVE-2022-41721
+# =========== HIGH ================
+# HIGH - otelcollector
+CVE-2023-2253
+CVE-2023-28840
+# HIGH - promconfigvalidator
+CVE-2023-2253
+CVE-2023-28840
+
+# =========== MEDIUM ================
+# MEDIUM - otelcollector
+CVE-2023-28841
+CVE-2023-28842
+CVE-2023-40577
+# MEDIUM - promconfigvalidator
+CVE-2023-28841
+CVE-2023-28842
+CVE-2023-40577

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,27 +3,27 @@
 
 # CRITICAL/HIGH
 # Ruby GEM
-CVE-2021-33621
+#CVE-2021-33621
 # node-exporter
-CVE-2021-38561
-CVE-2021-44716
-CVE-2022-21698
-CVE-2022-27191
+#CVE-2021-38561
+#CVE-2021-44716
+#CVE-2022-21698
+#CVE-2022-27191
 # opt/telegraf/telegraf
-CVE-2022-23471
-CVE-2023-25153
-CVE-2023-25173
+#CVE-2022-23471
+#CVE-2023-25153
+#CVE-2023-25173
 
 # MEDIUM
 # opt/telegraf/telegraf
-CVE-2019-3826
+#CVE-2019-3826
 # kube-state-metrics
-CVE-2022-41723
+#CVE-2022-41723
 # opt/microsoft/otelcollector/otelcollector
 # opt/promconfigvalidator
 # opt/telegraf/telegraf
 # kube-state-metrics
 # bin/node_exporter
-CVE-2022-41717
-CVE-2022-46146
-CVE-2022-41721
+#CVE-2022-41717
+#CVE-2022-46146
+#CVE-2022-41721

--- a/otelcollector/build/windows/Dockerfile
+++ b/otelcollector/build/windows/Dockerfile
@@ -21,7 +21,7 @@ COPY ./configmapparser/*.rb $tmpdir/microsoft/configmapparser/
 COPY ./configmapparser/default-prom-configs/*.yml $tmpdir/microsoft/otelcollector/default-prom-configs/
 COPY ./opentelemetry-collector-builder/otelcollector.exe ./opentelemetry-collector-builder/collector-config-default.yml ./opentelemetry-collector-builder/collector-config-template.yml $tmpdir/microsoft/otelcollector/
 COPY ./prom-config-validator-builder/promconfigvalidator.exe $tmpdir/
-COPY ./metricextension/me.config ./metricextension/me_internal.config ./metricextension/me_ds.config ./metricextension/me_ds_internal.config $tmpdir/metricextension/
+COPY ./metricextension/me.config ./metricextension/me_internal.config ./metricextension/me_ds.config ./metricextension/me_ds_win.config ./metricextension/me_ds_internal.config ./metricextension/me_ds_internal_win.config $tmpdir/metricextension/
 COPY ./telegraf/telegraf-prometheus-collector-windows.conf $tmpdir/telegraf/
 COPY ./fluent-bit/fluent-bit-windows.conf $tmpdir/fluent-bit/
 COPY ./fluent-bit/fluent-bit-parsers.conf $tmpdir/fluent-bit/

--- a/otelcollector/build/windows/scripts/main.ps1
+++ b/otelcollector/build/windows/scripts/main.ps1
@@ -1,5 +1,5 @@
 #setting it to replicaset by default
-$me_config_file = '/opt/metricextension/me_ds.config'
+$me_config_file = '/opt/metricextension/me_ds_win.config'
 
 function Set-EnvironmentVariablesAndConfigParser {
     # Set unfair semaphore wait for better initial CPU performance
@@ -275,10 +275,10 @@ function Set-EnvironmentVariablesAndConfigParser {
     }
     else {
         if ($cluster_override -eq "true") {
-            $meConfigFile = "/opt/metricextension/me_ds_internal.config"
+            $meConfigFile = "/opt/metricextension/me_ds_internal_win.config"
         }
         else {
-            $meConfigFile = "/opt/metricextension/me_ds.config"
+            $meConfigFile = "/opt/metricextension/me_ds_win.config"
         }
     }
     [System.Environment]::SetEnvironmentVariable("ME_CONFIG_FILE", $meConfigFile, "Process")
@@ -406,7 +406,7 @@ function Start-ME {
             }
             else {
                 Start-Process -NoNewWindow -FilePath "/opt/metricextension/MetricsExtension/MetricsExtension.Native.exe" -ArgumentList @("-Logger", "File", "-LogLevel", "Debug", "-LocalControlChannel", "-TokenSource", "AMCS", "-DataDirectory", "C:\opt\genevamonitoringagent\datadirectory\mcs\metricsextension\", "-Input", "otlp_grpc_prom", "-ConfigOverridesFilePath", $me_config_file) > $null
-                # /opt/metricextension/MetricsExtension/MetricsExtension.Native.exe -Logger Console -LogLevel Info -LocalControlChannel -TokenSource AMCS -DataDirectory C:\opt\genevamonitoringagent\datadirectory\mcs\metricsextension\ -Input otlp_grpc_prom -ConfigOverridesFilePath '/opt/metricextension/me_ds.config'
+                # /opt/metricextension/MetricsExtension/MetricsExtension.Native.exe -Logger Console -LogLevel Info -LocalControlChannel -TokenSource AMCS -DataDirectory C:\opt\genevamonitoringagent\datadirectory\mcs\metricsextension\ -Input otlp_grpc_prom -ConfigOverridesFilePath '/opt/metricextension/me_ds_win.config'
             }
         }
         else {

--- a/otelcollector/build/windows/scripts/setup.ps1
+++ b/otelcollector/build/windows/scripts/setup.ps1
@@ -59,7 +59,7 @@ Write-Host ('Finished Installing Visual C++ Redistributable Package')
 Write-Host ('Installing Telegraf');
 try {
     # Keep version in sync with linux in setup.sh file
-    $telegrafUri = 'https://dl.influxdata.com/telegraf/releases/telegraf-1.24.2_windows_amd64.zip'
+    $telegrafUri = 'https://dl.influxdata.com/telegraf/releases/telegraf-1.27.3_windows_amd64.zip'
     Invoke-WebRequest -Uri $telegrafUri -OutFile /installation/telegraf.zip
     Expand-Archive -Path /installation/telegraf.zip -Destination /installation/telegraf
     Move-Item -Path /installation/telegraf/*/* -Destination /opt/telegraf/ -ErrorAction SilentlyContinue

--- a/otelcollector/build/windows/scripts/setup.ps1
+++ b/otelcollector/build/windows/scripts/setup.ps1
@@ -59,7 +59,7 @@ Write-Host ('Finished Installing Visual C++ Redistributable Package')
 Write-Host ('Installing Telegraf');
 try {
     # Keep version in sync with linux in setup.sh file
-    $telegrafUri = 'https://dl.influxdata.com/telegraf/releases/telegraf-1.27.3_windows_amd64.zip'
+    $telegrafUri = 'https://dl.influxdata.com/telegraf/releases/telegraf-1.24.2_windows_amd64.zip'
     Invoke-WebRequest -Uri $telegrafUri -OutFile /installation/telegraf.zip
     Expand-Archive -Path /installation/telegraf.zip -Destination /installation/telegraf
     Move-Item -Path /installation/telegraf/*/* -Destination /opt/telegraf/ -ErrorAction SilentlyContinue

--- a/otelcollector/configmapparser/prometheus-config-merger.rb
+++ b/otelcollector/configmapparser/prometheus-config-merger.rb
@@ -365,15 +365,6 @@ def populateDefaultPrometheusConfig
         contents = contents.gsub("$$NODE_NAME$$", ENV["NODE_NAME"])
         File.open(@windowsexporterDefaultDsFile, "w") { |file| file.puts contents }
         defaultConfigs.push(@windowsexporterDefaultDsFile)
-
-        # If advanced mode is enabled, but not the windows daemonset, scrape windows kubelet from the replicaset as if it's simple mode
-      elsif currentControllerType == @replicasetControllerType && advancedMode == true && windowsDaemonset == false && ENV["OS_TYPE"].downcase == "linux"
-        UpdateScrapeIntervalConfig(@windowsexporterDefaultRsSimpleFile, windowsexporterScrapeInterval)
-        if !winexporterMetricsKeepListRegex.nil? && !winexporterMetricsKeepListRegex.empty?
-          AppendMetricRelabelConfig(@windowsexporterDefaultRsSimpleFile, winexporterMetricsKeepListRegex)
-        end
-        defaultConfigs.push(@windowsexporterDefaultRsSimpleFile)
-      end
     end
 
     if !ENV["AZMON_PROMETHEUS_WINDOWSKUBEPROXY_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_WINDOWSKUBEPROXY_SCRAPING_ENABLED"].downcase == "true"
@@ -399,15 +390,6 @@ def populateDefaultPrometheusConfig
         contents = contents.gsub("$$NODE_NAME$$", ENV["NODE_NAME"])
         File.open(@windowskubeproxyDefaultDsFile, "w") { |file| file.puts contents }
         defaultConfigs.push(@windowskubeproxyDefaultDsFile)
-
-        # If advanced mode is enabled, but not the windows daemonset, scrape windows kubelet from the replicaset as if it's simple mode
-      elsif currentControllerType == @replicasetControllerType && advancedMode == true && windowsDaemonset == false && ENV["OS_TYPE"].downcase == "linux"
-        UpdateScrapeIntervalConfig(@windowskubeproxyDefaultFileRsSimpleFile, windowskubeproxyScrapeInterval)
-        if !winkubeproxyMetricsKeepListRegex.nil? && !winkubeproxyMetricsKeepListRegex.empty?
-          AppendMetricRelabelConfig(@windowskubeproxyDefaultFileRsSimpleFile, winkubeproxyMetricsKeepListRegex)
-        end
-        defaultConfigs.push(@windowskubeproxyDefaultFileRsSimpleFile)
-      end
     end
 
     if !ENV["AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED"].downcase == "true"  && currentControllerType == @replicasetControllerType

--- a/otelcollector/configmapparser/prometheus-config-merger.rb
+++ b/otelcollector/configmapparser/prometheus-config-merger.rb
@@ -365,6 +365,7 @@ def populateDefaultPrometheusConfig
         contents = contents.gsub("$$NODE_NAME$$", ENV["NODE_NAME"])
         File.open(@windowsexporterDefaultDsFile, "w") { |file| file.puts contents }
         defaultConfigs.push(@windowsexporterDefaultDsFile)
+      end
     end
 
     if !ENV["AZMON_PROMETHEUS_WINDOWSKUBEPROXY_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_WINDOWSKUBEPROXY_SCRAPING_ENABLED"].downcase == "true"
@@ -390,6 +391,7 @@ def populateDefaultPrometheusConfig
         contents = contents.gsub("$$NODE_NAME$$", ENV["NODE_NAME"])
         File.open(@windowskubeproxyDefaultDsFile, "w") { |file| file.puts contents }
         defaultConfigs.push(@windowskubeproxyDefaultDsFile)
+      end
     end
 
     if !ENV["AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED"].nil? && ENV["AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED"].downcase == "true"  && currentControllerType == @replicasetControllerType

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
@@ -128,7 +128,7 @@ spec:
             - name: MODE
               value: "advanced" # only supported mode is 'advanced', any other value will be the default/non-advance mode
             - name: WINMODE
-              value: "" # WINDOWS: only supported mode is 'advanced', any other value will be the default/non-advance mode
+              value: "advanced" # WINDOWS: only supported mode is 'advanced', any other value will be the default/non-advance mode
             - name: MINIMAL_INGESTION_PROFILE
               value: "true" # only supported value is the string "true"
           securityContext:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
@@ -139,7 +139,7 @@ spec:
             - name: MODE
               value: "advanced" # only supported mode is 'advanced', any other value will be the default/non-advance mode
             - name: WINMODE
-              value: "" # WINDOWS: only supported mode is 'advanced', any other value will be the default/non-advance mode
+              value: "advanced" # WINDOWS: only supported mode is 'advanced', any other value will be the default/non-advance mode
             - name: MINIMAL_INGESTION_PROFILE
               value: "true" # only supported value is the string "true"
           securityContext:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -44,7 +44,7 @@ AzureMonitorMetrics:
   # ImageTag: https://msazure.visualstudio.com/CloudNativeCompute/_git/aks-rp?path=/ccp/charts/kube-control-plane/templates/_images.tpl&version=GBrashmi/prom-addon-arm64&line=530&lineEnd=530&lineStartColumn=28&lineEndColumn=53&lineStyle=plain&_a=contents
   AddonTokenAdapter:
     ImageRepository: "/aks/msi/addon-token-adapter"
-    ImageTag: "master.221118.2"
+    ImageTag: "master.230804.1"
     ImageRepositoryWin: "/aks/hcp/addon-token-adapter"
     ImageTagWin: "20230120winbeta"
   ArcExtension: ${ARC_EXTENSION}

--- a/otelcollector/metricextension/me_ds.config
+++ b/otelcollector/metricextension/me_ds.config
@@ -9,6 +9,7 @@
          "instance"
       ],
       "honorResourceAttributes":true,
+      "disableExemplars":true,
       "maxReceiveMessageSizeMBytes": 12
    },
    "publicationIntervalInSec":20,

--- a/otelcollector/metricextension/me_ds_internal.config
+++ b/otelcollector/metricextension/me_ds_internal.config
@@ -9,6 +9,7 @@
         "instance"
       ],
       "honorResourceAttributes": false,
+      "disableExemplars":true,
       "maxReceiveMessageSizeMBytes": 12
    },
    "publicationIntervalInSec":20,

--- a/otelcollector/metricextension/me_ds_internal_win.config
+++ b/otelcollector/metricextension/me_ds_internal_win.config
@@ -1,0 +1,26 @@
+{
+   "otlp":{
+      "endpoints":[
+         "127.0.0.1:55680"
+      ],
+      "resourceAttributes":[
+        "cluster",
+        "job",
+        "instance"
+      ],
+      "honorResourceAttributes": false,
+      "maxReceiveMessageSizeMBytes": 12
+   },
+   "publicationIntervalInSec":20,
+   "maxPublicationAttemptsPerMinute":12,
+   "maxPublicationPackageSizeInBytes":5000000,
+   "maxPublicationBytesPerMinute":200000000,
+   "maxPublicationMetricsPerMinute":10000000,
+   "maxAggregationQueueSize":7000000,
+   "maxNumberOfRawEventsPerCycle":5000000,
+   "compressMetricData":true,
+   "maxStringInternCacheSizeMb":5000,
+   "interningSwapPeriodInMin":10000,
+   "internalQueueSizeManagementPeriodInSec":10000,
+   "proxyDefinitionMode":1
+}

--- a/otelcollector/metricextension/me_ds_win.config
+++ b/otelcollector/metricextension/me_ds_win.config
@@ -1,0 +1,26 @@
+{
+   "otlp":{
+      "endpoints":[
+         "127.0.0.1:55680"
+      ],
+      "resourceAttributes":[
+         "cluster",
+         "job",
+         "instance"
+      ],
+      "honorResourceAttributes":true,
+      "maxReceiveMessageSizeMBytes": 12
+   },
+   "publicationIntervalInSec":20,
+   "maxPublicationAttemptsPerMinute":12,
+   "maxPublicationPackageSizeInBytes":5000000,
+   "maxPublicationBytesPerMinute":200000000,
+   "maxPublicationMetricsPerMinute":10000000,
+   "maxAggregationQueueSize":7000000,
+   "maxNumberOfRawEventsPerCycle":5000000,
+   "compressMetricData":true,
+   "maxStringInternCacheSizeMb":5000,
+   "interningSwapPeriodInMin":10000,
+   "internalQueueSizeManagementPeriodInSec":10000,
+   "proxyDefinitionMode":1
+}

--- a/otelcollector/metricextension/me_internal.config
+++ b/otelcollector/metricextension/me_internal.config
@@ -9,6 +9,7 @@
         "instance"
       ],
       "honorResourceAttributes": false,
+      "disableExemplars":true,
       "maxReceiveMessageSizeMBytes": 12
    },
    "publicationIntervalInSec":20,

--- a/otelcollector/scripts/setup.sh
+++ b/otelcollector/scripts/setup.sh
@@ -44,7 +44,7 @@ echo "Installing mdsd..."
 # fi
 
 # Install this way once moving to the Mariner published RPMs:
-sudo tdnf install -y azure-mdsd-1.23.5
+sudo tdnf install -y azure-mdsd-1.27.4
 
 cp -f $TMPDIR/envmdsd /etc/mdsd.d
 # Create the following directory for mdsd logs
@@ -52,7 +52,7 @@ mkdir /opt/microsoft/linuxmonagent
 
 # Install telegraf
 echo "Installing telegraf..."
-sudo tdnf install telegraf-1.25.2 -y
+sudo tdnf install telegraf-1.27.3 -y
 sudo tdnf list installed | grep telegraf | awk '{print $2}' > telegrafversion.txt
 
 # Install fluent-bit
@@ -64,7 +64,7 @@ cp /etc/cron.daily/logrotate /etc/cron.hourly/
 
 # Install ME
 echo "Installing Metrics Extension..."
-sudo tdnf install -y metricsext2-2.2023.224.2214
+sudo tdnf install -y metricsext2-2.2023.928.2134
 sudo tdnf list installed | grep metricsext2 | awk '{print $2}' > metricsextversion.txt
 
 # tdnf does not have an autoremove feature. Only necessary packages are copied over to distroless build. Below reduces the image size if using non-distroless


### PR DESCRIPTION
1) Upgrade dependencies (Linux)
* mdsd    = azure-mdsd-1.23.5 --> 1.27.4
* ME        = 2.2023.224.2214 --> 2.2023.928.2134
* telegraf = 1.25.2 --> 1.27.3
* golang  = 1.18 --> 1.20

2) Upgrade dependencies (Windows)
* golang = 1.18 --> 1.20

3) Upgrade addon token adapter for back door deployments (Linux only)
* master.221118.2 --> master.230804.1

4) Disable exemplars on ME 
5) Update CVE exemptions