### PR TITLE
Relabel host

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -3,7 +3,7 @@ trigger:
     include:
     - main
     - ccp_shell_removal_branch
-    - relabel-host-pasthistory
+    - ccp_shell_removal_branch_prod
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -3,6 +3,7 @@ trigger:
     include:
     - main
     - ccp_shell_removal_branch
+    - relabel-host-pasthistory
 
 pr:
   autoCancel: true
@@ -316,7 +317,7 @@ jobs:
 
         # Necessary due to necessary due to https://stackoverflow.com/questions/60080264/docker-cannot-build-multi-platform-images-with-docker-buildx
         sudo apt-get update && sudo apt-get -y install qemu binfmt-support qemu-user-static
-        docker system prune --volumes -y
+        docker system prune --all -f
         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -42,7 +42,7 @@ scrape_configs:
       regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - action: replace
+    - source_labels: [ host ]
       regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -40,11 +40,6 @@ scrape_configs:
       separator: "-"
       modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hosthash
-    - source_labels: [ host ]
-      target_label: hostalias
-      regex: (.*):*
-      replacement: $1  # Replace the entire label value with the first captured group.
-      action: replace
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -41,7 +41,7 @@ scrape_configs:
       modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hosthash
     - source_labels: [ host ]
-      target_label: host_alias
+      target_label: hostalias
       regex: (.*):*
       replacement: $1  # Replace the entire label value with the first captured group.
       action: replace

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -38,10 +38,7 @@ scrape_configs:
     - source_labels: [ host ]
       action: hashmod
       modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
-      target_label: __tmp_hosthash
-    - source_labels: [ __tmp_hosthash ]
-      replacement: $1
-      target_label: host
+      target_label: hosthash
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -35,14 +35,15 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
-    - source_labels: [ host ]
+    - source_labels: [ host, job ]
       action: hashmod
+      separator: "-"
       modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hosthash
     - source_labels: [ host ]
       target_label: host_alias
-      regex: '([^.]+).*'
-      replacement: 'alias-$1'  # Replace the entire label value with the first captured group.
+      regex: (.*):.*
+      replacement: $1  # Replace the entire label value with the first captured group.
       action: replace
   metric_relabel_configs:
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -35,12 +35,11 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
-    - source_labels: [ host, __address__ ]
-      action: hashmod
-      separator: "-"
-      modulus: 18446744073709551615 # math.MaxUint64 causing us to never mod, and only hash the label value
-      target_label: hosthash
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - source_labels: [ host ]
+      action: hashmod
+      modulus: 18446744073709551615 # math.MaxUint64 causing us to never mod, and only hash the label value
+      target_label: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -41,5 +41,9 @@ scrape_configs:
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ host ]
       action: hashmod
-      modulus: 18446744073709551615 # math.MaxUint64 causing us to never mod, and only hash the label value
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -35,14 +35,14 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
-    - source_labels: [ host, job ]
+    - source_labels: [ host, __address__ ]
       action: hashmod
       separator: "-"
       modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hosthash
     - source_labels: [ host ]
       target_label: host_alias
-      regex: (.*):.*
+      regex: (*):*
       replacement: $1  # Replace the entire label value with the first captured group.
       action: replace
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -42,7 +42,7 @@ scrape_configs:
       target_label: hosthash
     - source_labels: [ host ]
       target_label: host_alias
-      regex: (*):*
+      regex: (.*):*
       replacement: $1  # Replace the entire label value with the first captured group.
       action: replace
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,9 +36,17 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: hcp-kubernetes.*.svc.cluster.local:443
+      regex: ^*:443$
       target_label: host
       replacement: two-kittens
+    - source_labels: [ host ]
+      action: hashmod
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hosthash
+    - source_labels: [ hosthash ]
+      regex: ^*(?!:443$)
+      replacement: $1
+      target_label: host
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -44,6 +44,6 @@ scrape_configs:
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
-      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,9 +36,6 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    - source_labels: [ __name__ ]
-      action: drop
-      regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ host ]
       action: hashmod
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
@@ -47,3 +44,11 @@ scrape_configs:
       regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver
+    - source_labels: [ hostalias ]
+      action: replace
+      target_label: host
+    - source_labels: [ __name__ ]
+      action: drop
+      regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -37,10 +37,9 @@ scrape_configs:
       action: replace
     - source_labels: [ host ]
       action: hashmod
-      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
-      target_label: hosthash
-    - source_labels: [ hosthash ]
-      regex: (.*)
+      modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: __tmp_hosthash
+    - source_labels: [ __tmp_hosthash ]
       replacement: $1
       target_label: host
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -50,7 +50,7 @@ scrape_configs:
     - source_labels: [ hostalias, host ]
       separator: ";"
       regex: ^(.+);(.+)$
