### PR TITLE
Upgrade: fluent-bit from 2.0.9 to 2.1.10

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - grace/fb-upgrade
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -1215,7 +1215,7 @@ jobs:
             echo $(MCR_REGISTRY)$(MCR_REPOSITORY):$(IMAGE_TAG_WINDOWS)
 
             output=$(curl -s https://$(MCR_REGISTRY)/v2$(MCR_REPOSITORY)/tags/list)
-            if (echo $output | grep $(IMAGE_TAG_WINDOWS)) && (echo $output | grep $(IMAGE_TAG) && (echo $output | grep $(IMAGE_TAG_TARGET_ALLOCATOR) && (echo $output | grep $(IMAGE_TAG_CONFIG_READER))
+            if (echo $output | grep $(IMAGE_TAG_WINDOWS)) && (echo $output | grep $(IMAGE_TAG)) && (echo $output | grep $(IMAGE_TAG_TARGET_ALLOCATOR)) && (echo $output | grep $(IMAGE_TAG_CONFIG_READER))
             then
               echo "Images are published to mcr"
               exit 0

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - grace/fb-upgrade
 
 pr:
   autoCancel: true

--- a/otelcollector/build/linux/Dockerfile
+++ b/otelcollector/build/linux/Dockerfile
@@ -82,101 +82,101 @@ RUN chmod 775 $tmpdir/*.sh;
 RUN sync;
 RUN $tmpdir/setup.sh ${TARGETARCH}
 # If wanting to run without distroless, uncomment this line and comment everything after
-#CMD [ "/opt/main.sh" ]
-
-FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0
-# Below is for ContainerInsightsPrometheusCollector-Prod AppInsights Resource
-ENV APPLICATIONINSIGHTS_AUTH_PUBLIC MWNkYTMxMTItYWY1Ni00ZmNiLWI4MDQtZjg5NDVhYTFjYjMy
-# Below is for ContainerInsightsPrometheusCollector-Fairfax AppInsights Resource
-ENV APPLICATIONINSIGHTS_AUTH_USGOVERNMENT ZmRjMTE0MmUtY2U0YS1mNTFmLWE4M2EtODBjM2ZjNDYwNGE5
-# Below is for ContainerInsightsPrometheusCollector-Mooncake AppInsights Resource
-ENV APPLICATIONINSIGHTS_AUTH_CHINACLOUD ZTcyY2ZjOTYtNjY3Zi1jZGYwLTkwOWMtNzhiZjAwZjQ0NDg4
-# Below is for ContainerInsightsPrometheusCollector-USSec AppInsights Resource
-ENV APPLICATIONINSIGHTS_AUTH_USSEC ZTg4MzFlZGYtNWQ1ZC0wYjZmLTk3MGUtNDkxNTgyYjliMDFl
-# Below is for ContainerInsightsPrometheusCollector-USNat AppInsights Resource
-ENV APPLICATIONINSIGHTS_AUTH_USNAT ZTliNjRmZmUtZDZlYi0xYjczLThjYWQtNDU2OTFjN2FhNzIw
-ENV TELEMETRY_DISABLED false
-# Needed for ME, see https://github.com/microsoft/cpprestsdk/issues/1481
-ENV MALLOC_ARENA_MAX=2
-ENV PATH="/busybin:${PATH}"
-ENV OS_TYPE "linux"
-
-# files
-COPY --from=builder /opt /opt
-COPY --from=builder /etc /etc
-COPY --from=builder /busybin /busybin
-COPY --from=builder /static/react /static/react
-COPY --from=builder /usr/sbin/me.config /usr/sbin/me_internal.config /usr/sbin/me_ds.config /usr/sbin/me_ds_internal.config /usr/sbin/
-COPY --from=builder /var/opt/microsoft /var/opt/microsoft
-COPY --from=builder /var/lib/logrotate /var/lib/logrotate
-COPY --from=builder /var/spool/cron /var/spool/cron
-COPY --from=builder /usr/share/p11-kit /usr/share/p11-kit
-COPY --from=builder /usr/share/pki/ /usr/share/pki
-
-# executables
-COPY --from=builder /usr/sbin/MetricsExtension /usr/sbin/MetricsExtension
-COPY --from=builder /usr/bin/ruby /usr/bin/ruby
-COPY --from=builder /usr/lib/ruby /usr/lib/ruby
-COPY --from=builder /usr/bin/inotifywait /usr/bin/inotifywait
-COPY --from=builder /usr/bin/bash /usr/bin/bash
-COPY --from=builder /usr/sbin/busybox /usr/sbin/busybox
-COPY --from=builder /usr/bin/fluent-bit /usr/bin/fluent-bit
-COPY --from=builder /usr/bin/telegraf /usr/bin/telegraf
-COPY --from=builder /usr/sbin/crond /usr/sbin/crond
-COPY --from=builder /usr/bin/vim /usr/bin/vim
-COPY --from=builder /usr/share/vim /usr/share/vim
-COPY --from=builder /usr/sbin/mdsd /usr/sbin/mdsd
-COPY --from=builder /usr/sbin/logrotate /usr/sbin/logrotate
-COPY --from=builder /usr/bin/gzip /usr/bin/
-COPY --from=builder /usr/bin/curl /usr/bin/
-COPY --from=builder /usr/bin/update-ca-trust /usr/bin
-COPY --from=builder /bin/sh /bin/sh
-COPY --from=builder /usr/bin/p11-kit /usr/bin
-COPY --from=builder /usr/bin/trust /usr/bin
-
-# bash dependencies
-COPY --from=builder /lib/libreadline.so.8 /lib/
-COPY --from=builder /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /usr/lib/
-# inotifywait dependencies
-COPY --from=builder /lib/libinotifytools.so.0 /lib/
-# crond dependencies
-COPY --from=builder /lib/libselinux.so.1 /lib/libpam.so.0 /lib/libc.so.6 /lib/libpcre.so.1 /lib/libaudit.so.1 /lib/libcap-ng.so.0/ /lib/
-# vim dependencies
-COPY --from=builder /lib/libm.so.6 /lib/libtinfo.so.6 /lib/
-# ruby dependencies
-COPY --from=builder /usr/lib/libruby.so.3.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/
-# ruby re2 dependencies
-COPY --from=builder /usr/lib/libre2.so.0a /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/
-# metricsextension dependencies
-# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
-COPY --from=builder /lib/libprotobuf.so.28 /lib/libgrpc++.so.1.42 /lib/libabsl_synchronization.so.2206.0.0 /lib/libboost_filesystem.so.1.76.0 /lib/libboost_coroutine.so.1.76.0 /lib/libboost_thread.so.1.76.0 /lib/libcpprest.so.2.10  /lib/libuuid.so.1 /lib/libstdc++.so.6 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/libc.so.6 /lib/libz.so.1 /lib64/libgrpc.so.20 /lib/libabsl_raw_hash_set.so.2206.0.0 /lib/libabsl_hash.so.2206.0.0 /lib/libabsl_statusor.so.2206.0.0 /lib/libgpr.so.20 /lib/libupb.so.20 /lib/libabsl_status.so.2206.0.0 /lib/libabsl_time.so.2206.0.0 /lib/libabsl_strings.so.2206.0.0 /lib/libabsl_stacktrace.so.2206.0.0  /lib/libabsl_symbolize.so.2206.0.0 /lib/libabsl_malloc_internal.so.2206.0.0 /lib/libabsl_base.so.2206.0.0 /lib/libabsl_spinlock_wait.so.2206.0.0 /lib/libabsl_raw_logging_internal.so.2206.0.0 /lib/libboost_chrono.so.1.76.0 /lib/libboost_context.so.1.76.0 /lib/libbrotlidec.so.1 /lib/libbrotlienc.so.1 /lib/libcares.so.2 /lib/libaddress_sorting.so.20 /lib/libre2.so.0a /lib/libabsl_cord.so.2206.0.0 /lib/libabsl_str_format_internal.so.2206.0.0 /lib/libabsl_time_zone.so.2206.0.0 /lib/libabsl_city.so.2206.0.0 /lib/libabsl_low_level_hash.so.2206.0.0 /lib/libabsl_cordz_info.so.2206.0.0 /lib/libabsl_strerror.so.2206.0.0 /lib/libabsl_int128.so.2206.0.0 /lib/libabsl_strings_internal.so.2206.0.0 /lib/libabsl_debugging_internal.so.2206.0.0 /lib/libabsl_demangle_internal.so.2206.0.0 /lib/libbrotlicommon.so.1 /lib/libabsl_cord_internal.so.2206.0.0 /lib/libabsl_cordz_functions.so.2206.0.0 /lib/libabsl_cordz_handle.so.2206.0.0 /lib/libabsl_throw_delegate.so.2206.0.0 /lib/libabsl_exponential_biased.so.2206.0.0 /lib/
-# fluent-bit dependencies
-# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
-COPY --from=builder  /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/liblzma.so.5 /lib/liblz4.so.1 /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libgpg-error.so.0 /lib/
-# telegraf dependencies
-COPY --from=builder /lib/libc.so.6 /lib/
-# mdsd dependencies
-COPY --from=builder /usr/lib/libdl.so.2 /usr/lib/librt.so.1 /usr/lib/libpthread.so.0 /usr/lib/libm.so.6 /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /usr/lib/
-COPY --from=builder /usr/local/lib/libtcmalloc_minimal.so.4 /usr/local/lib/
-# logrotate dependencies
-COPY --from=builder /lib/libselinux.so.1 /lib/libpopt.so.0 /lib/libpcre.so.1 /lib/
-# curl dependencies
-# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
-COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssh2.so.1   /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
-COPY --from=builder /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /usr/lib/libresolv.so.2 /usr/lib/
-# sh dependencies
-COPY --from=builder /lib/libreadline.so.8 /lib/libc.so.6 /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /lib/
-# update-ca-trust dependencies
-COPY --from=builder /usr/lib64/pkcs11 /usr/lib64
-COPY --from=builder /usr/lib/pkcs11 /usr/lib/
-COPY --from=builder /usr/libexec/p11-kit /usr/libexec
-COPY --from=builder /lib/libp11-kit.so.0 /lib/libtasn1.so.6 /lib/libc.so.6 /lib/libffi.so.8 /lib/
-COPY --from=builder /usr/lib/p11-kit-trust.so /usr/lib/p11-kit-proxy.so /usr/lib/libp11-kit.so.0.3.0 /usr/lib/libnssckbi.so /usr/lib/
-COPY --from=builder /usr/lib/pkcs11/p11-kit-trust.so /usr/lib/pkcs11/
-
-RUN [ "/bin/bash", "-c", "chmod 644 /etc/crontab" ]
-RUN [ "/bin/bash", "-c", "chown root.root /etc/crontab" ]
-RUN [ "/bin/bash", "-c", "chmod 755 /etc/cron.daily/logrotate" ]
-RUN [ "/bin/bash", "-c", "chmod 644 /etc/logrotate.d/prometheus-collector" ]
-ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/opt/main.sh" ]
+
+# FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0
+# # Below is for ContainerInsightsPrometheusCollector-Prod AppInsights Resource
+# ENV APPLICATIONINSIGHTS_AUTH_PUBLIC MWNkYTMxMTItYWY1Ni00ZmNiLWI4MDQtZjg5NDVhYTFjYjMy
+# # Below is for ContainerInsightsPrometheusCollector-Fairfax AppInsights Resource
+# ENV APPLICATIONINSIGHTS_AUTH_USGOVERNMENT ZmRjMTE0MmUtY2U0YS1mNTFmLWE4M2EtODBjM2ZjNDYwNGE5
+# # Below is for ContainerInsightsPrometheusCollector-Mooncake AppInsights Resource
+# ENV APPLICATIONINSIGHTS_AUTH_CHINACLOUD ZTcyY2ZjOTYtNjY3Zi1jZGYwLTkwOWMtNzhiZjAwZjQ0NDg4
+# # Below is for ContainerInsightsPrometheusCollector-USSec AppInsights Resource
+# ENV APPLICATIONINSIGHTS_AUTH_USSEC ZTg4MzFlZGYtNWQ1ZC0wYjZmLTk3MGUtNDkxNTgyYjliMDFl
+# # Below is for ContainerInsightsPrometheusCollector-USNat AppInsights Resource
+# ENV APPLICATIONINSIGHTS_AUTH_USNAT ZTliNjRmZmUtZDZlYi0xYjczLThjYWQtNDU2OTFjN2FhNzIw
+# ENV TELEMETRY_DISABLED false
+# # Needed for ME, see https://github.com/microsoft/cpprestsdk/issues/1481
+# ENV MALLOC_ARENA_MAX=2
+# ENV PATH="/busybin:${PATH}"
+# ENV OS_TYPE "linux"
+
+# # files
+# COPY --from=builder /opt /opt
+# COPY --from=builder /etc /etc
+# COPY --from=builder /busybin /busybin
+# COPY --from=builder /static/react /static/react
+# COPY --from=builder /usr/sbin/me.config /usr/sbin/me_internal.config /usr/sbin/me_ds.config /usr/sbin/me_ds_internal.config /usr/sbin/
+# COPY --from=builder /var/opt/microsoft /var/opt/microsoft
+# COPY --from=builder /var/lib/logrotate /var/lib/logrotate
+# COPY --from=builder /var/spool/cron /var/spool/cron
+# COPY --from=builder /usr/share/p11-kit /usr/share/p11-kit
+# COPY --from=builder /usr/share/pki/ /usr/share/pki
+
+# # executables
+# COPY --from=builder /usr/sbin/MetricsExtension /usr/sbin/MetricsExtension
+# COPY --from=builder /usr/bin/ruby /usr/bin/ruby
+# COPY --from=builder /usr/lib/ruby /usr/lib/ruby
+# COPY --from=builder /usr/bin/inotifywait /usr/bin/inotifywait
+# COPY --from=builder /usr/bin/bash /usr/bin/bash
+# COPY --from=builder /usr/sbin/busybox /usr/sbin/busybox
+# COPY --from=builder /usr/bin/fluent-bit /usr/bin/fluent-bit
+# COPY --from=builder /usr/bin/telegraf /usr/bin/telegraf
+# COPY --from=builder /usr/sbin/crond /usr/sbin/crond
+# COPY --from=builder /usr/bin/vim /usr/bin/vim
+# COPY --from=builder /usr/share/vim /usr/share/vim
+# COPY --from=builder /usr/sbin/mdsd /usr/sbin/mdsd
+# COPY --from=builder /usr/sbin/logrotate /usr/sbin/logrotate
+# COPY --from=builder /usr/bin/gzip /usr/bin/
+# COPY --from=builder /usr/bin/curl /usr/bin/
+# COPY --from=builder /usr/bin/update-ca-trust /usr/bin
+# COPY --from=builder /bin/sh /bin/sh
+# COPY --from=builder /usr/bin/p11-kit /usr/bin
+# COPY --from=builder /usr/bin/trust /usr/bin
+
+# # bash dependencies
+# COPY --from=builder /lib/libreadline.so.8 /lib/
+# COPY --from=builder /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /usr/lib/
+# # inotifywait dependencies
+# COPY --from=builder /lib/libinotifytools.so.0 /lib/
+# # crond dependencies
+# COPY --from=builder /lib/libselinux.so.1 /lib/libpam.so.0 /lib/libc.so.6 /lib/libpcre.so.1 /lib/libaudit.so.1 /lib/libcap-ng.so.0/ /lib/
+# # vim dependencies
+# COPY --from=builder /lib/libm.so.6 /lib/libtinfo.so.6 /lib/
+# # ruby dependencies
+# COPY --from=builder /usr/lib/libruby.so.3.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/
+# # ruby re2 dependencies
+# COPY --from=builder /usr/lib/libre2.so.0a /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/
+# # metricsextension dependencies
+# # libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
+# COPY --from=builder /lib/libprotobuf.so.28 /lib/libgrpc++.so.1.42 /lib/libabsl_synchronization.so.2206.0.0 /lib/libboost_filesystem.so.1.76.0 /lib/libboost_coroutine.so.1.76.0 /lib/libboost_thread.so.1.76.0 /lib/libcpprest.so.2.10  /lib/libuuid.so.1 /lib/libstdc++.so.6 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/libc.so.6 /lib/libz.so.1 /lib64/libgrpc.so.20 /lib/libabsl_raw_hash_set.so.2206.0.0 /lib/libabsl_hash.so.2206.0.0 /lib/libabsl_statusor.so.2206.0.0 /lib/libgpr.so.20 /lib/libupb.so.20 /lib/libabsl_status.so.2206.0.0 /lib/libabsl_time.so.2206.0.0 /lib/libabsl_strings.so.2206.0.0 /lib/libabsl_stacktrace.so.2206.0.0  /lib/libabsl_symbolize.so.2206.0.0 /lib/libabsl_malloc_internal.so.2206.0.0 /lib/libabsl_base.so.2206.0.0 /lib/libabsl_spinlock_wait.so.2206.0.0 /lib/libabsl_raw_logging_internal.so.2206.0.0 /lib/libboost_chrono.so.1.76.0 /lib/libboost_context.so.1.76.0 /lib/libbrotlidec.so.1 /lib/libbrotlienc.so.1 /lib/libcares.so.2 /lib/libaddress_sorting.so.20 /lib/libre2.so.0a /lib/libabsl_cord.so.2206.0.0 /lib/libabsl_str_format_internal.so.2206.0.0 /lib/libabsl_time_zone.so.2206.0.0 /lib/libabsl_city.so.2206.0.0 /lib/libabsl_low_level_hash.so.2206.0.0 /lib/libabsl_cordz_info.so.2206.0.0 /lib/libabsl_strerror.so.2206.0.0 /lib/libabsl_int128.so.2206.0.0 /lib/libabsl_strings_internal.so.2206.0.0 /lib/libabsl_debugging_internal.so.2206.0.0 /lib/libabsl_demangle_internal.so.2206.0.0 /lib/libbrotlicommon.so.1 /lib/libabsl_cord_internal.so.2206.0.0 /lib/libabsl_cordz_functions.so.2206.0.0 /lib/libabsl_cordz_handle.so.2206.0.0 /lib/libabsl_throw_delegate.so.2206.0.0 /lib/libabsl_exponential_biased.so.2206.0.0 /lib/
+# # fluent-bit dependencies
+# # libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
+# COPY --from=builder  /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/liblzma.so.5 /lib/liblz4.so.1 /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libgpg-error.so.0 /lib/
+# # telegraf dependencies
+# COPY --from=builder /lib/libc.so.6 /lib/
+# # mdsd dependencies
+# COPY --from=builder /usr/lib/libdl.so.2 /usr/lib/librt.so.1 /usr/lib/libpthread.so.0 /usr/lib/libm.so.6 /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /usr/lib/
+# COPY --from=builder /usr/local/lib/libtcmalloc_minimal.so.4 /usr/local/lib/
+# # logrotate dependencies
+# COPY --from=builder /lib/libselinux.so.1 /lib/libpopt.so.0 /lib/libpcre.so.1 /lib/
+# # curl dependencies
+# # libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
+# COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssh2.so.1   /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
+# COPY --from=builder /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /usr/lib/libresolv.so.2 /usr/lib/
+# # sh dependencies
+# COPY --from=builder /lib/libreadline.so.8 /lib/libc.so.6 /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /lib/
+# # update-ca-trust dependencies
+# COPY --from=builder /usr/lib64/pkcs11 /usr/lib64
+# COPY --from=builder /usr/lib/pkcs11 /usr/lib/
+# COPY --from=builder /usr/libexec/p11-kit /usr/libexec
+# COPY --from=builder /lib/libp11-kit.so.0 /lib/libtasn1.so.6 /lib/libc.so.6 /lib/libffi.so.8 /lib/
+# COPY --from=builder /usr/lib/p11-kit-trust.so /usr/lib/p11-kit-proxy.so /usr/lib/libp11-kit.so.0.3.0 /usr/lib/libnssckbi.so /usr/lib/
+# COPY --from=builder /usr/lib/pkcs11/p11-kit-trust.so /usr/lib/pkcs11/
+
+# RUN [ "/bin/bash", "-c", "chmod 644 /etc/crontab" ]
+# RUN [ "/bin/bash", "-c", "chown root.root /etc/crontab" ]
+# RUN [ "/bin/bash", "-c", "chmod 755 /etc/cron.daily/logrotate" ]
+# RUN [ "/bin/bash", "-c", "chmod 644 /etc/logrotate.d/prometheus-collector" ]
+# ENTRYPOINT [ "/bin/bash" ]
+# CMD [ "/opt/main.sh" ]

--- a/otelcollector/build/linux/Dockerfile
+++ b/otelcollector/build/linux/Dockerfile
@@ -92,101 +92,102 @@ RUN chmod 775 $tmpdir/*.sh;
 RUN sync;
 RUN $tmpdir/setup.sh ${TARGETARCH}
 # If wanting to run without distroless, uncomment this line and comment everything after
-CMD [ "/opt/main.sh" ]
-
-# FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0
-# # Below is for ContainerInsightsPrometheusCollector-Prod AppInsights Resource
-# ENV APPLICATIONINSIGHTS_AUTH_PUBLIC MWNkYTMxMTItYWY1Ni00ZmNiLWI4MDQtZjg5NDVhYTFjYjMy
-# # Below is for ContainerInsightsPrometheusCollector-Fairfax AppInsights Resource
-# ENV APPLICATIONINSIGHTS_AUTH_USGOVERNMENT ZmRjMTE0MmUtY2U0YS1mNTFmLWE4M2EtODBjM2ZjNDYwNGE5
-# # Below is for ContainerInsightsPrometheusCollector-Mooncake AppInsights Resource
-# ENV APPLICATIONINSIGHTS_AUTH_CHINACLOUD ZTcyY2ZjOTYtNjY3Zi1jZGYwLTkwOWMtNzhiZjAwZjQ0NDg4
-# # Below is for ContainerInsightsPrometheusCollector-USSec AppInsights Resource
-# ENV APPLICATIONINSIGHTS_AUTH_USSEC ZTg4MzFlZGYtNWQ1ZC0wYjZmLTk3MGUtNDkxNTgyYjliMDFl
-# # Below is for ContainerInsightsPrometheusCollector-USNat AppInsights Resource
-# ENV APPLICATIONINSIGHTS_AUTH_USNAT ZTliNjRmZmUtZDZlYi0xYjczLThjYWQtNDU2OTFjN2FhNzIw
-# ENV TELEMETRY_DISABLED false
-# # Needed for ME, see https://github.com/microsoft/cpprestsdk/issues/1481
-# ENV MALLOC_ARENA_MAX=2
-# ENV PATH="/busybin:${PATH}"
-# ENV OS_TYPE "linux"
-
-# # files
-# COPY --from=builder /opt /opt
-# COPY --from=builder /etc /etc
-# COPY --from=builder /busybin /busybin
-# COPY --from=builder /static/react /static/react
-# COPY --from=builder /usr/sbin/me.config /usr/sbin/me_internal.config /usr/sbin/me_ds.config /usr/sbin/me_ds_internal.config /usr/sbin/
-# COPY --from=builder /var/opt/microsoft /var/opt/microsoft
-# COPY --from=builder /var/lib/logrotate /var/lib/logrotate
-# COPY --from=builder /var/spool/cron /var/spool/cron
-# COPY --from=builder /usr/share/p11-kit /usr/share/p11-kit
-# COPY --from=builder /usr/share/pki/ /usr/share/pki
-
-# # executables
-# COPY --from=builder /usr/sbin/MetricsExtension /usr/sbin/MetricsExtension
-# COPY --from=builder /usr/bin/ruby /usr/bin/ruby
-# COPY --from=builder /usr/lib/ruby /usr/lib/ruby
-# COPY --from=builder /usr/bin/inotifywait /usr/bin/inotifywait
-# COPY --from=builder /usr/bin/bash /usr/bin/bash
-# COPY --from=builder /usr/sbin/busybox /usr/sbin/busybox
-# COPY --from=builder /usr/bin/fluent-bit /usr/bin/fluent-bit
-# COPY --from=builder /usr/bin/telegraf /usr/bin/telegraf
-# COPY --from=builder /usr/sbin/crond /usr/sbin/crond
-# COPY --from=builder /usr/bin/vim /usr/bin/vim
-# COPY --from=builder /usr/share/vim /usr/share/vim
-# COPY --from=builder /usr/sbin/mdsd /usr/sbin/mdsd
-# COPY --from=builder /usr/sbin/logrotate /usr/sbin/logrotate
-# COPY --from=builder /usr/bin/gzip /usr/bin/
-# COPY --from=builder /usr/bin/curl /usr/bin/
-# COPY --from=builder /usr/bin/update-ca-trust /usr/bin
-# COPY --from=builder /bin/sh /bin/sh
-# COPY --from=builder /usr/bin/p11-kit /usr/bin
-# COPY --from=builder /usr/bin/trust /usr/bin
-
-# # bash dependencies
-# COPY --from=builder /lib/libreadline.so.8 /lib/
-# COPY --from=builder /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /usr/lib/
-# # inotifywait dependencies
-# COPY --from=builder /lib/libinotifytools.so.0 /lib/
-# # crond dependencies
-# COPY --from=builder /lib/libselinux.so.1 /lib/libpam.so.0 /lib/libc.so.6 /lib/libpcre.so.1 /lib/libaudit.so.1 /lib/libcap-ng.so.0/ /lib/
-# # vim dependencies
-# COPY --from=builder /lib/libm.so.6 /lib/libtinfo.so.6 /lib/
-# # ruby dependencies
-# COPY --from=builder /usr/lib/libruby.so.3.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/
-# # ruby re2 dependencies
-# COPY --from=builder /usr/lib/libre2.so.0a /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/
-# # metricsextension dependencies
-# # libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
-# COPY --from=builder /lib/libprotobuf.so.28 /lib/libgrpc++.so.1.42 /lib/libabsl_synchronization.so.2206.0.0 /lib/libboost_filesystem.so.1.76.0 /lib/libboost_coroutine.so.1.76.0 /lib/libboost_thread.so.1.76.0 /lib/libcpprest.so.2.10  /lib/libuuid.so.1 /lib/libstdc++.so.6 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/libc.so.6 /lib/libz.so.1 /lib64/libgrpc.so.20 /lib/libabsl_raw_hash_set.so.2206.0.0 /lib/libabsl_hash.so.2206.0.0 /lib/libabsl_statusor.so.2206.0.0 /lib/libgpr.so.20 /lib/libupb.so.20 /lib/libabsl_status.so.2206.0.0 /lib/libabsl_time.so.2206.0.0 /lib/libabsl_strings.so.2206.0.0 /lib/libabsl_stacktrace.so.2206.0.0  /lib/libabsl_symbolize.so.2206.0.0 /lib/libabsl_malloc_internal.so.2206.0.0 /lib/libabsl_base.so.2206.0.0 /lib/libabsl_spinlock_wait.so.2206.0.0 /lib/libabsl_raw_logging_internal.so.2206.0.0 /lib/libboost_chrono.so.1.76.0 /lib/libboost_context.so.1.76.0 /lib/libbrotlidec.so.1 /lib/libbrotlienc.so.1 /lib/libcares.so.2 /lib/libaddress_sorting.so.20 /lib/libre2.so.0a /lib/libabsl_cord.so.2206.0.0 /lib/libabsl_str_format_internal.so.2206.0.0 /lib/libabsl_time_zone.so.2206.0.0 /lib/libabsl_city.so.2206.0.0 /lib/libabsl_low_level_hash.so.2206.0.0 /lib/libabsl_cordz_info.so.2206.0.0 /lib/libabsl_strerror.so.2206.0.0 /lib/libabsl_int128.so.2206.0.0 /lib/libabsl_strings_internal.so.2206.0.0 /lib/libabsl_debugging_internal.so.2206.0.0 /lib/libabsl_demangle_internal.so.2206.0.0 /lib/libbrotlicommon.so.1 /lib/libabsl_cord_internal.so.2206.0.0 /lib/libabsl_cordz_functions.so.2206.0.0 /lib/libabsl_cordz_handle.so.2206.0.0 /lib/libabsl_throw_delegate.so.2206.0.0 /lib/libabsl_exponential_biased.so.2206.0.0 /lib/
-# # fluent-bit dependencies
-# # libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
-# COPY --from=builder  /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/liblzma.so.5 /lib/liblz4.so.1 /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libgpg-error.so.0 /lib/
-# # telegraf dependencies
-# COPY --from=builder /lib/libc.so.6 /lib/
-# # mdsd dependencies
-# COPY --from=builder /usr/lib/libdl.so.2 /usr/lib/librt.so.1 /usr/lib/libpthread.so.0 /usr/lib/libm.so.6 /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /usr/lib/
-# COPY --from=builder /usr/local/lib/libtcmalloc_minimal.so.4 /usr/local/lib/
-# # logrotate dependencies
-# COPY --from=builder /lib/libselinux.so.1 /lib/libpopt.so.0 /lib/libpcre.so.1 /lib/
-# # curl dependencies
-# # libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
-# COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssh2.so.1   /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
-# COPY --from=builder /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /usr/lib/libresolv.so.2 /usr/lib/
-# # sh dependencies
-# COPY --from=builder /lib/libreadline.so.8 /lib/libc.so.6 /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /lib/
-# # update-ca-trust dependencies
-# COPY --from=builder /usr/lib64/pkcs11 /usr/lib64
-# COPY --from=builder /usr/lib/pkcs11 /usr/lib/
-# COPY --from=builder /usr/libexec/p11-kit /usr/libexec
-# COPY --from=builder /lib/libp11-kit.so.0 /lib/libtasn1.so.6 /lib/libc.so.6 /lib/libffi.so.8 /lib/
-# COPY --from=builder /usr/lib/p11-kit-trust.so /usr/lib/p11-kit-proxy.so /usr/lib/libp11-kit.so.0.3.0 /usr/lib/libnssckbi.so /usr/lib/
-# COPY --from=builder /usr/lib/pkcs11/p11-kit-trust.so /usr/lib/pkcs11/
-
-# RUN [ "/bin/bash", "-c", "chmod 644 /etc/crontab" ]
-# RUN [ "/bin/bash", "-c", "chown root.root /etc/crontab" ]
-# RUN [ "/bin/bash", "-c", "chmod 755 /etc/cron.daily/logrotate" ]
-# RUN [ "/bin/bash", "-c", "chmod 644 /etc/logrotate.d/prometheus-collector" ]
-# ENTRYPOINT [ "/bin/bash" ]
 # CMD [ "/opt/main.sh" ]
+
+FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0
+# Below is for ContainerInsightsPrometheusCollector-Prod AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_PUBLIC MWNkYTMxMTItYWY1Ni00ZmNiLWI4MDQtZjg5NDVhYTFjYjMy
+# Below is for ContainerInsightsPrometheusCollector-Fairfax AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_USGOVERNMENT ZmRjMTE0MmUtY2U0YS1mNTFmLWE4M2EtODBjM2ZjNDYwNGE5
+# Below is for ContainerInsightsPrometheusCollector-Mooncake AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_CHINACLOUD ZTcyY2ZjOTYtNjY3Zi1jZGYwLTkwOWMtNzhiZjAwZjQ0NDg4
+# Below is for ContainerInsightsPrometheusCollector-USSec AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_USSEC ZTg4MzFlZGYtNWQ1ZC0wYjZmLTk3MGUtNDkxNTgyYjliMDFl
+# Below is for ContainerInsightsPrometheusCollector-USNat AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_USNAT ZTliNjRmZmUtZDZlYi0xYjczLThjYWQtNDU2OTFjN2FhNzIw
+ENV TELEMETRY_DISABLED false
+# Needed for ME, see https://github.com/microsoft/cpprestsdk/issues/1481
+ENV MALLOC_ARENA_MAX=2
+ENV PATH="/busybin:${PATH}"
+ENV OS_TYPE "linux"
+
+# files
+COPY --from=builder /opt /opt
+COPY --from=builder /etc /etc
+COPY --from=builder /busybin /busybin
+COPY --from=builder /static/react /static/react
+COPY --from=builder /usr/sbin/me.config /usr/sbin/me_internal.config /usr/sbin/me_ds.config /usr/sbin/me_ds_internal.config /usr/sbin/
+COPY --from=builder /var/opt/microsoft /var/opt/microsoft
+COPY --from=builder /var/lib/logrotate /var/lib/logrotate
+COPY --from=builder /var/spool/cron /var/spool/cron
+COPY --from=builder /usr/share/p11-kit /usr/share/p11-kit
+COPY --from=builder /usr/share/pki/ /usr/share/pki
+
+# executables
+COPY --from=builder /usr/sbin/MetricsExtension /usr/sbin/MetricsExtension
+COPY --from=builder /usr/bin/ruby /usr/bin/ruby
+COPY --from=builder /usr/lib/ruby /usr/lib/ruby
+COPY --from=builder /usr/bin/inotifywait /usr/bin/inotifywait
+COPY --from=builder /usr/bin/bash /usr/bin/bash
+COPY --from=builder /usr/sbin/busybox /usr/sbin/busybox
+COPY --from=builder /usr/bin/fluent-bit /usr/bin/fluent-bit
+COPY --from=builder /usr/bin/telegraf /usr/bin/telegraf
+COPY --from=builder /usr/sbin/crond /usr/sbin/crond
+COPY --from=builder /usr/bin/vim /usr/bin/vim
+COPY --from=builder /usr/share/vim /usr/share/vim
+COPY --from=builder /usr/sbin/mdsd /usr/sbin/mdsd
+COPY --from=builder /usr/sbin/logrotate /usr/sbin/logrotate
+COPY --from=builder /usr/bin/gzip /usr/bin/
+COPY --from=builder /usr/bin/curl /usr/bin/
+COPY --from=builder /usr/bin/update-ca-trust /usr/bin
+COPY --from=builder /bin/sh /bin/sh
+COPY --from=builder /usr/bin/p11-kit /usr/bin
+COPY --from=builder /usr/bin/trust /usr/bin
+
+# bash dependencies
+COPY --from=builder /lib/libreadline.so.8 /lib/
+COPY --from=builder /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /usr/lib/
+# inotifywait dependencies
+COPY --from=builder /lib/libinotifytools.so.0 /lib/
+# crond dependencies
+COPY --from=builder /lib/libselinux.so.1 /lib/libpam.so.0 /lib/libc.so.6 /lib/libpcre.so.1 /lib/libaudit.so.1 /lib/libcap-ng.so.0/ /lib/
+# vim dependencies
+COPY --from=builder /lib/libm.so.6 /lib/libtinfo.so.6 /lib/
+# ruby dependencies
+COPY --from=builder /usr/lib/libruby.so.3.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/
+# ruby re2 dependencies
+COPY --from=builder /usr/lib/libre2.so.0a /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /usr/lib/libz.so.1 /usr/lib/libgmp.so.10 /usr/lib/libcrypt.so.1 /usr/lib/libm.so.6 /usr/lib/
+# metricsextension dependencies
+# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
+COPY --from=builder /lib/libprotobuf.so.28 /lib/libgrpc++.so.1.42 /lib/libabsl_synchronization.so.2206.0.0 /lib/libboost_filesystem.so.1.76.0 /lib/libboost_coroutine.so.1.76.0 /lib/libboost_thread.so.1.76.0 /lib/libcpprest.so.2.10  /lib/libuuid.so.1 /lib/libstdc++.so.6 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/libc.so.6 /lib/libz.so.1 /lib64/libgrpc.so.20 /lib/libabsl_raw_hash_set.so.2206.0.0 /lib/libabsl_hash.so.2206.0.0 /lib/libabsl_statusor.so.2206.0.0 /lib/libgpr.so.20 /lib/libupb.so.20 /lib/libabsl_status.so.2206.0.0 /lib/libabsl_time.so.2206.0.0 /lib/libabsl_strings.so.2206.0.0 /lib/libabsl_stacktrace.so.2206.0.0  /lib/libabsl_symbolize.so.2206.0.0 /lib/libabsl_malloc_internal.so.2206.0.0 /lib/libabsl_base.so.2206.0.0 /lib/libabsl_spinlock_wait.so.2206.0.0 /lib/libabsl_raw_logging_internal.so.2206.0.0 /lib/libboost_chrono.so.1.76.0 /lib/libboost_context.so.1.76.0 /lib/libbrotlidec.so.1 /lib/libbrotlienc.so.1 /lib/libcares.so.2 /lib/libaddress_sorting.so.20 /lib/libre2.so.0a /lib/libabsl_cord.so.2206.0.0 /lib/libabsl_str_format_internal.so.2206.0.0 /lib/libabsl_time_zone.so.2206.0.0 /lib/libabsl_city.so.2206.0.0 /lib/libabsl_low_level_hash.so.2206.0.0 /lib/libabsl_cordz_info.so.2206.0.0 /lib/libabsl_strerror.so.2206.0.0 /lib/libabsl_int128.so.2206.0.0 /lib/libabsl_strings_internal.so.2206.0.0 /lib/libabsl_debugging_internal.so.2206.0.0 /lib/libabsl_demangle_internal.so.2206.0.0 /lib/libbrotlicommon.so.1 /lib/libabsl_cord_internal.so.2206.0.0 /lib/libabsl_cordz_functions.so.2206.0.0 /lib/libabsl_cordz_handle.so.2206.0.0 /lib/libabsl_throw_delegate.so.2206.0.0 /lib/libabsl_exponential_biased.so.2206.0.0 /lib/
+# fluent-bit dependencies
+# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
+COPY --from=builder /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libcurl.so.4 /lib/libm.so.6 /lib/libz.so.1 /lib/libzstd.so.1 /lib/libsasl2.so.3 /lib/libgcc_s.so.1 /lib/libc.so.6 /lib/liblzma.so.5 /lib/liblz4.so.1  /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libnghttp2.so.14 /lib/libssh2.so.1 /lib/libgssapi_krb5.so.2 /lib/libresolv.so.2 /lib/libgpg-error.so.0 /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /lib/
+COPY --from=builder /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/liblzma.so.5 /lib/liblz4.so.1 /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libgpg-error.so.0 /lib/
+# telegraf dependencies
+COPY --from=builder /lib/libc.so.6 /lib/
+# mdsd dependencies
+COPY --from=builder /usr/lib/libdl.so.2 /usr/lib/librt.so.1 /usr/lib/libpthread.so.0 /usr/lib/libm.so.6 /usr/lib/libstdc++.so.6 /usr/lib/libgcc_s.so.1 /usr/lib/
+COPY --from=builder /usr/local/lib/libtcmalloc_minimal.so.4 /usr/local/lib/
+# logrotate dependencies
+COPY --from=builder /lib/libselinux.so.1 /lib/libpopt.so.0 /lib/libpcre.so.1 /lib/
+# curl dependencies
+# libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
+COPY --from=builder /lib/libcurl.so.4 /lib/libz.so.1 /lib/libc.so.6 /lib/libnghttp2.so.14 /lib/libssh2.so.1   /lib/libgssapi_krb5.so.2 /lib/libzstd.so.1 /lib/
+COPY --from=builder /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /usr/lib/libresolv.so.2 /usr/lib/
+# sh dependencies
+COPY --from=builder /lib/libreadline.so.8 /lib/libc.so.6 /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6 /lib/
+# update-ca-trust dependencies
+COPY --from=builder /usr/lib64/pkcs11 /usr/lib64
+COPY --from=builder /usr/lib/pkcs11 /usr/lib/
+COPY --from=builder /usr/libexec/p11-kit /usr/libexec
+COPY --from=builder /lib/libp11-kit.so.0 /lib/libtasn1.so.6 /lib/libc.so.6 /lib/libffi.so.8 /lib/
+COPY --from=builder /usr/lib/p11-kit-trust.so /usr/lib/p11-kit-proxy.so /usr/lib/libp11-kit.so.0.3.0 /usr/lib/libnssckbi.so /usr/lib/
+COPY --from=builder /usr/lib/pkcs11/p11-kit-trust.so /usr/lib/pkcs11/
+
+RUN [ "/bin/bash", "-c", "chmod 644 /etc/crontab" ]
+RUN [ "/bin/bash", "-c", "chown root.root /etc/crontab" ]
+RUN [ "/bin/bash", "-c", "chmod 755 /etc/cron.daily/logrotate" ]
+RUN [ "/bin/bash", "-c", "chmod 644 /etc/logrotate.d/prometheus-collector" ]
+ENTRYPOINT [ "/bin/bash" ]
+CMD [ "/opt/main.sh" ]

--- a/otelcollector/build/linux/Dockerfile
+++ b/otelcollector/build/linux/Dockerfile
@@ -163,7 +163,6 @@ COPY --from=builder /lib/libprotobuf.so.28 /lib/libgrpc++.so.1.42 /lib/libabsl_s
 # fluent-bit dependencies
 # libssl.so.1.1 & libcrypto.so.1.1 are already available with openssl in distroless and copying them over causes FIPS HMAC verification failures
 COPY --from=builder /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libcurl.so.4 /lib/libm.so.6 /lib/libz.so.1 /lib/libzstd.so.1 /lib/libsasl2.so.3 /lib/libgcc_s.so.1 /lib/libc.so.6 /lib/liblzma.so.5 /lib/liblz4.so.1  /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libnghttp2.so.14 /lib/libssh2.so.1 /lib/libgssapi_krb5.so.2 /lib/libresolv.so.2 /lib/libgpg-error.so.0 /usr/lib/libkrb5.so.3 /usr/lib/libk5crypto.so.3 /usr/lib/libcom_err.so.2 /usr/lib/libkrb5support.so.0 /lib/
-COPY --from=builder /lib/libyaml-0.so.2 /lib/libsystemd.so.0 /lib/libm.so.6 /lib/libgcc_s.so.1 /lib/liblzma.so.5 /lib/liblz4.so.1 /lib/libcap.so.2 /lib/libgcrypt.so.20 /lib/libgpg-error.so.0 /lib/
 # telegraf dependencies
 COPY --from=builder /lib/libc.so.6 /lib/
 # mdsd dependencies

--- a/otelcollector/build/linux/Dockerfile
+++ b/otelcollector/build/linux/Dockerfile
@@ -45,6 +45,16 @@ ENV OS_TYPE "linux"
 ENV tmpdir /opt
 # Below is for ContainerInsightsPrometheusCollector-Prod AppInsights Resource
 ENV APPLICATIONINSIGHTS_AUTH MWNkYTMxMTItYWY1Ni00ZmNiLWI4MDQtZjg5NDVhYTFjYjMy
+# Below is for ContainerInsightsPrometheusCollector-Prod AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_PUBLIC MWNkYTMxMTItYWY1Ni00ZmNiLWI4MDQtZjg5NDVhYTFjYjMy
+# Below is for ContainerInsightsPrometheusCollector-Fairfax AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_USGOVERNMENT ZmRjMTE0MmUtY2U0YS1mNTFmLWE4M2EtODBjM2ZjNDYwNGE5
+# Below is for ContainerInsightsPrometheusCollector-Mooncake AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_CHINACLOUD ZTcyY2ZjOTYtNjY3Zi1jZGYwLTkwOWMtNzhiZjAwZjQ0NDg4
+# Below is for ContainerInsightsPrometheusCollector-USSec AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_USSEC ZTg4MzFlZGYtNWQ1ZC0wYjZmLTk3MGUtNDkxNTgyYjliMDFl
+# Below is for ContainerInsightsPrometheusCollector-USNat AppInsights Resource
+ENV APPLICATIONINSIGHTS_AUTH_USNAT ZTliNjRmZmUtZDZlYi0xYjczLThjYWQtNDU2OTFjN2FhNzIw
 ENV TELEMETRY_DISABLED false
 # Needed for ME, see https://github.com/microsoft/cpprestsdk/issues/1481
 ENV MALLOC_ARENA_MAX=2

--- a/otelcollector/build/windows/scripts/setup.ps1
+++ b/otelcollector/build/windows/scripts/setup.ps1
@@ -31,7 +31,7 @@ Write-Host ('Installing Fluent Bit');
 try {
     # Keep version in sync with linux in setup.sh file
     # $fluentBitUri = 'https://github.com/microsoft/OMS-docker/releases/download/winakslogagent/td-agent-bit-1.4.0-win64.zip'
-    $fluentBitUri = 'https://fluentbit.io/releases/2.0/fluent-bit-2.0.9-win64.zip'
+    $fluentBitUri = 'https://releases.fluentbit.io/2.1/fluent-bit-2.1.10-win64.zip'
     Invoke-WebRequest -Uri $fluentBitUri -OutFile /installation/fluent-bit.zip
     Expand-Archive -Path /installation/fluent-bit.zip -Destination /installation/fluent-bit
     Move-Item -Path /installation/fluent-bit/*/bin/* -Destination /opt/fluent-bit/bin/ -ErrorAction SilentlyContinue

--- a/otelcollector/fluent-bit/fluent-bit-windows.conf
+++ b/otelcollector/fluent-bit/fluent-bit-windows.conf
@@ -10,7 +10,7 @@
 [INPUT]
     Name tail
     Tag prometheus.log.prometheuscollectorcontainer
-    Path C:\\var\\log\\containers\\*prometheus-collector-win*.log
+    Path C:\\var\\log\\containers\\*ama-metrics*prometheus-collector*.log
     DB C:\\opt\\state\\prometheus-collector-win-ai.db
     DB.Sync Off
     Parser cri
@@ -24,7 +24,7 @@
 [INPUT]
     Name tail
     Tag prometheus.log.addontokenadapter
-    Path C:\\var\\log\\containers\\*prometheus-collector-win*addon-token-adapter-win*.log,C:\\var\\log\\containers\\*ama-metrics*addon-token-adapter-win*.log
+    Path C:\\var\\log\\containers\\*ama-metrics*addon-token-adapter-win*.log
     DB C:\\opt\\state\\addon-token-adapter.db
     DB.Sync Off
     Parser cri

--- a/otelcollector/fluent-bit/src/out_appinsights.go
+++ b/otelcollector/fluent-bit/src/out_appinsights.go
@@ -43,7 +43,7 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 		go SendCoreCountToAppInsightsMetrics()
 	}
 
-	if strings.ToLower(os.Getenv(envControllerType)) == "daemonset" && strings.ToLower(os.Getenv("OS_TYPE")) == "linux" {
+	if strings.ToLower(os.Getenv(envControllerType)) == "daemonset" {
 		go SendContainersCpuMemoryToAppInsightsMetrics()
 	}
 

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -437,6 +437,7 @@ func SendContainersCpuMemoryToAppInsightsMetrics() {
 	for ; true; <-ksmTelemetryTicker.C {
 		for podId := 0; podId < len(p.Pods); podId++ {
 			PodRefName := strings.TrimSpace(p.Pods[podId].PodRef.PodRefName)
+			fmt.Printf("PodRefName: %s", PodRefName)
 			for containerId := 0; containerId < len(p.Pods[podId].Containers); containerId++ {
 				container := p.Pods[podId].Containers[containerId]
 				containerName := strings.TrimSpace(container.Name)
@@ -652,74 +653,77 @@ func PushMEProcessedAndReceivedCountToAppInsightsMetrics() {
 			if DefaultPrometheusConfig != "" {
 				metric.Properties["DefaultPrometheusConfig"] = DefaultPrometheusConfig
 			}
-			if KubeletKeepListRegex != "" {
-				metric.Properties["KubeletKeepListRegex"] = KubeletKeepListRegex
-			}
-			if CoreDNSKeepListRegex != "" {
-				metric.Properties["CoreDNSKeepListRegex"] = CoreDNSKeepListRegex
-			}
-			if CAdvisorKeepListRegex != "" {
-				metric.Properties["CAdvisorKeepListRegex"] = CAdvisorKeepListRegex
-			}
-			if KubeProxyKeepListRegex != "" {
-				metric.Properties["KubeProxyKeepListRegex"] = KubeProxyKeepListRegex
-			}
-			if ApiServerKeepListRegex != "" {
-				metric.Properties["ApiServerKeepListRegex"] = ApiServerKeepListRegex
-			}
-			if KubeStateKeepListRegex != "" {
-				metric.Properties["KubeStateKeepListRegex"] = KubeStateKeepListRegex
-			}
-			if NodeExporterKeepListRegex != "" {
-				metric.Properties["NodeExporterKeepListRegex"] = NodeExporterKeepListRegex
-			}
-			if WinExporterKeepListRegex != "" {
-				metric.Properties["WinExporterKeepListRegex"] = WinExporterKeepListRegex
-			}
-			if WinKubeProxyKeepListRegex != "" {
-				metric.Properties["WinKubeProxyKeepListRegex"] = WinKubeProxyKeepListRegex
-			}
-			if PodannotationKeepListRegex != "" {
-				metric.Properties["PodannotationKeepListRegex"] = PodannotationKeepListRegex
-			}
-			if KappieBasicKeepListRegex != "" {
-				metric.Properties["KappieBasicKeepListRegex"] = KappieBasicKeepListRegex
-			}
-			if KubeletScrapeInterval != "" {
-				metric.Properties["KubeletScrapeInterval"] = KubeletScrapeInterval
-			}
-			if CoreDNSScrapeInterval != "" {
-				metric.Properties["CoreDNSScrapeInterval"] = CoreDNSScrapeInterval
-			}
-			if CAdvisorScrapeInterval != "" {
-				metric.Properties["CAdvisorScrapeInterval"] = CAdvisorScrapeInterval
-			}
-			if KubeProxyScrapeInterval != "" {
-				metric.Properties["KubeProxyScrapeInterval"] = KubeProxyScrapeInterval
-			}
-			if ApiServerScrapeInterval != "" {
-				metric.Properties["ApiServerScrapeInterval"] = ApiServerScrapeInterval
-			}
-			if KubeStateScrapeInterval != "" {
-				metric.Properties["KubeStateScrapeInterval"] = KubeStateScrapeInterval
-			}
-			if NodeExporterScrapeInterval != "" {
-				metric.Properties["NodeExporterScrapeInterval"] = NodeExporterScrapeInterval
-			}
-			if WinExporterScrapeInterval != "" {
-				metric.Properties["WinExporterScrapeInterval"] = WinExporterScrapeInterval
-			}
-			if WinKubeProxyScrapeInterval != "" {
-				metric.Properties["WinKubeProxyScrapeInterval"] = WinKubeProxyScrapeInterval
-			}
-			if PromHealthScrapeInterval != "" {
-				metric.Properties["PromHealthScrapeInterval"] = PromHealthScrapeInterval
-			}
-			if PodAnnotationScrapeInterval != "" {
-				metric.Properties["PodAnnotationScrapeInterval"] = PodAnnotationScrapeInterval
-			}
-			if KappieBasicScrapeInterval != "" {
-				metric.Properties["KappieBasicScrapeInterval"] = KappieBasicScrapeInterval
+
+			if os.Getenv(envControllerType) == "ReplicaSet" {
+				if KubeletKeepListRegex != "" {
+					metric.Properties["KubeletKeepListRegex"] = KubeletKeepListRegex
+				}
+				if CoreDNSKeepListRegex != "" {
+					metric.Properties["CoreDNSKeepListRegex"] = CoreDNSKeepListRegex
+				}
+				if CAdvisorKeepListRegex != "" {
+					metric.Properties["CAdvisorKeepListRegex"] = CAdvisorKeepListRegex
+				}
+				if KubeProxyKeepListRegex != "" {
+					metric.Properties["KubeProxyKeepListRegex"] = KubeProxyKeepListRegex
+				}
+				if ApiServerKeepListRegex != "" {
+					metric.Properties["ApiServerKeepListRegex"] = ApiServerKeepListRegex
+				}
+				if KubeStateKeepListRegex != "" {
+					metric.Properties["KubeStateKeepListRegex"] = KubeStateKeepListRegex
+				}
+				if NodeExporterKeepListRegex != "" {
+					metric.Properties["NodeExporterKeepListRegex"] = NodeExporterKeepListRegex
+				}
+				if WinExporterKeepListRegex != "" {
+					metric.Properties["WinExporterKeepListRegex"] = WinExporterKeepListRegex
+				}
+				if WinKubeProxyKeepListRegex != "" {
+					metric.Properties["WinKubeProxyKeepListRegex"] = WinKubeProxyKeepListRegex
+				}
+				if PodannotationKeepListRegex != "" {
+					metric.Properties["PodannotationKeepListRegex"] = PodannotationKeepListRegex
+				}
+				if KappieBasicKeepListRegex != "" {
+					metric.Properties["KappieBasicKeepListRegex"] = KappieBasicKeepListRegex
+				}
+				if KubeletScrapeInterval != "" {
+					metric.Properties["KubeletScrapeInterval"] = KubeletScrapeInterval
+				}
+				if CoreDNSScrapeInterval != "" {
+					metric.Properties["CoreDNSScrapeInterval"] = CoreDNSScrapeInterval
+				}
+				if CAdvisorScrapeInterval != "" {
+					metric.Properties["CAdvisorScrapeInterval"] = CAdvisorScrapeInterval
+				}
+				if KubeProxyScrapeInterval != "" {
+					metric.Properties["KubeProxyScrapeInterval"] = KubeProxyScrapeInterval
+				}
+				if ApiServerScrapeInterval != "" {
+					metric.Properties["ApiServerScrapeInterval"] = ApiServerScrapeInterval
+				}
+				if KubeStateScrapeInterval != "" {
+					metric.Properties["KubeStateScrapeInterval"] = KubeStateScrapeInterval
+				}
+				if NodeExporterScrapeInterval != "" {
+					metric.Properties["NodeExporterScrapeInterval"] = NodeExporterScrapeInterval
+				}
+				if WinExporterScrapeInterval != "" {
+					metric.Properties["WinExporterScrapeInterval"] = WinExporterScrapeInterval
+				}
+				if WinKubeProxyScrapeInterval != "" {
+					metric.Properties["WinKubeProxyScrapeInterval"] = WinKubeProxyScrapeInterval
+				}
+				if PromHealthScrapeInterval != "" {
+					metric.Properties["PromHealthScrapeInterval"] = PromHealthScrapeInterval
+				}
+				if PodAnnotationScrapeInterval != "" {
+					metric.Properties["PodAnnotationScrapeInterval"] = PodAnnotationScrapeInterval
+				}
+				if KappieBasicScrapeInterval != "" {
+					metric.Properties["KappieBasicScrapeInterval"] = KappieBasicScrapeInterval
+				}
 			}
 
 			TelemetryClient.Track(metric)

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -436,8 +436,8 @@ func SendContainersCpuMemoryToAppInsightsMetrics() {
 	ksmTelemetryTicker := time.NewTicker(time.Second * time.Duration(ksmAttachedTelemetryIntervalSeconds))
 	for ; true; <-ksmTelemetryTicker.C {
 		for podId := 0; podId < len(p.Pods); podId++ {
-			PodRefName := strings.TrimSpace(p.Pods[podId].PodRef.PodRefName)
-			fmt.Printf("PodRefName: %s", PodRefName)
+			podRefName := strings.TrimSpace(p.Pods[podId].PodRef.PodRefName)
+			Log(fmt.Printf("PodRefName: %s\n", podRefName))
 			for containerId := 0; containerId < len(p.Pods[podId].Containers); containerId++ {
 				container := p.Pods[podId].Containers[containerId]
 				containerName := strings.TrimSpace(container.Name)
@@ -448,22 +448,22 @@ func SendContainersCpuMemoryToAppInsightsMetrics() {
 					Log(message)
 					continue
 				case "ama-metrics-ksm":
-					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, ksmCpuMemoryTelemetryName, "MemKsmRssBytes", PodRefName)
+					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, ksmCpuMemoryTelemetryName, "MemKsmRssBytes", podRefName)
 				case "targetallocator":
-					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "taCPUUsage", "taMemRssBytes", PodRefName)
+					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "taCPUUsage", "taMemRssBytes", podRefName)
 				case "config-reader":
-					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "cnfgRdrCPUUsage", "cnfgRdrMemRssBytes", PodRefName)
+					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "cnfgRdrCPUUsage", "cnfgRdrMemRssBytes", podRefName)
 				case "addon-token-adapter":
-					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "adnTknAdtrCPUUsage", "adnTknAdtrMemRssBytes", PodRefName)
+					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "adnTknAdtrCPUUsage", "adnTknAdtrMemRssBytes", podRefName)
 				case "prometheus-collector":
-					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "promColCPUUsage", "promColMemRssBytes", PodRefName)
+					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "promColCPUUsage", "promColMemRssBytes", podRefName)
 				}
 			}
 		}
 	}
 }
 
-func GetAndSendContainerCPUandMemoryFromCadvisorJSON(container Container, cpuMetricName string, memMetricName string, PodRefName string) {
+func GetAndSendContainerCPUandMemoryFromCadvisorJSON(container Container, cpuMetricName string, memMetricName string, podRefName string) {
 	cpuUsageNanoCoresLinux := container.Cpu.UsageNanoCores
 	memoryRssBytesLinux := container.Memory.RssBytes
 
@@ -473,10 +473,11 @@ func GetAndSendContainerCPUandMemoryFromCadvisorJSON(container Container, cpuMet
 	// Abbreviated properties to save telemetry cost
 	metricTelemetryItem.Properties[memMetricName] = fmt.Sprintf("%d", int(memoryRssBytesLinux))
 	// Adding the actual pod name from Cadvisor output since the podname environment variable points to the pod on which plugin is running
-	metricTelemetryItem.Properties["PodRefName"] = fmt.Sprintf("%s", PodRefName)
+	metricTelemetryItem.Properties["PodRefName"] = fmt.Sprintf("%s", podRefName)
 
 	TelemetryClient.Track(metricTelemetryItem)
 
+	Log(fmt.Printf("PodRefName: %s\n", podRefName))
 	Log(fmt.Sprintf("Sent container CPU and Mem data for %s", cpuMetricName))
 }
 

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -437,7 +437,6 @@ func SendContainersCpuMemoryToAppInsightsMetrics() {
 	for ; true; <-ksmTelemetryTicker.C {
 		for podId := 0; podId < len(p.Pods); podId++ {
 			podRefName := strings.TrimSpace(p.Pods[podId].PodRef.PodRefName)
-			Log(fmt.Sprintf("PodRefName: %s\n", podRefName))
 			for containerId := 0; containerId < len(p.Pods[podId].Containers); containerId++ {
 				container := p.Pods[podId].Containers[containerId]
 				containerName := strings.TrimSpace(container.Name)
@@ -479,7 +478,6 @@ func GetAndSendContainerCPUandMemoryFromCadvisorJSON(container Container, cpuMet
 
 	TelemetryClient.Track(metricTelemetryItem)
 
-	Log(fmt.Sprintf("PodRefName: %s\n", podRefName))
 	Log(fmt.Sprintf("Sent container CPU and Mem data for %s", cpuMetricName))
 }
 

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -455,6 +455,8 @@ func SendContainersCpuMemoryToAppInsightsMetrics() {
 					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "cnfgRdrCPUUsage", "cnfgRdrMemRssBytes", podRefName)
 				case "addon-token-adapter":
 					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "adnTknAdtrCPUUsage", "adnTknAdtrMemRssBytes", podRefName)
+				case "addon-token-adapter-win":
+					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "adnTknAdtrCPUUsage", "adnTknAdtrMemRssBytes", podRefName)
 				case "prometheus-collector":
 					GetAndSendContainerCPUandMemoryFromCadvisorJSON(container, "promColCPUUsage", "promColMemRssBytes", podRefName)
 				}

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -437,7 +437,7 @@ func SendContainersCpuMemoryToAppInsightsMetrics() {
 	for ; true; <-ksmTelemetryTicker.C {
 		for podId := 0; podId < len(p.Pods); podId++ {
 			podRefName := strings.TrimSpace(p.Pods[podId].PodRef.PodRefName)
-			Log(fmt.Printf("PodRefName: %s\n", podRefName))
+			Log(fmt.Sprintf("PodRefName: %s\n", podRefName))
 			for containerId := 0; containerId < len(p.Pods[podId].Containers); containerId++ {
 				container := p.Pods[podId].Containers[containerId]
 				containerName := strings.TrimSpace(container.Name)
@@ -477,7 +477,7 @@ func GetAndSendContainerCPUandMemoryFromCadvisorJSON(container Container, cpuMet
 
 	TelemetryClient.Track(metricTelemetryItem)
 
-	Log(fmt.Printf("PodRefName: %s\n", podRefName))
+	Log(fmt.Sprintf("PodRefName: %s\n", podRefName))
 	Log(fmt.Sprintf("Sent container CPU and Mem data for %s", cpuMetricName))
 }
 

--- a/otelcollector/scripts/setup.sh
+++ b/otelcollector/scripts/setup.sh
@@ -57,7 +57,7 @@ sudo tdnf list installed | grep telegraf | awk '{print $2}' > telegrafversion.tx
 
 # Install fluent-bit
 echo "Installing fluent-bit..."
-sudo tdnf install fluent-bit-2.0.9 -y
+sudo tdnf install fluent-bit-2.1.10 -y
 
 # Setup hourly cron for logrotate
 cp /etc/cron.daily/logrotate /etc/cron.hourly/


### PR DESCRIPTION
- Add new .so files for upgraded fluent-bit
- Fix container log collection path for Windows
- Add Windows container CPU and memory usage telemetry for prometheus-collector and addon-token-adapter-win containers
- Only send keeplistregex and scrapeinterval telemetry from the replicaset since these env vars are the same no matter if it's on the daemonset or replicaset
- Add app insights key env var in Dockerfile to non-distroless build for whenever building without the distroless image
- Fix bug in build for image check before deploying to the dev clusters