### PR TITLE
Update recommendedMetricAlerts.json

### DIFF
--- a/GeneratedMonitoringArtifacts/Default/recommendedMetricAlerts.json
+++ b/GeneratedMonitoringArtifacts/Default/recommendedMetricAlerts.json
@@ -814,7 +814,7 @@
                     },
                     {
                         "alert": "Average PV usage is greater than 80%",
-                        "expression": "avg by (namespace, controller, container, cluster)(((kubelet_volume_stats_used_bytes{job=\"kubelet\"} / on(namespace,cluster,pod,container) group_left kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(namespace, pod, cluster) group_left(controller) label_replace(kube_pod_owner, \"controller\", \"$1\", \"owner_name\", \"(.*)\")) > .8",
+                        "expression": "avg by (namespace, controller, container, cluster)(((kubelet_volume_stats_used_bytes{job=\"kubelet\"} / on(namespace,cluster,pod,container) group_left kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(namespace, pod, cluster) group_left(controller) label_replace(kube_pod_owner, \"controller\", \"$1\", \"owner_name\", \"(.*)\"))) > .8",
                         "for": "PT15M",
                         "annotations": {
                             "description": "Average PV usage on pod {{ $labels.pod }} in container {{ $labels.container }}  is greater than 80%"


### PR DESCRIPTION
Parentheses were missing in one alert, causing deployment to fail with a missing parentheses error.

Tested using azurerm_resource_group_template_deployment terraform resource and http data block pointing at this repo (fails with missing parentheses error) and then my fork (succeeds, all rules created).

I understand this is likely a generated file so it may just point to a bug somewhere else but wanted to raise attention in order to get it fixed.