-      replacement: $1
+      replacement: $1;$2
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -42,14 +42,14 @@ scrape_configs:
       regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - action: replace
+    - source_labels: [ host ]
       regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver
     # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
-      regex: "^(.+);(.+)$"
-      replacement: $$1;$$2
+      regex: (.+);(.+)
+      action: replace
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -44,7 +44,7 @@ scrape_configs:
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hosthash
     - source_labels: [ hosthash ]
-      regex: ^*(?!:443$)
+      regex: ^(?!.*:443$).*
       replacement: $1
       target_label: host
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,16 +36,17 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    - source_labels: [ host, __name__ ]
+    # Generate host alias
+    - source_labels: [ host ]
       action: hashmod
-      separator: ";"
-      regex: (.+);(.+)
+      regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - source_labels: [ host ]
+    - action: replace
       regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver
+    # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
       separator: ";"
       regex: (.+);(.+)

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -54,3 +54,5 @@ scrape_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,7 +36,7 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: (.*)
+      regex: hcp-kubernetes.*.svc.cluster.local:443
       target_label: host
       replacement: two-kittens
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -39,6 +39,11 @@ scrape_configs:
       action: hashmod
       modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hosthash
+    - source_labels: [ host ]
+      target_label: host_alias
+      regex: '([^\\.]+).*'  # Capture everything before the first hyphen.
+      replacement: '$1'  # Replace the entire label value with the first captured group.
+      action: replace
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,7 +36,7 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: hcp\-kubernetes\.(.*)\.svc\.cluster\.local:443
+      regex: hcp-kubernetes.(.*).svc.cluster.local::443
       target_label: host
       replacement: kube-apiserver
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -49,11 +49,9 @@ scrape_configs:
     # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
       separator: ";"
-      regex: (.+);(.+)
+      regex: [a-zA-Z0-9]+;[a-zA-Z0-9]+
       replacement: $1
       target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - action: labeldrop
-      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -49,7 +49,7 @@ scrape_configs:
     # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
       regex: "^(.+);(.+)$"
-      replacement: $1;$2
+      replacement: $$1;$$2
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -41,8 +41,8 @@ scrape_configs:
       target_label: hosthash
     - source_labels: [ host ]
       target_label: host_alias
-      regex: '([^\\.]+).*'  # Capture everything before the first hyphen.
-      replacement: '$1'  # Replace the entire label value with the first captured group.
+      regex: '([^.]+).*'
+      replacement: 'alias-$1'  # Replace the entire label value with the first captured group.
       action: replace
   metric_relabel_configs:
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -49,7 +49,7 @@ scrape_configs:
     # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
       separator: ";"
-      regex: [a-zA-Z0-9]+;[a-zA-Z0-9]+
+      regex: ^(.+);(.+)$
       replacement: $1
       target_label: host
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,15 +36,11 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: ^*:443$
-      target_label: host
-      replacement: two-kittens
-    - source_labels: [ host ]
       action: hashmod
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hosthash
     - source_labels: [ hosthash ]
-      regex: ^(?!.*:443$).*
+      regex: (.*)
       replacement: $1
       target_label: host
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,15 +36,23 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    - source_labels: [ host ]
+    - source_labels: [ host, __name__ ]
       action: hashmod
