### PR TITLE
Fix: configreader CPU request chart variable name

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -54,7 +54,7 @@ AzureMonitorMetrics:
   DeploymentReplicas: 1
   CfgReaderCPULimit: 1
   CfgReaderMemoryLimit: 1Gi
-  CfgReaderCpuRequest: 1m
+  CfgReaderCPURequest: 1m
   CfgReaderMemoryRequest: 10Mi
   TargetAllocatorCPULimit: 5
   TargetAllocatorMemoryLimit: 8Gi


### PR DESCRIPTION
Change this to match what is in the chart yaml. This affected backdoor deployments with the operator enabled (and Arc with operator enabled, which we haven't opened up yet)