### PR TITLE
[Arc] Upgrade node-exporter chart from 4.21.0 to 4.26.0

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - grace/node-expoter-upgrade
 
 pr:
   autoCancel: true

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -120,6 +120,7 @@ Azure:
 ClusterDistribution: ""
 prometheus-node-exporter:
   service:
+    enabled: true
     port: 9110
     targetPort: 9110
   image:

--- a/otelcollector/deploy/dependentcharts/prometheus-node-exporter/Chart.yaml
+++ b/otelcollector/deploy/dependentcharts/prometheus-node-exporter/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.21.0
-appVersion: 1.6.0
+version: 4.26.0
+appVersion: 1.7.0
 home: https://github.com/prometheus/node_exporter/
 sources:
   - https://github.com/prometheus/node_exporter/

--- a/otelcollector/deploy/dependentcharts/prometheus-node-exporter/README.md
+++ b/otelcollector/deploy/dependentcharts/prometheus-node-exporter/README.md
@@ -1,18 +1,18 @@
-# Prometheus `Node Exporter`
+# Prometheus Node Exporter
 
 Prometheus exporter for hardware and OS metrics exposed by *NIX kernels, written in Go with pluggable metric collectors.
 
-This chart bootstraps a prometheus [`Node Exporter`](http://github.com/prometheus/node_exporter) daemonset on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a Prometheus [Node Exporter](http://github.com/prometheus/node_exporter) daemonset on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Get Repository Info
-
+<!-- textlint-disable terminology -->
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+<!-- textlint-enable -->
 ## Install Chart
 
 ```console
@@ -36,14 +36,10 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 ## Upgrading Chart
 
 ```console
-helm upgrade [RELEASE_NAME] [CHART] --install
+helm upgrade [RELEASE_NAME] prometheus-community/prometheus-node-exporter --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
-
-### 4.16 to 4.17+
-
-`containerSecurityContext.readOnlyRootFilesystem` is set to `true` by default.
 
 ### 3.x to 4.x
 

--- a/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/_helpers.tpl
+++ b/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/_helpers.tpl
@@ -55,8 +55,8 @@ release: {{ .Release.Name }}
 Selector labels
 */}}
 {{- define "prometheus-node-exporter.selectorLabels" -}}
-app: {{ template "prometheus-node-exporter.name" . }}
-release: {{.Release.Name }}
+app.kubernetes.io/name: {{ include "prometheus-node-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 

--- a/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/clusterrole.yaml
+++ b/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "prometheus-node-exporter.fullname" . }}
-  namespace: {{ include "prometheus-node-exporter.namespace" . }}
   labels:
     {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
 rules:

--- a/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/daemonset.yaml
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "prometheus-node-exporter.selectorLabels" . | nindent 6 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -40,7 +41,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "prometheus-node-exporter.serviceAccountName" . }}
       containers:
-        {{- $servicePort := ternary 8100 .Values.service.port .Values.kubeRBACProxy.enabled }}
+        {{- $servicePort := ternary .Values.kubeRBACProxy.port .Values.service.port .Values.kubeRBACProxy.enabled }}
         - name: node-exporter
           image: {{ include "prometheus-node-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -49,7 +50,7 @@ spec:
             - --path.sysfs=/host/sys
             {{- if .Values.hostRootFsMount.enabled }}
             - --path.rootfs=/host/root
-            {{- if semverCompare ">=1.4.0" (default .Chart.AppVersion .Values.image.tag) }}
+            {{- if semverCompare ">=1.4.0" (coalesce .Values.version .Values.image.tag .Chart.AppVersion) }}
             - --path.udev.data=/host/root/run/udev/data
             {{- end }}
             {{- end }}
@@ -199,7 +200,10 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.service.port}}
-              name: "http"
+              name: {{ .Values.kubeRBACProxy.portName }}
+              {{- if .Values.kubeRBACProxy.enableHostPort }}
+              hostPort: {{ .Values.service.port }}
+              {{- end }}
             - containerPort: 8888
               name: "http-healthz"
           readinessProbe:

--- a/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/extra-manifests.yaml
+++ b/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{ range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ tpl . $ }}
 {{ end }}

--- a/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/service.yaml
+++ b/otelcollector/deploy/dependentcharts/prometheus-node-exporter/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,3 +26,4 @@ spec:
       name: {{ .Values.service.portName }}
   selector:
     {{- include "prometheus-node-exporter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/otelcollector/deploy/dependentcharts/prometheus-node-exporter/values.yaml
+++ b/otelcollector/deploy/dependentcharts/prometheus-node-exporter/values.yaml
@@ -14,6 +14,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Number of old history to retain to allow rollback
+# Default Kubernetes value is set to 10
+revisionHistoryLimit: 10
+
 global:
   # To help compatibility with other charts which use global.imagePullSecrets.
   # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).
@@ -38,7 +42,7 @@ kubeRBACProxy:
   image:
     registry: quay.io
     repository: brancz/kube-rbac-proxy
-    tag: v0.14.0
+    tag: v0.15.0
     sha: ""
     pullPolicy: IfNotPresent
 
@@ -51,6 +55,13 @@ kubeRBACProxy:
   ## Allows overrides and additional options compared to (Pod) securityContext
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}
+
+  # Specify the port used for the Node exporter container (upstream port)
+  port: 8100
+  # Specify the name of the container port
+  portName: http
+  # Configure a hostPort. If true, hostPort will be enabled in the container and set to service.port.
+  enableHostPort: false
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -65,6 +76,7 @@ kubeRBACProxy:
   #  memory: 32Mi
 
 service:
+  enabled: true
   type: ClusterIP
   port: 9100
   targetPort: 9100
@@ -466,9 +478,13 @@ verticalPodAutoscaler:
 
 # Extra manifests to deploy as an array
 extraManifests: []
-  # - apiVersion: v1
+  # - |
+  #   apiVersion: v1
   #   kind: ConfigMap
   #   metadata:
   #     name: prometheus-extra
   #   data:
   #     extra-data: "value"
+
+# Override version of app, required if image.tag is defined and does not follow semver
+version: ""


### PR DESCRIPTION
- The newest node-exporter chart has a service.enabled field added in values.yaml. We can utilize this to allow customers to change this to false. This option was added for those who don't use serviceMonitor service discovery to scrape node exporter: https://github.com/prometheus-community/helm-charts/pull/3749
- This also updates the image from 1.6.0 to 1.7.0 which is available from upstream team:https://mcr.microsoft.com/v2/oss/prometheus/node-exporter/tags/list