-      regex: (.+)
+      separator: ";"
+      regex: (.+);(.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
       regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver
+    - source_labels: [ hostalias, host ]
+      separator: ";"
+      regex: (.+);(.+)
+      replacement: $1
+      target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -38,17 +38,13 @@ scrape_configs:
   metric_relabel_configs:
     - source_labels: [ host ]
       action: hashmod
+      regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
       regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver
-    - source_labels: [ hostalias ]
-      action: replace
-      target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - action: labeldrop
-      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -42,14 +42,13 @@ scrape_configs:
       regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - source_labels: [ host ]
+    - action: replace
       regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver
     # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
-      separator: ";"
-      regex: ^(.+);(.+)$
+      regex: "^(.+);(.+)$"
       replacement: $1;$2
       target_label: host
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -48,7 +48,7 @@ scrape_configs:
       replacement: kube-apiserver
     # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
-      regex: (.+);(.+)
+      regex: ^(.+);(.+)$
       action: replace
       target_label: host
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,9 +36,9 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: hcp-kubernetes.(.*).svc.cluster.local::443
+      regex: (.*)
       target_label: host
-      replacement: kube-apiserver
+      replacement: two-kittens
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -38,7 +38,7 @@ scrape_configs:
     - source_labels: [ host, __address__ ]
       action: hashmod
       separator: "-"
-      modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      modulus: 18446744073709551615 # math.MaxUint64 causing us to never mod, and only hash the label value
       target_label: hosthash
   metric_relabel_configs:
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -35,6 +35,10 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
+    - source_labels: [ host ]
+      regex: hcp\-kubernetes\.(.*)\.svc\.cluster\.local:443
+      target_label: host
+      replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -43,8 +43,8 @@ scrape_configs:
       action: replace
     - source_labels: [ host ]
       target_label: host_alias
-      regex: '([^\.]+)\..*'
-      replacement: 'alias-$1'  # Replace the entire label value with the first captured group.
+      regex: .*($$POD_NAMESPACE$$.svc.cluster.local):.*
+      replacement: $1  # Replace the entire label value with the first captured group.
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -43,9 +43,13 @@ scrape_configs:
       action: replace
     - source_labels: [ host ]
       target_label: host_alias
-      regex: .*($$POD_NAMESPACE$$.svc.cluster.local):.*
+      regex: $$POD_NAMESPACE$$.svc.cluster.local
       replacement: $1  # Replace the entire label value with the first captured group.
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - source_labels: [ host ]
+      target_label: host_alias2
+      regex: .*($$POD_NAMESPACE$$.svc.cluster.local).*
+      replacement: $1  # Replace the entire label value with the first captured group.

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -46,6 +46,6 @@ scrape_configs:
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ host ]
-      regex: (.*)
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: host
-      replacement: two-little-kittens
+      replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -45,3 +45,7 @@ scrape_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - source_labels: [ host ]
+      regex: (.*)
+      target_label: host
+      replacement: two-little-kittens

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -41,11 +41,14 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
+    - source_labels: [ host ]
+      action: hashmod
+      modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: __tmp_hosthash
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - source_labels: [ host ]
-      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+    - source_labels: [ __tmp_hosthash ]
+      replacement: $1
       target_label: host
-      replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -44,6 +44,7 @@ scrape_configs:
   metric_relabel_configs:
     - source_labels: [ host ]
       action: hashmod
+      regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
@@ -52,6 +53,7 @@ scrape_configs:
       replacement: kube-apiserver
     - source_labels: [ hostalias ]
       action: replace
+      regex: (.+)
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -43,7 +43,7 @@ scrape_configs:
       action: replace
     - source_labels: [ host ]
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
-      target_label: host
+      target_label: hostalias
       replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -42,9 +42,9 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      action: hashmod
-      modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
-      target_label: host
+      target_label: host_alias
+      regex: '([^\.]+)\..*'
+      replacement: 'alias-$1'  # Replace the entire label value with the first captured group.
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -42,16 +42,10 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      target_label: hostalias
-      regex: $$POD_NAMESPACE$$.svc.cluster.local
-      replacement: $1  # Replace the entire label value with the first captured group.
-    - action: keep
-      regex: (.*)
+      regex: hcp-kubernetes.*.svc.cluster.local:443
+      target_label: host
+      replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - source_labels: [ host ]
-      target_label: host
-      regex: .*($$POD_NAMESPACE$$.svc.cluster.local).*
-      replacement: $1  # Replace the entire label value with the first captured group.

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -41,11 +41,11 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
-    - source_labels: [ host ]
-      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
-      target_label: hostalias
-      replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - source_labels: [ host ]
+      action: hashmod
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -42,7 +42,7 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: hcp-kubernetes.*.svc.cluster.local:443
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: host
       replacement: kube-apiserver
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -42,18 +42,20 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
+    # Generate host alias
     - source_labels: [ host ]
       action: hashmod
-      regex: (.+)
+      regex: ^(.+)$
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver
-    - source_labels: [ hostalias ]
+    # Replace the host with hostalias
+    - source_labels: [ hostalias, host ]
+      regex: ^(.+);(.+)$
       action: replace
-      regex: (.+)
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -44,11 +44,8 @@ scrape_configs:
     - source_labels: [ host ]
       action: hashmod
       modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
-      target_label: __tmp_hosthash
+      target_label: host
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - source_labels: [ __tmp_hosthash ]
-      replacement: $1
-      target_label: host

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -42,10 +42,19 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    - source_labels: [ __name__ ]
-      action: drop
-      regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ host ]
       action: hashmod
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver
+    - source_labels: [ hostalias ]
+      action: replace
+      target_label: host
+    - source_labels: [ __name__ ]
+      action: drop
+      regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -45,11 +45,13 @@ scrape_configs:
       target_label: hostalias
       regex: $$POD_NAMESPACE$$.svc.cluster.local
       replacement: $1  # Replace the entire label value with the first captured group.
+    - action: keep
+      regex: (.*)
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ host ]
-      target_label: hostalias2
+      target_label: host
       regex: .*($$POD_NAMESPACE$$.svc.cluster.local).*
       replacement: $1  # Replace the entire label value with the first captured group.

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -42,7 +42,7 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      target_label: host_alias
+      target_label: hostalias
       regex: $$POD_NAMESPACE$$.svc.cluster.local
       replacement: $1  # Replace the entire label value with the first captured group.
   metric_relabel_configs:
