### PR TITLE
fix: stop copying libssl.so.1.1 & libcrypto.so.1.1 for config-reader

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - kaveesh/toggle_everything
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - kaveesh/toggle_everything
 
 pr:
   autoCancel: true

--- a/otelcollector/build/linux/configuration-reader/Dockerfile
+++ b/otelcollector/build/linux/configuration-reader/Dockerfile
@@ -96,7 +96,8 @@ COPY --from=builder /usr/lib/libre2.so.0a /usr/lib/libstdc++.so.6 /usr/lib/libgc
 # logrotate dependencies
 COPY --from=builder /lib/libselinux.so.1 /lib/libpopt.so.0 /lib/libpcre.so.1 /lib/
 # curl dependencies
-COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssh2.so.1 /lib/libssl.so.1.1   /lib/libcrypto.so.1.1  /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
+# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
+COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssh2.so.1 /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
 COPY --from=builder /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /usr/lib/libresolv.so.2 /usr/lib/
 # sh dependencies
 COPY --from=builder /lib/libreadline.so.8 /lib/libc.so.6 /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /lib/


### PR DESCRIPTION
fix: stop copying libssl.so.1.1 & libcrypto.so.1.1 as they are alread…y available with openssl in distroless and copying them over causes FIPS HMAC verification failures

Image with change from this PR: 6.8.4-kaveesh-toggle-everything-02-14-2024-ac93f841

Deployed on cluster linked to this grafana : https://kaveeshshellremoval-a9aah5cdatdubab5.eus.grafana.azure.com/