### PR TITLE
Fix $ substitution issue in relabel and metric relabel config

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - rashmi/fix-dollar
 pr:
   autoCancel: true
   branches:

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - rashmi/fix-dollar
 pr:
   autoCancel: true
   branches:

--- a/otelcollector/prom-config-validator-builder/main.go
+++ b/otelcollector/prom-config-validator-builder/main.go
@@ -121,6 +121,9 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 							regexString := relabelConfig["regex"].(string)
 							modifiedRegexString := strings.ReplaceAll(regexString, "$$", "$")
 							modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$", "$$")
+							// Doing the below since we dont want to substitute $ with $$ for env variables NODE_NAME and NODE_IP.
+							modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$$NODE_NAME", "$NODE_NAME")
+							modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$$NODE_IP", "$NODE_IP")
 							relabelConfig["regex"] = modifiedRegexString
 						}
 					}
@@ -129,6 +132,8 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 						replacement := relabelConfig["replacement"].(string)
 						modifiedReplacementString := strings.ReplaceAll(replacement, "$$", "$")
 						modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$", "$$")
+						modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$$NODE_NAME", "$NODE_NAME")
+						modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$$NODE_IP", "$NODE_IP")
 						relabelConfig["replacement"] = modifiedReplacementString
 					}
 				}
@@ -145,6 +150,8 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 							regexString := metricRelabelConfig["regex"].(string)
 							modifiedRegexString := strings.ReplaceAll(regexString, "$$", "$")
 							modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$", "$$")
+							modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$$NODE_NAME", "$NODE_NAME")
+							modifiedRegexString = strings.ReplaceAll(modifiedRegexString, "$$NODE_IP", "$NODE_IP")
 							metricRelabelConfig["regex"] = modifiedRegexString
 						}
 					}
@@ -154,6 +161,8 @@ func generateOtelConfig(promFilePath string, outputFilePath string, otelConfigTe
 						replacement := metricRelabelConfig["replacement"].(string)
 						modifiedReplacementString := strings.ReplaceAll(replacement, "$$", "$")
 						modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$", "$$")
+						modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$$NODE_NAME", "$NODE_NAME")
+						modifiedReplacementString = strings.ReplaceAll(modifiedReplacementString, "$$NODE_IP", "$NODE_IP")
 						metricRelabelConfig["replacement"] = modifiedReplacementString
 					}
 				}


### PR DESCRIPTION
Test prom custom config I used - 
![image](https://github.com/Azure/prometheus-collector/assets/36861737/61a00a4e-f0f2-4fec-b54a-cffe7358b740)

What I see when i do a port-forward -
![image](https://github.com/Azure/prometheus-collector/assets/36861737/684672f9-00dd-4117-8f90-915dc6ec14d0)

