### PR TITLE
Add life cycle metadata to container image

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - AddLifeCycleImage
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -404,6 +404,9 @@ stages:
             --artifact-type 'application/vnd.cncf.notary.signature' \
             ./payload.json:application/cose \
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
+          oras attach $(LINUX_FULL_IMAGE_NAME) \
+            --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+30 days' +"%Y-%m-%dT%H:%M:%SZ")"
         workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -568,6 +571,9 @@ stages:
             --artifact-type 'application/vnd.cncf.notary.signature' \
             ./payload.json:application/cose \
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
+          oras attach $(LINUX_CCP_FULL_IMAGE_NAME) \
+            --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+30 days' +"%Y-%m-%dT%H:%M:%SZ")"            
         workingDirectory: $(Build.ArtifactStagingDirectory)/linuxccp/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linuxccp/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -716,6 +722,9 @@ stages:
             --artifact-type 'application/vnd.cncf.notary.signature' \
             ./payload.json:application/cose \
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
+          oras attach $(TARGET_ALLOCATOR_FULL_IMAGE_NAME) \
+            --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+30 days' +"%Y-%m-%dT%H:%M:%SZ")"                
         workingDirectory: $(Build.ArtifactStagingDirectory)/targetallocator/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/targetallocator/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -793,6 +802,9 @@ stages:
             --artifact-type 'application/vnd.cncf.notary.signature' \
             ./payload.json:application/cose \
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
+          oras attach $(LINUX_CONFIG_READER_FULL_IMAGE_NAME) \
+            --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+30 days' +"%Y-%m-%dT%H:%M:%SZ")"              
         workingDirectory: $(Build.ArtifactStagingDirectory)/linuxcfgreader/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linuxcfgreader/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -1005,6 +1017,9 @@ stages:
           Copy-Item -Path $currentDirectory\oras.exe -Destination "$env:USERPROFILE\bin\"
           $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
           oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\""79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\""]
+          oras attach $(WINDOWS_FULL_IMAGE_NAME) \
+            --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddDays(30).ToString('yyyy-MM-ddTHH:mm:ssZ')")"          
         workingDirectory: $(Build.ArtifactStagingDirectory)/windows
         displayName: "Download, install Oras and run oras attach"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - AddLifeCycleImage
 
 pr:
   autoCancel: true

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -407,7 +407,7 @@ stages:
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
           oras attach $(LINUX_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+30 days' +"%Y-%m-%dT%H:%M:%SZ")"
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+1 hour' +"%Y-%m-%dT%H:%M:%SZ")"
         workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -574,7 +574,7 @@ stages:
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
           oras attach $(LINUX_CCP_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+30 days' +"%Y-%m-%dT%H:%M:%SZ")"            
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+1 hour' +"%Y-%m-%dT%H:%M:%SZ")"            
         workingDirectory: $(Build.ArtifactStagingDirectory)/linuxccp/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linuxccp/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -725,7 +725,7 @@ stages:
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
           oras attach $(TARGET_ALLOCATOR_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+30 days' +"%Y-%m-%dT%H:%M:%SZ")"                
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+1 hour' +"%Y-%m-%dT%H:%M:%SZ")"                
         workingDirectory: $(Build.ArtifactStagingDirectory)/targetallocator/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/targetallocator/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -805,7 +805,7 @@ stages:
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
           oras attach $(LINUX_CONFIG_READER_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+30 days' +"%Y-%m-%dT%H:%M:%SZ")"              
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+1 hour' +"%Y-%m-%dT%H:%M:%SZ")"              
         workingDirectory: $(Build.ArtifactStagingDirectory)/linuxcfgreader/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linuxcfgreader/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -1020,7 +1020,7 @@ stages:
           oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\""79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\""]
           oras attach $(WINDOWS_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddDays(30).ToString('yyyy-MM-ddTHH:mm:ssZ')")"          
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"          
         workingDirectory: $(Build.ArtifactStagingDirectory)/windows
         displayName: "Download, install Oras and run oras attach"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -406,7 +406,7 @@ stages:
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
           oras attach $(LINUX_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+1 hour' +"%Y-%m-%dT%H:%M:%SZ")"
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"
         workingDirectory: $(Build.ArtifactStagingDirectory)/linux/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linux/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -573,7 +573,7 @@ stages:
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
           oras attach $(LINUX_CCP_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+1 hour' +"%Y-%m-%dT%H:%M:%SZ")"            
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"            
         workingDirectory: $(Build.ArtifactStagingDirectory)/linuxccp/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linuxccp/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -724,7 +724,7 @@ stages:
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
           oras attach $(TARGET_ALLOCATOR_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+1 hour' +"%Y-%m-%dT%H:%M:%SZ")"                
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"                
         workingDirectory: $(Build.ArtifactStagingDirectory)/targetallocator/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/targetallocator/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -804,7 +804,7 @@ stages:
             -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
           oras attach $(LINUX_CONFIG_READER_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '+1 hour' +"%Y-%m-%dT%H:%M:%SZ")"              
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"              
         workingDirectory: $(Build.ArtifactStagingDirectory)/linuxcfgreader/
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linuxcfgreader/"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))
@@ -1019,7 +1019,7 @@ stages:
           oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\""79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\""]
           oras attach $(WINDOWS_FULL_IMAGE_NAME) \
             --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"          
+            --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"          
         workingDirectory: $(Build.ArtifactStagingDirectory)/windows
         displayName: "Download, install Oras and run oras attach"
         condition: and(succeeded(), eq(variables.IS_MAIN_BRANCH, true))


### PR DESCRIPTION
This change adds life cycle metadata to the container image.

Followed this document: https://eng.ms/docs/more/containers-secure-supply-chain/lifecycle-and-lineage

This adds metadata end-of-life annotation at the image build time so that it does not get flagged later in downstream.