@@ -50,6 +50,6 @@ scrape_configs:
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ host ]
-      target_label: host_alias2
+      target_label: hostalias2
       regex: .*($$POD_NAMESPACE$$.svc.cluster.local).*
       replacement: $1  # Replace the entire label value with the first captured group.

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
@@ -35,10 +35,19 @@ scrape_configs:
       action: drop
       regex: (etcd2-.*)
   metric_relabel_configs:
-    - source_labels: [ __name__ ]
-      action: drop
-      regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ host ]
       action: hashmod
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver
+    - source_labels: [ hostalias ]
+      action: replace
+      target_label: host
+    - source_labels: [ __name__ ]
+      action: drop
+      regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
@@ -39,12 +39,14 @@ scrape_configs:
       action: hashmod
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
+      regex: (.+)
     - source_labels: [ host ]
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver
     - source_labels: [ hostalias ]
       action: replace
+      regex: (.+)
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
@@ -41,7 +41,7 @@ scrape_configs:
     - action: hashmod
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - source_labels: [ host ]
+    - action: replace
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
@@ -36,10 +36,11 @@ scrape_configs:
       regex: (etcd2-.*)
   metric_relabel_configs:
     - source_labels: [ host ]
-      action: hashmod
+      action: keep
+      regex: (.+)
+    - action: hashmod
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-      regex: (.+)
     - source_labels: [ host ]
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
@@ -35,19 +35,20 @@ scrape_configs:
       action: drop
       regex: (etcd2-.*)
   metric_relabel_configs:
+    # Generate host alias
     - source_labels: [ host ]
-      action: keep
-      regex: (.+)
-    - action: hashmod
+      action: hashmod
+      regex: ^(.+)$
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - action: replace
+    - source_labels: [ host ]
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver
-    - source_labels: [ hostalias ]
+    # Replace the host with hostalias
+    - source_labels: [ hostalias, host ]
+      regex: ^(.+);(.+)$
       action: replace
-      regex: (.+)
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
@@ -38,3 +38,7 @@ scrape_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - source_labels: [ host ]
+      action: hashmod
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -49,14 +49,14 @@ scrape_configs:
       regex: ^(.+)$
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - action: replace
+    - source_labels: [ host ]
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver
     # Replace the host with hostalias
-    - source_labels: [ host, hostalias ]
+    - source_labels: [ hostalias, host ]
       regex: ^(.+);(.+)$
-      replacement: $2
+      replacement: $$1
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,7 +43,7 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: hcp-kubernetes.*.svc.cluster.local:443
+      regex: (.*)
       target_label: host
       replacement: kube-apiserver
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -49,15 +49,14 @@ scrape_configs:
       regex: ^(.+)$
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - source_labels: [ host ]
+    - action: replace
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver
     # Replace the host with hostalias
-    - source_labels: [ hostalias, host ]
-      separator: ";"
+    - source_labels: [ host, hostalias ]
       regex: ^(.+);(.+)$
-      replacement: $1
+      replacement: $2
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -56,7 +56,7 @@ scrape_configs:
     # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
       regex: ^(.+);(.+)$
-      replacement: $$1
+      action: replace
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -56,7 +56,7 @@ scrape_configs:
     # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
       separator: ";"
-      regex: (.+);(.+)
+      regex: ^(.+);(.+)$
       replacement: $1
       target_label: host
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,10 +43,19 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    - source_labels: [ __name__ ]
-      action: drop
-      regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ host ]
       action: hashmod
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver
+    - source_labels: [ hostalias ]
+      action: replace
+      target_label: host
+    - source_labels: [ __name__ ]
+      action: drop
+      regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -47,6 +47,6 @@ scrape_configs:
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ host ]
-      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      action: hashmod
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-      replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -45,6 +45,7 @@ scrape_configs:
   metric_relabel_configs:
     - source_labels: [ host ]
       action: hashmod
+      regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
@@ -52,6 +53,7 @@ scrape_configs:
       target_label: hostalias
       replacement: kube-apiserver
     - source_labels: [ hostalias ]
+      regex: (.+)
       action: replace
       target_label: host
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,13 +43,10 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      action: hashmod
-      modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
-      target_label: hosthash
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: host_alias
+      replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - source_labels: [ hosthash ]
-      action: replace
-      target_label: host

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -46,11 +46,11 @@ scrape_configs:
     # Generate host alias
     - source_labels: [ host ]
       action: hashmod
-      regex: (.+)
+      regex: ^(.+)$
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
-      regex: ^(localhost|\[::1\]):443$
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver
     # Replace the host with hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -44,7 +44,7 @@ scrape_configs:
       action: replace
     - source_labels: [ host ]
       regex: hcp-kubernetes.*.svc.cluster.local:443
