### PR TITLE
Add telemetry for collector and addon token adaptor

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - addTelemetryCollectorTokenAdaptor
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - addTelemetryCollectorTokenAdaptor
 
 pr:
   autoCancel: true
@@ -54,7 +55,7 @@ jobs:
         #Truncating this to 124 to add the cfg suffix
         LINUX_IMAGE_TAG_PREFIX=$(echo "${LINUX_IMAGE_TAG}" | cut -c1-124)
         LINUX_CONFIG_READER_IMAGE_TAG=$LINUX_IMAGE_TAG_PREFIX-cfg
-        
+
         #Truncating this to 113 to add the ref app suffices
         LINUX_REF_APP_IMAGE_TAG_PREFIX=$(echo "${LINUX_IMAGE_TAG}" | cut -c1-113)
         LINUX_REF_APP_GOLANG_IMAGE_TAG=$LINUX_REF_APP_IMAGE_TAG_PREFIX-ref-app-golang
@@ -241,7 +242,7 @@ jobs:
         docker push $(WINDOWS_REF_APP_PYTHON_FULL_IMAGE_NAME)
       displayName: "Build: build and push reference app python windows image to dev ACR"
       workingDirectory: $(Build.SourcesDirectory)/internal/referenceapp/python
-      
+
 - job: SDL_Policheck_Scan
   displayName: "SDL: policheck scanning"
   pool:
@@ -952,7 +953,7 @@ jobs:
       else
         echo "-e error failed to login to az with managed identity credentials"
         exit 1
-      fi    
+      fi
 
       ACCESS_TOKEN=$(az account get-access-token --resource $RESOURCE_AUDIENCE --query accessToken -o json)
       if [ $? -eq 0 ]; then
@@ -960,7 +961,7 @@ jobs:
       else
         echo "-e error get access token from resource:$RESOURCE_AUDIENCE failed."
         exit 1
-      fi   
+      fi
       ACCESS_TOKEN=$(echo $ACCESS_TOKEN | tr -d '"' | tr -d '"\r\n')
 
       ARC_API_URL="https://eastus2euap.dp.kubernetesconfiguration.azure.com"
@@ -982,7 +983,7 @@ jobs:
     inputs:
       azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
       scriptType: 'bash'
-      scriptLocation: 'inlineScript' 
+      scriptLocation: 'inlineScript'
       inlineScript: |
         for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
           do
@@ -1004,7 +1005,7 @@ jobs:
     inputs:
       azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
       scriptType: 'bash'
-      scriptLocation: 'inlineScript' 
+      scriptLocation: 'inlineScript'
       inlineScript: |
         az config set extension.use_dynamic_install=yes_without_prompt
         az k8s-extension update --name azuremonitor-metrics --resource-group ci-dev-arc-wcus --cluster-name ci-dev-arc-wcus --cluster-type connectedClusters --version $HELM_SEMVER --release-train pipeline


### PR DESCRIPTION
This change adds the telemetry for collector and addon token adaptor. 
It also updates the pod name from the podRef from Cadvisor Json output since the podname environment variable points to the pod from which the cadvisor endpoint is curl-ed.


test branch: https://github-private.visualstudio.com/azure/_build/results?buildId=74436&view=results

Screenshot showing RefPodName of ama-metrics-ksm container:
<img width="1868" alt="PodRefName" src="https://github.com/Azure/prometheus-collector/assets/31517098/1857c090-ed04-4d83-88c7-88bacb92d5be">

Screenshot showing RefPodName of addon-token-adapter container:

<img width="1849" alt="RefPodToken" src="https://github.com/Azure/prometheus-collector/assets/31517098/5343f4c2-808d-475a-a8d9-13471f1d5336">
