### PR TITLE
fix (ccp) : Relabel host for Control Plane Metrics

### DIFF
--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,6 +36,23 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
+    # Generate host alias
+    - source_labels: [ host ]
+      action: hashmod
+      regex: (.+)
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hostalias
+    - source_labels: [ host ]
+      regex: ^(localhost|\[::1\]):443$
+      target_label: hostalias
+      replacement: kube-apiserver
+    # Replace the host with hostalias
+    - source_labels: [ hostalias, host ]
+      regex: ^(.+);(.+)$
+      action: replace
+      target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_cluster_autoscaler.yml
@@ -45,6 +45,23 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
+    # Generate host alias
+    - source_labels: [ host ]
+      action: hashmod
+      regex: ^(.+)$
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hostalias
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver
+    # Replace the host with hostalias
+    - source_labels: [ hostalias, host ]
+      regex: ^(.+);(.+)$
+      action: replace
+      target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_etcd.yml
@@ -43,6 +43,23 @@ scrape_configs:
       action: drop
       regex: (etcd2-.*)
   metric_relabel_configs:
+    # Generate host alias
+    - source_labels: [ host ]
+      action: hashmod
+      regex: ^(.+)$
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hostalias
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver
+    # Replace the host with hostalias
+    - source_labels: [ hostalias, host ]
+      regex: ^(.+);(.+)$
+      action: replace
+      target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_controller_manager.yml
@@ -46,6 +46,23 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
+    # Generate host alias
+    - source_labels: [ host ]
+      action: hashmod
+      regex: ^(.+)$
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hostalias
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver
+    # Replace the host with hostalias
+    - source_labels: [ hostalias, host ]
+      regex: ^(.+);(.+)$
+      action: replace
+      target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_kube_scheduler.yml
@@ -46,6 +46,23 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
+    # Generate host alias
+    - source_labels: [ host ]
+      action: hashmod
+      regex: ^(.+)$
+      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
+      target_label: hostalias
+    - source_labels: [ host ]
+      regex: ^hcp-kubernetes.*.svc.cluster.local:443$
+      target_label: hostalias
+      replacement: kube-apiserver
+    # Replace the host with hostalias
+    - source_labels: [ hostalias, host ]
+      regex: ^(.+);(.+)$
+      action: replace
+      target_label: host
     - source_labels: [ __name__ ]
       action: drop
       regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    - action: labeldrop
+      regex: hostalias

--- a/otelcollector/shared/file_utilities.go
+++ b/otelcollector/shared/file_utilities.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -24,7 +23,7 @@ func printMdsdVersion() {
 }
 
 func readVersionFile(filePath string) (string, error) {
-	content, err := ioutil.ReadFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", err
 	}
@@ -32,7 +31,7 @@ func readVersionFile(filePath string) (string, error) {
 }
 
 func fmtVar(name, value string) {
-	fmt.Printf("%s=\"%s\"\n", name, value)
+	fmt.Printf("%s=\"%s\"\n", name, strings.TrimRight(value, "\n\r"))
 }
 
 func existsAndNotEmpty(filename string) bool {
@@ -50,7 +49,7 @@ func existsAndNotEmpty(filename string) bool {
 }
 
 func readAndTrim(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

Add a relabel for host to control plane metrics

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