-      target_label: host_alias
+      target_label: hostalias
       replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,16 +43,17 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    - source_labels: [ host, __name__ ]
+    # Generate host alias
+    - source_labels: [ host ]
       action: hashmod
-      separator: ";"
-      regex: (.+);(.+)
+      regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - source_labels: [ host ]
+    - action: replace
       regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver
+    # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
       separator: ";"
       regex: (.+);(.+)

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,10 +43,13 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
-      target_label: host
-      replacement: kube-apiserver
+      action: hashmod
+      modulus: 10000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hosthash
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - source_labels: [ hosthash ]
+      replacement: $1
+      target_label: host

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -61,3 +61,5 @@ scrape_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,7 +43,7 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: hcp\-kubernetes\.(.*)\.svc\.cluster\.local:443
+      regex: hcp-kubernetes.(.*).svc.cluster.local:443
       target_label: host
       replacement: kube-apiserver
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,7 +43,7 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: hcp-kubernetes.(.*).svc.cluster.local:443
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: host
       replacement: kube-apiserver
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -42,6 +42,10 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
+    - source_labels: [ host ]
+      regex: hcp\-kubernetes\.(.*)\.svc\.cluster\.local:443
+      target_label: host
+      replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,8 +43,8 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: (.*)
-      target_label: host
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
       replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -44,7 +44,7 @@ scrape_configs:
       action: replace
     - source_labels: [ host ]
       regex: hcp-kubernetes.*.svc.cluster.local:443
-      target_label: hostalias
+      target_label: host
       replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,7 +43,7 @@ scrape_configs:
       target_label: instance
       action: replace
     - source_labels: [ host ]
-      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      regex: hcp-kubernetes.*.svc.cluster.local:443
       target_label: host_alias
       replacement: kube-apiserver
   metric_relabel_configs:

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -46,10 +46,10 @@ scrape_configs:
     # Generate host alias
     - source_labels: [ host ]
       action: hashmod
-      regex: [a-zA-Z0-9]+
+      regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - action: replace
+    - source_labels: [ host ]
       regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -46,7 +46,7 @@ scrape_configs:
     # Generate host alias
     - source_labels: [ host ]
       action: hashmod
-      regex: (.+)
+      regex: [a-zA-Z0-9]+
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - action: replace
@@ -62,5 +62,3 @@ scrape_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - action: labeldrop
-      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -51,5 +51,5 @@ scrape_configs:
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
     - source_labels: [ hosthash ]
-      replacement: $1
+      action: replace
       target_label: host

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -43,18 +43,20 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    - source_labels: [ host ]
+    - source_labels: [ host, __name__ ]
       action: hashmod
