### PR TITLE
update for clause in agent version alert

### DIFF
--- a/internal/alerts/example-alert-template.json
+++ b/internal/alerts/example-alert-template.json
@@ -255,13 +255,13 @@
                     {
                         "alert": "New agent version found for prometheus collector",
                         "expression": "count(count (kube_pod_container_info{image=~\"mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector.*\"})  by (image)) > 2",
-                        "for": "PT30M",
+                        "for": "PT60S",
                         "annotations": {
                             "description": "New agent version found for prometheus collector. This alert is only used in near ring regions for prod monitoring clusters"
                         },
                         "severity": 4,
                         "resolveConfiguration": {
-                            "autoResolved": true,
+                            "autoResolved": false,
                             "timeToResolve": "PT10M"
                         },
                         "actions": [


### PR DESCRIPTION


Note:
The duration of 30S is not allowed in the "for" clause since rule group checks on intervals of 1M,by default and it allows >30S . 
I tried putting "interval": "PT30S" but still got same error below. Hence going with 60S.

←[K←[K←[91m{"status":"Failed","error":{"code":"DeploymentFailed","target":"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourceGroups/ci-dev-aks-mac-eus-rg/providers/Microsoft.Resources/deployments/example-alert-template","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"code":"BadRequest","target":"/subscriptions/9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb/resourceGroups/ci-dev-aks-mac-eus-rg/providers/Microsoft.Resources/deployments/example-alert-template","message":"{\r\n  \"code\": \"BadRequest\",\r\n  \"message\": \"Property name: Rules[13].For, Attempted value: 0.5, Error: '' must be greater than or equal to '1'. Activity ID: 32f613b1-c2ee-4dcf-a96d-d4e9db451125.\"\r\