### PR TITLE
Adding back release steps for 1p helm chart

### DIFF
--- a/.pipelines/deployment/ServiceGroupRoot/Parameters/PrometheusCollector.Chart.Parameters.json
+++ b/.pipelines/deployment/ServiceGroupRoot/Parameters/PrometheusCollector.Chart.Parameters.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://schema.express.azure.com/schemas/2015-01-01-alpha/RolloutParameters.json",
+  "contentVersion": "1.0.0.0",
+  "wait": [
+    {
+      "name": "waitSdpBakeTime",
+      "properties": {
+        "duration": "PT24H"
+      }
+    }
+  ],
+  "shellExtensions": [
+    {
+      "name": "PushAgentToACR",
+      "type": "ShellExtensionType",
+      "properties": {
+        "maxexecutiontime": "PT1H"
+      },
+      "package": {
+        "reference": {
+          "path": "artifacts.tar.gz"
+        }
+      },
+      "launch": {
+        "command": [
+          "/bin/bash",
+          "pushChartToAcr.sh"
+        ],
+        "environmentVariables": [
+          {
+            "name": "ACR_REGISTRY",
+            "value": "__ACR_REGISTRY__"
+          },
+          {
+            "name": "PROD_ACR_REPOSITORY",
+            "value": "__PROD_ACR_CHART_REPOSITORY__"
+          },
+          {
+            "name": "MCR_REGISTRY",
+            "value": "__MCR_REGISTRY__"
+          },
+          {
+            "name": "MCR_REPOSITORY",
+            "value": "__PROD_MCR_CHART_REPOSITORY__"
+          },
+          {
+            "name": "PROD_MCR_REPOSITORY",
+            "value": "__PROD_MCR_CHART_REPOSITORY__"
+          },
+          {
+            "name": "MCR_REPOSITORY_HELM_DEPENDENCIES",
+            "value": "__PROD_MCR_REPOSITORY_HELM_DEPENDENCIES__"
+          },
+          {
+            "name": "IMAGE_TAG",
+            "value": "__LINUX_TAG__"
+          },
+          {
+            "name": "IMAGE_TAG_WINDOWS",
+            "value": "__WINDOWS_TAG__"
+          },
+          {
+            "name": "HELM_SEMVER",
+            "value": "__CHART_TAG__"
+          },
+          {
+            "name": "HELM_CHART_NAME",
+            "value": "__HELM_CHART_NAME__"
+          },
+          {
+            "name": "PROD_MCR_KSM_REPOSITORY",
+            "value": "__PROD_MCR_KSM_REPOSITORY__"
+          },
+          {
+            "name": "KSM_CHART_TAG",
+            "value": "__KSM_CHART_TAG__"
+          },
+          {
+            "name": "PROD_MCR_NE_REPOSITORY",
+            "value": "__PROD_MCR_NE_REPOSITORY__"
+          },
+          {
+            "name": "NE_CHART_TAG",
+            "value": "__NE_CHART_TAG__"
+          }
+        ], 
+        "identity": {
+          "type": "userAssigned",
+          "userAssignedIdentities": [
+            "__MANAGED_IDENTITY__"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/.pipelines/deployment/ServiceGroupRoot/RolloutSpecs/RolloutSpecs.json
+++ b/.pipelines/deployment/ServiceGroupRoot/RolloutSpecs/RolloutSpecs.json
@@ -22,50 +22,83 @@
       "name": "PushLinuxAgent",
       "targetType": "ServiceResource",
       "targetName": "PushLinuxAgent",
-      "actions": [ "Shell/PushAgentToACR" ],
-      "dependsOn": [ ]
+      "actions": [
+        "Shell/PushAgentToACR"
+      ],
+      "dependsOn": []
     },
     {
       "name": "PushWindowsAgent",
       "targetType": "ServiceResource",
       "targetName": "PushWindowsAgent",
-      "actions": [ "Shell/PushAgentToACR" ],
-      "dependsOn": [ ]
+      "actions": [
+        "Shell/PushAgentToACR"
+      ],
+      "dependsOn": []
     },
     {
       "name": "PushTargetAllocator",
       "targetType": "ServiceResource",
       "targetName": "PushTargetAllocator",
-      "actions": [ "Shell/PushAgentToACR" ],
-      "dependsOn": [ ]
+      "actions": [
+        "Shell/PushAgentToACR"
+      ],
+      "dependsOn": []
     },
     {
       "name": "PushConfigReader",
       "targetType": "ServiceResource",
       "targetName": "PushConfigReader",
-      "actions": [ "Shell/PushAgentToACR" ],
-      "dependsOn": [ ]
+      "actions": [
+        "Shell/PushAgentToACR"
+      ],
+      "dependsOn": []
     },
     {
       "name": "PushKSMChart",
       "targetType": "ServiceResource",
       "targetName": "PushKSMChart",
-      "actions": [ "Shell/PushAgentToACR" ],
-      "dependsOn": [ ]
+      "actions": [
+        "Shell/PushAgentToACR"
+      ],
+      "dependsOn": []
     },
     {
       "name": "PushNEChart",
       "targetType": "ServiceResource",
       "targetName": "PushNEChart",
-      "actions": [ "Shell/PushAgentToACR" ],
-      "dependsOn": [ ]
+      "actions": [
+        "Shell/PushAgentToACR"
+      ],
+      "dependsOn": []
+    },
+    {
+      "name": "Push1PHelmChart",
+      "targetType": "ServiceResource",
+      "targetName": "Push1PHelmChart",
+      "actions": [
+        "Shell/PushAgentToACR"
+      ],
+      "dependsOn": [
+        "PushLinuxAgent",
+        "PushWindowsAgent",
+        "PushKSMChart",
+        "PushNEChart"
+      ]
     },
     {
       "name": "PushARCHelmChart",
       "targetType": "ServiceResource",
       "targetName": "PushARCHelmChart",
-      "actions": [ "Shell/PushAgentToACR" ],
-      "dependsOn": [ "PushLinuxAgent", "PushWindowsAgent", "PushKSMChart", "PushNEChart" ]
+      "actions": [
+        "Shell/PushAgentToACR"
+      ],
+      "dependsOn": [
+        "PushLinuxAgent",
+        "PushWindowsAgent",
+        "PushKSMChart",
+        "PushNEChart"
+      ]
     }
   ]
 }

--- a/.pipelines/deployment/ServiceGroupRoot/ScopeBindings/Public.ScopeBindings.json
+++ b/.pipelines/deployment/ServiceGroupRoot/ScopeBindings/Public.ScopeBindings.json
@@ -1,115 +1,119 @@
 {
   "$schema": "https://ev2schema.azure.net/schemas/2020-01-01/scopeBindings.json",
   "contentVersion": "0.0.0.1",
-  "scopeBindings": [       
-      {
-          "scopeTagName": "Global",
-          "bindings": [        
-              {
-                  "find": "__ACR_REGISTRY__",
-                  "replaceWith": "$(ACRRegistry)"
-              },            
-              {
-                  "find": "__PROD_ACR_AGENT_REPOSITORY__",
-                  "replaceWith": "$(ProdACRAgentRepository)"
-              },
-              {
-                "find": "__PROD_ACR_CHART_REPOSITORY__",
-                "replaceWith": "$(ProdACRChartRepository)"
-              },
-              {
-                "find": "__PROD_ACR_KSM_REPOSITORY__",
-                "replaceWith": "$(ProdACRKSMRepository)"
-              },
-              {
-                "find": "__PROD_ACR_NE_REPOSITORY__",
-                "replaceWith": "$(ProdACRNERepository)"
-              },
-              {
-                "find": "__MANAGED_IDENTITY__",
-                "replaceWith": "$(ManagedIdentity)"
-              },
-              {
-                "find": "__MCR_REGISTRY__",
-                "replaceWith": "$(MCRRegistry)"
-              },
-              {
-                "find": "__DEV_MCR_AGENT_REPOSITORY__",
-                "replaceWith": "$(DevMCRAgentRepository)"
-              },
-              {
-                "find": "__DEV_MCR_KSM_REPOSITORY__",
-                "replaceWith": "$(DevMCRKSMRepository)"
-              },
-              {
-                "find": "__DEV_MCR_NE_REPOSITORY__",
-                "replaceWith": "$(DevMCRNERepository)"
-              },
-              {
-                  "find": "__LINUX_TAG__",
-                  "replaceWith": "$(LinuxTag)"
-              },
-              {
-                  "find": "__WINDOWS_TAG__",
-                  "replaceWith": "$(WindowsTag)"
-              },
-              {
-                "find": "__TARGETALLOCATOR_TAG__",
-                "replaceWith": "$(TargetAllocatorTag)"
-              },
-              {
-                "find": "__CONFIGREADER_TAG__",
-                "replaceWith": "$(ConfigReaderTag)"
-              },
-              {
-                "find": "__PROD_MCR_AGENT_REPOSITORY__",
-                "replaceWith": "$(ProdMCRAgentRepository)"
-              },
-              {
-                "find": "__DEV_MCR_CHART_REPOSITORY__",
-                "replaceWith": "$(DevMCRChartRepository)"
-              },
-              {
-                "find": "__PROD_MCR_CHART_REPOSITORY__",
-                "replaceWith": "$(ProdMCRChartRepository)"
-              },
-              {
-                "find": "__PROD_MCR_KSM_REPOSITORY__",
-                "replaceWith": "$(ProdMCRKSMRepository)"
-              },
-              {
-                "find": "__PROD_MCR_NE_REPOSITORY__",
-                "replaceWith": "$(ProdMCRNERepository)"
-              },
-              {
-                "find": "__PROD_MCR_REPOSITORY_HELM_DEPENDENCIES__",
-                "replaceWith": "$(ProdMCRRepositoryHelmDependencies)"
-              },
-              {
-                "find": "__PUSH_NEW_KSM_CHART__",
-                "replaceWith": "$(PushNewKSMChart)"
-              },
-              {
-                "find": "__PUSH_NEW_NE_CHART__",
-                "replaceWith": "$(PushNewNEChart)"
-              },
-              {
-                "find": "__KSM_CHART_TAG__",
-                "replaceWith": "$(KSMChartTag)"
-              },
-              {
-                "find": "__NE_CHART_TAG__",
-                "replaceWith": "$(NEChartTag)"
-              },
-              {
-                "find": "__HELM_CHART_NAME__",
-                "replaceWith": "$(HelmChartName)"
-              },
-              {
-                "find": "__ARC_HELM_CHART_NAME__",
-                "replaceWith": "$(ARCHelmChartName)"
-              }
-          ]
-      }                                                                                                                                                
+  "scopeBindings": [
+    {
+      "scopeTagName": "Global",
+      "bindings": [
+        {
+          "find": "__ACR_REGISTRY__",
+          "replaceWith": "$(ACRRegistry)"
+        },
+        {
+          "find": "__PROD_ACR_AGENT_REPOSITORY__",
+          "replaceWith": "$(ProdACRAgentRepository)"
+        },
+        {
+          "find": "__PROD_ACR_CHART_REPOSITORY__",
+          "replaceWith": "$(ProdACRChartRepository)"
+        },
+        {
+          "find": "__PROD_ACR_KSM_REPOSITORY__",
+          "replaceWith": "$(ProdACRKSMRepository)"
+        },
+        {
+          "find": "__PROD_ACR_NE_REPOSITORY__",
+          "replaceWith": "$(ProdACRNERepository)"
+        },
+        {
+          "find": "__MANAGED_IDENTITY__",
+          "replaceWith": "$(ManagedIdentity)"
+        },
+        {
+          "find": "__MCR_REGISTRY__",
+          "replaceWith": "$(MCRRegistry)"
+        },
+        {
+          "find": "__DEV_MCR_AGENT_REPOSITORY__",
+          "replaceWith": "$(DevMCRAgentRepository)"
+        },
+        {
+          "find": "__DEV_MCR_KSM_REPOSITORY__",
+          "replaceWith": "$(DevMCRKSMRepository)"
+        },
+        {
+          "find": "__DEV_MCR_NE_REPOSITORY__",
+          "replaceWith": "$(DevMCRNERepository)"
+        },
+        {
+          "find": "__LINUX_TAG__",
+          "replaceWith": "$(LinuxTag)"
+        },
+        {
+          "find": "__WINDOWS_TAG__",
+          "replaceWith": "$(WindowsTag)"
+        },
+        {
+          "find": "__TARGETALLOCATOR_TAG__",
+          "replaceWith": "$(TargetAllocatorTag)"
+        },
+        {
+          "find": "__CONFIGREADER_TAG__",
+          "replaceWith": "$(ConfigReaderTag)"
+        },
+        {
+          "find": "__PROD_MCR_AGENT_REPOSITORY__",
+          "replaceWith": "$(ProdMCRAgentRepository)"
+        },
+        {
+          "find": "__DEV_MCR_CHART_REPOSITORY__",
+          "replaceWith": "$(DevMCRChartRepository)"
+        },
+        {
+          "find": "__PROD_MCR_CHART_REPOSITORY__",
+          "replaceWith": "$(ProdMCRChartRepository)"
+        },
+        {
+          "find": "__PROD_MCR_KSM_REPOSITORY__",
+          "replaceWith": "$(ProdMCRKSMRepository)"
+        },
+        {
+          "find": "__PROD_MCR_NE_REPOSITORY__",
+          "replaceWith": "$(ProdMCRNERepository)"
+        },
+        {
+          "find": "__PROD_MCR_REPOSITORY_HELM_DEPENDENCIES__",
+          "replaceWith": "$(ProdMCRRepositoryHelmDependencies)"
+        },
+        {
+          "find": "__CHART_TAG__",
+          "replaceWith": "$(ChartTag)"
+        },
+        {
+          "find": "__PUSH_NEW_KSM_CHART__",
+          "replaceWith": "$(PushNewKSMChart)"
+        },
+        {
+          "find": "__PUSH_NEW_NE_CHART__",
+          "replaceWith": "$(PushNewNEChart)"
+        },
+        {
+          "find": "__KSM_CHART_TAG__",
+          "replaceWith": "$(KSMChartTag)"
+        },
+        {
+          "find": "__NE_CHART_TAG__",
+          "replaceWith": "$(NEChartTag)"
+        },
+        {
+          "find": "__HELM_CHART_NAME__",
+          "replaceWith": "$(HelmChartName)"
+        },
+        {
+          "find": "__ARC_HELM_CHART_NAME__",
+          "replaceWith": "$(ARCHelmChartName)"
+        }
+      ]
+    }
   ]
 }

--- a/.pipelines/deployment/ServiceGroupRoot/ServiceModels/Public.ServiceModel.json
+++ b/.pipelines/deployment/ServiceGroupRoot/ServiceModels/Public.ServiceModel.json
@@ -61,6 +61,11 @@
           "RolloutParametersPath": "Parameters\\PrometheusCollector.ConfigReader.Parameters.json"
         },
         {
+          "Name": "Push1PHelmChart",
+          "InstanceOf": "ShellExtension",
+          "RolloutParametersPath": "Parameters\\PrometheusCollector.Chart.Parameters.json"
+        },
+        {
           "Name": "PushARCHelmChart",
           "InstanceOf": "ShellExtension",
           "RolloutParametersPath": "Parameters\\PrometheusCollector.ARCChart.Parameters.json"


### PR DESCRIPTION
Adding back 1p helm chart release since this is required to deploy on prod clusters