-      regex: (.+)
+      separator: ";"
+      regex: (.+);(.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
-      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      regex: ^(localhost|\[::1\]):443$
       target_label: hostalias
       replacement: kube-apiserver
-    - source_labels: [ hostalias ]
-      regex: (.+)
-      action: replace
+    - source_labels: [ hostalias, host ]
+      separator: ";"
+      regex: (.+);(.+)
+      replacement: $1
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -42,11 +42,11 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
-    - source_labels: [ host ]
-      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
-      target_label: hostalias
-      replacement: kube-apiserver
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -42,6 +42,11 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
+    - source_labels: [ host ]
+      target_label: host
+      regex: (.*).(.*)
+      replacement: $1  # Replace the entire label value with the first captured group.
+      action: replace
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -53,5 +53,5 @@ scrape_configs:
     - source_labels: [ hostalias ]
       action: hashmod
       regex: ^$ # emtpy host alias will have a hash
-      modulus: 18446744073709551615 # math.MaxUint64 causing us to never mod, and only hash the label value
-      target_label: hostalias
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: host

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -47,7 +47,12 @@ scrape_configs:
       action: hashmod
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - action: replace
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver
+    - source_labels: [ hostalias ]
+      action: replace
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -48,13 +48,14 @@ scrape_configs:
       regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - source_labels: [ host ]
+    - action: replace
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver
-    - source_labels: [ hostalias ]
-      action: replace
-      regex: (.+)
+    - source_labels: [ hostalias, host ]
+      separator: ";"
+      regex: (.+);(.+)
+      replacement: $1
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -45,6 +45,7 @@ scrape_configs:
   metric_relabel_configs:
     - source_labels: [ host ]
       action: hashmod
+      regex: (.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
@@ -53,6 +54,7 @@ scrape_configs:
       replacement: kube-apiserver
     - source_labels: [ hostalias ]
       action: replace
+      regex: (.+)
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -54,9 +54,7 @@ scrape_configs:
       target_label: hostalias
       replacement: kube-apiserver
     - source_labels: [ hostalias, host ]
-      separator: ";"
       regex: (.+);(.+)
-      replacement: $1
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -46,12 +46,12 @@ scrape_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - source_labels: [ host, __address__ ]
-      action: hashmod
-      separator: "-"
-      modulus: 18446744073709551615 # math.MaxUint64 causing us to never mod, and only hash the label value
-      target_label: hosthash
     - source_labels: [ host ]
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
-      target_label: host
+      target_label: hostalias
       replacement: kube-apiserver
+    - source_labels: [ hostalias ]
+      action: hashmod
+      regex: ^$ # emtpy host alias will have a hash
+      modulus: 18446744073709551615 # math.MaxUint64 causing us to never mod, and only hash the label value
+      target_label: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -43,15 +43,14 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
+    - source_labels: [ host ]
+      action: hashmod
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hostalias
+    - action: replace
+      target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - source_labels: [ host ]
-      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
-      target_label: hostalias
-      replacement: kube-apiserver
-    - source_labels: [ hostalias ]
-      action: hashmod
-      regex: ^$ # emtpy host alias will have a hash
-      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
-      target_label: host
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -46,7 +46,12 @@ scrape_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - source_labels: [ host, __address__ ]
+      action: hashmod
+      separator: "-"
+      modulus: 18446744073709551615 # math.MaxUint64 causing us to never mod, and only hash the label value
+      target_label: hosthash
     - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: host
-      regex: (.*).(.*)
-      replacement: $1  # Replace the entire label value with the first captured group.
+      replacement: kube-apiserver

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -43,19 +43,23 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    - source_labels: [ host, __name__ ]
+    # Generate host alias
+    - source_labels: [ host ]
       action: hashmod
-      regex: (.+);(.+)
+      regex: ^(.+)$
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - source_labels: [ host ]
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver
+    # Replace the host with hostalias
     - source_labels: [ hostalias, host ]
+      regex: ^(.+);(.+)$
       action: replace
-      regex: (.*);(.+)
       target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -45,16 +45,16 @@ scrape_configs:
   metric_relabel_configs:
     - source_labels: [ host, __name__ ]
       action: hashmod
-      separator: ";"
       regex: (.+);(.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
-    - action: replace
+    - source_labels: [ host ]
       regex: ^hcp-kubernetes.*.svc.cluster.local:443$
       target_label: hostalias
       replacement: kube-apiserver
     - source_labels: [ hostalias, host ]
-      regex: (.+);(.+)
+      action: replace
+      regex: (.*);(.+)
       target_label: host
     - source_labels: [ __name__ ]
       action: drop

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -42,12 +42,11 @@ scrape_configs:
       regex: (.*)
       target_label: instance
       action: replace
-    - source_labels: [ host ]
-      target_label: host
-      regex: (.*).(.*)
-      replacement: $1  # Replace the entire label value with the first captured group.
-      action: replace
   metric_relabel_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - source_labels: [ host ]
+      target_label: host
+      regex: (.*).(.*)
+      replacement: $1  # Replace the entire label value with the first captured group.

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -43,9 +43,10 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    - source_labels: [ host ]
+    - source_labels: [ host, __name__ ]
       action: hashmod
-      regex: (.+)
+      separator: ";"
+      regex: (.+);(.+)
       modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
       target_label: hostalias
     - action: replace
@@ -60,5 +61,3 @@ scrape_configs:
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - action: labeldrop
-      regex: hostalias

--- a/otelcollector/prometheuscollector/file_utilities.go
+++ b/otelcollector/prometheuscollector/file_utilities.go
@@ -1,16 +1,15 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "os/exec"
-    "io/ioutil"
-    "strings"
-    "log"
-    "io"
-    "bufio"
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
 )
-
 
 func printMdsdVersion() {
 	cmd := exec.Command("mdsd", "--version")
@@ -32,41 +31,41 @@ func readVersionFile(filePath string) (string, error) {
 }
 
 func fmtVar(name, value string) {
-	fmt.Printf("%s=\"%s\"\n", name, value)
+	fmt.Printf("%s=\"%s\"", name, strings.TrimRight(value, "\n\r"))
 }
 
 func existsAndNotEmpty(filename string) bool {
-    info, err := os.Stat(filename)
-    if os.IsNotExist(err) {
-        return false
-    }
-    if err != nil {
-        // Handle the error, e.g., log it or return false
-        return false
-    }
-    if info.Size() == 0 {
-        return false
-    }
-    return true
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	if err != nil {
+		// Handle the error, e.g., log it or return false
+		return false
+	}
+	if info.Size() == 0 {
+		return false
+	}
+	return true
 }
 
 func readAndTrim(filename string) (string, error) {
-    content, err := ioutil.ReadFile(filename)
-    if err != nil {
-        return "", err
-    }
-    trimmedContent := strings.TrimSpace(string(content))
-    return trimmedContent, nil
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+	trimmedContent := strings.TrimSpace(string(content))
+	return trimmedContent, nil
 }
 
 func exists(path string) bool {
-    _, err := os.Stat(path)
-    if err != nil {
-        if os.IsNotExist(err) {
-            return false
-        }
-    }
-    return true
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
 }
 
 func copyFile(sourcePath, destinationPath string) error {

--- a/otelcollector/prometheuscollector/file_utilities.go
+++ b/otelcollector/prometheuscollector/file_utilities.go
@@ -31,7 +31,7 @@ func readVersionFile(filePath string) (string, error) {
 }
 
 func fmtVar(name, value string) {
-	fmt.Printf("%s=\"%s\"", name, strings.TrimRight(value, "\n\r"))
+	fmt.Printf("%s=\"%s\"\n", name, strings.TrimRight(value, "\n\r"))
 }
 
 func existsAndNotEmpty(filename string) bool {

--- a/otelcollector/scripts/main.sh
+++ b/otelcollector/scripts/main.sh
@@ -220,7 +220,7 @@ else
       mdsd -a -A -e ${MDSD_LOG}/mdsd.err -w ${MDSD_LOG}/mdsd.warn -o ${MDSD_LOG}/mdsd.info -q ${MDSD_LOG}/mdsd.qos 2>> /dev/null &
 
       # Running mdsd --version can't be captured into a variable unlike telegraf and otelcollector, have to run after printing the string
-      echo -n -e "${Cyan}MDSD_VERSION${Color_Off}="; mdsd --version | xargs
+      echo -n -e "${Cyan}MDSD_VERSION${Color_Off}="; mdsd --version
 
       echo "Waiting for 30s for MDSD to get the config and put them in place for ME"
       # sleep for 30 seconds
@@ -233,15 +233,15 @@ else
 fi
 
 # Get ME version
-ME_VERSION=`cat /opt/metricsextversion.txt | awk 'BEGIN{RS=""; OFS=" "} {$1=$1; print}'`
+ME_VERSION=`cat /opt/metricsextversion.txt`
 echo_var "ME_VERSION" "$ME_VERSION"
 
 # Get ruby version
-RUBY_VERSION=$(ruby --version | tr -d '\n\r')
-echo "RUBY_VERSION" "$RUBY_VERSION"
+RUBY_VERSION=`ruby --version`
+echo_var "RUBY_VERSION" "$RUBY_VERSION"
 
 # Get golang version
-GOLANG_VERSION=$(cat /opt/goversion.txt | tr -d '\n')
+GOLANG_VERSION=`cat /opt/goversion.txt`
 echo_var "GOLANG_VERSION" "$GOLANG_VERSION"
 
 # Start otelcollector
@@ -256,9 +256,9 @@ else
       echo "Starting otelcollector"
       /opt/microsoft/otelcollector/otelcollector --config /opt/microsoft/otelcollector/collector-config.yml &> /opt/microsoft/otelcollector/collector-log.txt &
 fi
-OTELCOLLECTOR_VERSION=`/opt/microsoft/otelcollector/otelcollector --version | tr -d '\n'`
+OTELCOLLECTOR_VERSION=`/opt/microsoft/otelcollector/otelcollector --version`
 echo_var "OTELCOLLECTOR_VERSION" "$OTELCOLLECTOR_VERSION"
-PROMETHEUS_VERSION=`cat /opt/microsoft/otelcollector/PROMETHEUS_VERSION | tr -d '\n'`
+PROMETHEUS_VERSION=`cat /opt/microsoft/otelcollector/PROMETHEUS_VERSION`
 echo_var "PROMETHEUS_VERSION" "$PROMETHEUS_VERSION"
 
 echo "starting telegraf"

--- a/otelcollector/scripts/main.sh
+++ b/otelcollector/scripts/main.sh
@@ -233,7 +233,7 @@ else
 fi
 
 # Get ME version
-ME_VERSION=`cat /opt/metricsextversion.txt | xargs`
+ME_VERSION=`cat /opt/metricsextversion.txt | awk 'BEGIN{RS=""; OFS=" "} {$1=$1; print}'`
 echo_var "ME_VERSION" "$ME_VERSION"
 
 # Get ruby version

--- a/otelcollector/scripts/main.sh
+++ b/otelcollector/scripts/main.sh
@@ -220,7 +220,7 @@ else
       mdsd -a -A -e ${MDSD_LOG}/mdsd.err -w ${MDSD_LOG}/mdsd.warn -o ${MDSD_LOG}/mdsd.info -q ${MDSD_LOG}/mdsd.qos 2>> /dev/null &
 
       # Running mdsd --version can't be captured into a variable unlike telegraf and otelcollector, have to run after printing the string
-      echo -n -e "${Cyan}MDSD_VERSION${Color_Off}="; mdsd --version | tr -d '\n'
+      echo -n -e "${Cyan}MDSD_VERSION${Color_Off}="; mdsd --version | xargs
 
       echo "Waiting for 30s for MDSD to get the config and put them in place for ME"
       # sleep for 30 seconds
@@ -233,7 +233,7 @@ else
 fi
 
 # Get ME version
-ME_VERSION=`cat /opt/metricsextversion.txt | tr -d '\n'`
+ME_VERSION=`cat /opt/metricsextversion.txt | xargs`
 echo_var "ME_VERSION" "$ME_VERSION"
 
 # Get ruby version

--- a/otelcollector/scripts/main.sh
+++ b/otelcollector/scripts/main.sh
@@ -220,7 +220,7 @@ else
       mdsd -a -A -e ${MDSD_LOG}/mdsd.err -w ${MDSD_LOG}/mdsd.warn -o ${MDSD_LOG}/mdsd.info -q ${MDSD_LOG}/mdsd.qos 2>> /dev/null &
 
       # Running mdsd --version can't be captured into a variable unlike telegraf and otelcollector, have to run after printing the string
-      echo -n -e "${Cyan}MDSD_VERSION${Color_Off}="; mdsd --version
+      echo -n -e "${Cyan}MDSD_VERSION${Color_Off}="; mdsd --version | tr -d '\n'
 
       echo "Waiting for 30s for MDSD to get the config and put them in place for ME"
       # sleep for 30 seconds
@@ -233,15 +233,15 @@ else
 fi
 
 # Get ME version
-ME_VERSION=`cat /opt/metricsextversion.txt`
+ME_VERSION=`cat /opt/metricsextversion.txt | tr -d '\n'`
 echo_var "ME_VERSION" "$ME_VERSION"
 
 # Get ruby version
-RUBY_VERSION=`ruby --version`
+RUBY_VERSION=`ruby --version | tr -d '\n'`
 echo_var "RUBY_VERSION" "$RUBY_VERSION"
 
 # Get golang version
-GOLANG_VERSION=`cat /opt/goversion.txt`
+GOLANG_VERSION=`cat /opt/goversion.txt | tr -d '\n'`
 echo_var "GOLANG_VERSION" "$GOLANG_VERSION"
 
 # Start otelcollector
@@ -256,9 +256,9 @@ else
       echo "Starting otelcollector"
       /opt/microsoft/otelcollector/otelcollector --config /opt/microsoft/otelcollector/collector-config.yml &> /opt/microsoft/otelcollector/collector-log.txt &
 fi
-OTELCOLLECTOR_VERSION=`/opt/microsoft/otelcollector/otelcollector --version`
+OTELCOLLECTOR_VERSION=`/opt/microsoft/otelcollector/otelcollector --version | tr -d '\n'`
 echo_var "OTELCOLLECTOR_VERSION" "$OTELCOLLECTOR_VERSION"
-PROMETHEUS_VERSION=`cat /opt/microsoft/otelcollector/PROMETHEUS_VERSION`
+PROMETHEUS_VERSION=`cat /opt/microsoft/otelcollector/PROMETHEUS_VERSION | tr -d '\n'`
 echo_var "PROMETHEUS_VERSION" "$PROMETHEUS_VERSION"
 
 echo "starting telegraf"

--- a/otelcollector/scripts/main.sh
+++ b/otelcollector/scripts/main.sh
@@ -237,11 +237,11 @@ ME_VERSION=`cat /opt/metricsextversion.txt | awk 'BEGIN{RS=""; OFS=" "} {$1=$1; 
 echo_var "ME_VERSION" "$ME_VERSION"
 
 # Get ruby version
-RUBY_VERSION=`ruby --version | tr -d '\n'`
-echo_var "RUBY_VERSION" "$RUBY_VERSION"
+RUBY_VERSION=$(ruby --version | tr -d '\n\r')
+echo "RUBY_VERSION" "$RUBY_VERSION"
 
 # Get golang version
-GOLANG_VERSION=`cat /opt/goversion.txt | tr -d '\n'`
+GOLANG_VERSION=$(cat /opt/goversion.txt | tr -d '\n')
 echo_var "GOLANG_VERSION" "$GOLANG_VERSION"
 
 # Start otelcollector


### PR DESCRIPTION
Mask host value with hash or alias 

Metrics without a host won't be affected
![image](https://github.com/Azure/prometheus-collector/assets/79080068/9695eac9-9467-4319-a13e-c1c37fe0e33c)

Metrics with a host display a hash or alias value
![image](https://github.com/Azure/prometheus-collector/assets/79080068/16215ebd-2155-454c-8b8d-02914ca98cca)
