### PR TITLE
fix: set threadpool unfair semaphore spin limit in dockerfile for windows

### DIFF
--- a/otelcollector/build/windows/Dockerfile
+++ b/otelcollector/build/windows/Dockerfile
@@ -6,6 +6,8 @@ LABEL maintainer="ciprometheus@microsoft.com"
 ENV OS_TYPE "windows"
 ENV MONITORING_DATA_DIRECTORY "C:\\opt\\genevamonitoringagent\\datadirectory"
 ENV MONITORING_MCS_MODE "1"
+# Set unfair semaphore wait for better initial CPU performance
+ENV COMPlus_ThreadPool_UnfairSemaphoreSpinLimit 0
 ENV tmpdir /opt/
 
 # Below is for ContainerInsightsPrometheusCollector-Prod AppInsights Resource

--- a/otelcollector/build/windows/scripts/main.ps1
+++ b/otelcollector/build/windows/scripts/main.ps1
@@ -2,8 +2,6 @@
 $me_config_file = '/opt/metricextension/me_ds_win.config'
 
 function Set-EnvironmentVariablesAndConfigParser {
-    # Set unfair semaphore wait for better initial CPU performance
-    Set-ProcessAndMachineEnvVariables "COMPlus_ThreadPool_UnfairSemaphoreSpinLimit" "0"
     # Set windows 2019 or 2022 version (Microsoft Windows Server 2019 Datacenter or Microsoft Windows Server 2022 Datacenter)
     $windowsVersion = (Get-WmiObject -class Win32_OperatingSystem).Caption
     [System.Environment]::SetEnvironmentVariable("windowsVersion", $windowsVersion, "Process")


### PR DESCRIPTION
This is a fix for the bug of setting this in the powershell script as that results in the following error:

C:\var\log>type pods\kube-system_ama-metrics-win-node-v89cj_c0520578-d97b-436f-86c0-68a7d5f05bf0\prometheus-collector\0.log
2023-10-11T11:08:06.6631612Z stdout F Transcript started, output file is main.txt
2023-10-11T11:08:13.2279364Z stderr F Set-ProcessAndMachineEnvVariables : The term
2023-10-11T11:08:13.2279364Z stderr F 'Set-ProcessAndMachineEnvVariables' is not recognized as the name of a cmdlet,
2023-10-11T11:08:13.2279364Z stderr F function, script file, or operable program. Check the spelling of the name, or...