### PR TITLE
remove Tls setup from reference app

### DIFF
--- a/internal/referenceapp/golang/linux/Dockerfile
+++ b/internal/referenceapp/golang/linux/Dockerfile
@@ -15,8 +15,8 @@ COPY go.sum .
 RUN go mod download
 
 
-COPY client-cert.pem /etc/prometheus/certs/
-COPY client-key.pem /etc/prometheus/certs/
+# COPY client-cert.pem /etc/prometheus/certs/
+# COPY client-key.pem /etc/prometheus/certs/
 
 # Copy the code into the container
 COPY . .

--- a/internal/referenceapp/golang/main.go
+++ b/internal/referenceapp/golang/main.go
@@ -459,8 +459,8 @@ func untypedHandler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 
-	certFile := "/etc/prometheus/certs/client-cert.pem"
-	keyFile := "/etc/prometheus/certs/client-key.pem"
+	// certFile := "/etc/prometheus/certs/client-cert.pem"
+	// keyFile := "/etc/prometheus/certs/client-key.pem"
 	if os.Getenv("RUN_PERF_TEST") == "true" {
 		if os.Getenv("SCRAPE_INTERVAL") != "" {
 			scrapeIntervalSec, _ = strconv.Atoi(os.Getenv("SCRAPE_INTERVAL"))
@@ -491,10 +491,10 @@ func main() {
 	}()
 
 	// Run main server for weather app metrics
-	err := http.ListenAndServeTLS(":2112", certFile, keyFile, weatherServer)
-	if err != nil {
-		log.Printf("HTTP server failed to start: %v", err)
-	}
+	// err := http.ListenAndServeTLS(":2112", certFile, keyFile, weatherServer)
+	// if err != nil {
+	// 	log.Printf("HTTP server failed to start: %v", err)
+	// }
 
 	fmt.Printf("ending main function")
 }


### PR DESCRIPTION
This change removes Tls setup from reference app since we cannot check in secrets into our repo for security violation