### PR TITLE
Infra: switch to managed identity for Arc extension version release

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - grace/arc-msi-release
 pr:
   autoCancel: true
   branches:
@@ -1407,7 +1408,7 @@ stages:
   jobs:
   - deployment: Deploy_Chart_ARC
     displayName: "Deploy: Arc dev cluster"
-    condition: and(succeeded(), and(and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)), or(not(succeeded('Deploy_Chart_ARC')), eq(variables['System.StageAttempt'], 1))))
+    #condition: and(succeeded(), and(and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)), or(not(succeeded('Deploy_Chart_ARC')), eq(variables['System.StageAttempt'], 1))))
     environment: Prometheus-Collector
     pool:
       name: Azure-Pipelines-CI-Test-EO
@@ -1418,69 +1419,71 @@ stages:
       runOnce:
         deploy:
           steps:
-          - bash: |
-              # Create JSON request body
-              cat <<EOF > "request.json"
-                {
-                  "artifactEndpoints": [
-                      {
-                          "Regions": [
-                              "westcentralus"
-                          ],
-                          "Releasetrains": [
-                              "pipeline"
-                          ],
-                          "FullPathToHelmChart": "https://mcr.microsoft.com/azuremonitor/containerinsights/cidev/ama-metrics-arc",
-                          "ExtensionUpdateFrequencyInMinutes": 5,
-                          "IsCustomerHidden": true,
-                          "ReadyforRollout": true,
-                          "RollbackVersion": null,
-                          "PackageConfigName": "Microsoft.AzureMonitor.Containers.Metrics-Prom041823"
-                      }
-                  ]
-                }
-              EOF
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: 'prometheus-arc-dev-release-mi'
+              scriptType: 'batch'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                # Create JSON request body
+                cat <<EOF > "request.json"
+                  {
+                    "artifactEndpoints": [
+                        {
+                            "Regions": [
+                                "westcentralus"
+                            ],
+                            "Releasetrains": [
+                                "pipeline"
+                            ],
+                            "FullPathToHelmChart": "https://mcr.microsoft.com/azuremonitor/containerinsights/cidev/ama-metrics-arc",
+                            "ExtensionUpdateFrequencyInMinutes": 5,
+                            "IsCustomerHidden": true,
+                            "ReadyforRollout": true,
+                            "RollbackVersion": null,
+                            "PackageConfigName": "Microsoft.AzureMonitor.Containers.Metrics-Prom041823"
+                        }
+                    ]
+                  }
+                EOF
 
-              # Send Request
-              SUBSCRIPTION="b9842c7c-1a38-4385-8f39-a51314758bcf"
-              RESOURCE_AUDIENCE="c699bf69-fb1d-4eaf-999b-99e6b2ae4d85"
-              SPN_CLIENT_ID="9a4c55e9-576a-450a-88bd-53bd634db38d"
-              SPN_TENANT_ID="72f988bf-86f1-41af-91ab-2d7cd011db47"
-              METHOD="PUT"
+                # Send Request
+                SUBSCRIPTION="b9842c7c-1a38-4385-8f39-a51314758bcf"
+                RESOURCE_AUDIENCE="c699bf69-fb1d-4eaf-999b-99e6b2ae4d85"
+                METHOD="PUT"
 
-              echo "Request parameter preparation, SUBSCRIPTION is $SUBSCRIPTION, RESOURCE_AUDIENCE is $RESOURCE_AUDIENCE, CHART_VERSION is $HELM_SEMVER, SPN_CLIENT_ID is $SPN_CLIENT_ID, SPN_TENANT_ID is $SPN_TENANT_ID"
+                echo "Request parameter preparation, SUBSCRIPTION is $SUBSCRIPTION, RESOURCE_AUDIENCE is $RESOURCE_AUDIENCE, CHART_VERSION is $HELM_SEMVER"
 
-              # MSI is not supported
-              echo "Login cli using spn"
-              az login --service-principal --username=$SPN_CLIENT_ID --password=$(ARC_SPN_SECRET) --tenant=$SPN_TENANT_ID
-              if [ $? -eq 0 ]; then
-                echo "Logged in successfully with spn"
-              else
-                echo "-e error failed to login to az with managed identity credentials"
-                exit 1
-              fi
+                echo "Login cli using MSI"
+                az login --managed-identity
+                if [ $? -eq 0 ]; then
+                  echo "Logged in successfully with MSI"
+                else
+                  echo "-e error failed to login to az with managed identity credentials"
+                  exit 1
+                fi
 
-              ACCESS_TOKEN=$(az account get-access-token --resource $RESOURCE_AUDIENCE --query accessToken -o json)
-              if [ $? -eq 0 ]; then
-                echo "get access token from resource:$RESOURCE_AUDIENCE successfully."
-              else
-                echo "-e error get access token from resource:$RESOURCE_AUDIENCE failed."
-                exit 1
-              fi
-              ACCESS_TOKEN=$(echo $ACCESS_TOKEN | tr -d '"' | tr -d '"\r\n')
+                ACCESS_TOKEN=$(az account get-access-token --resource $RESOURCE_AUDIENCE --query accessToken -o json)
+                if [ $? -eq 0 ]; then
+                  echo "get access token from resource:$RESOURCE_AUDIENCE successfully."
+                else
+                  echo "-e error get access token from resource:$RESOURCE_AUDIENCE failed."
+                  exit 1
+                fi
+                ACCESS_TOKEN=$(echo $ACCESS_TOKEN | tr -d '"' | tr -d '"\r\n')
 
-              ARC_API_URL="https://eastus2euap.dp.kubernetesconfiguration.azure.com"
-              EXTENSION_NAME="microsoft.azuremonitor.containers.metrics"
-              API_VERSION="2021-05-01"
+                ARC_API_URL="https://eastus2euap.dp.kubernetesconfiguration.azure.com"
+                EXTENSION_NAME="microsoft.azuremonitor.containers.metrics"
+                API_VERSION="2021-05-01"
 
-              echo "start send request"
-              az rest --method $METHOD --headers "{\"Authorization\": \"Bearer $ACCESS_TOKEN\", \"Content-Type\": \"application/json\"}" --body @request.json --uri $ARC_API_URL/subscriptions/$SUBSCRIPTION/extensionTypeRegistrations/$EXTENSION_NAME/versions/$HELM_SEMVER?api-version=$API_VERSION
-              if [ $? -eq 0 ]; then
-                echo "arc extension registered successfully"
-              else
-                echo "-e error failed to register arc extension"
-                exit 1
-              fi
+                echo "start send request"
+                az rest --method $METHOD --headers "{\"Authorization\": \"Bearer $ACCESS_TOKEN\", \"Content-Type\": \"application/json\"}" --body @request.json --uri $ARC_API_URL/subscriptions/$SUBSCRIPTION/extensionTypeRegistrations/$EXTENSION_NAME/versions/$HELM_SEMVER?api-version=$API_VERSION
+                if [ $? -eq 0 ]; then
+                  echo "arc extension registered successfully"
+                else
+                  echo "-e error failed to register arc extension"
+                  exit 1
+                fi
             displayName: "Deploy: Release to dev release train"
 
           - task: AzureCLI@2

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2,7 +2,7 @@ trigger:
   branches:
     include:
     - main
-    - grace/arc-msi-release
+
 pr:
   autoCancel: true
   branches:
@@ -1115,243 +1115,243 @@ stages:
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linuxcfgreader/"
         condition: succeeded()
 
-  # - job: Windows2019_Prometheus_Collector
-  #   displayName: "Build: windows 2019 prometheus-collector image"
-  #   pool:
-  #     name: Azure-Pipelines-Windows-CI-Test-EO
-  #   timeoutInMinutes: 120
-  #   dependsOn:
-  #   - Image_Tags_and_Ev2_Artifacts
-  #   variables:
-  #     WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
-  #     WINDOWS_2019_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2019_BASE_IMAGE_VERSION'] ]
-  #     skipComponentGovernanceDetection: true
-  #   steps:
-  #     - task: GoTool@0
-  #       displayName: "Build: specify golang version"
-  #       inputs:
-  #         version: '1.20'
+  - job: Windows2019_Prometheus_Collector
+    displayName: "Build: windows 2019 prometheus-collector image"
+    pool:
+      name: Azure-Pipelines-Windows-CI-Test-EO
+    timeoutInMinutes: 120
+    dependsOn:
+    - Image_Tags_and_Ev2_Artifacts
+    variables:
+      WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
+      WINDOWS_2019_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2019_BASE_IMAGE_VERSION'] ]
+      skipComponentGovernanceDetection: true
+    steps:
+      - task: GoTool@0
+        displayName: "Build: specify golang version"
+        inputs:
+          version: '1.20'
 
-  #     - powershell: |
-  #         ./makefile_windows.ps1
-  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/opentelemetry-collector-builder/
-  #       displayName: "Build: build otelcollector, promconfigvalidator, and fluent-bit plugin"
+      - powershell: |
+          ./makefile_windows.ps1
+        workingDirectory: $(Build.SourcesDirectory)/otelcollector/opentelemetry-collector-builder/
+        displayName: "Build: build otelcollector, promconfigvalidator, and fluent-bit plugin"
 
-  #     - powershell: |
-  #         docker build . --isolation=hyperv --file ./build/windows/Dockerfile -t $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION) --build-arg WINDOWS_VERSION=$(WINDOWS_2019_BASE_IMAGE_VERSION)
-  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/
-  #       displayName: "Build: build WS2019 image"
-  #       retryCountOnTaskFailure: 2
+      - powershell: |
+          docker build . --isolation=hyperv --file ./build/windows/Dockerfile -t $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION) --build-arg WINDOWS_VERSION=$(WINDOWS_2019_BASE_IMAGE_VERSION)
+        workingDirectory: $(Build.SourcesDirectory)/otelcollector/
+        displayName: "Build: build WS2019 image"
+        retryCountOnTaskFailure: 2
 
-  #     - powershell: |
-  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-  #         docker push $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION)
-  #       displayName: "Build: push image to dev ACR"
+      - powershell: |
+          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+          docker push $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION)
+        displayName: "Build: push image to dev ACR"
 
-  # - job: Windows2022_Prometheus_Collector
-  #   displayName: "Build: windows 2022 prometheus-collector image"
-  #   pool:
-  #     name: Azure-Pipelines-Windows-CI-Test-EO
-  #   timeoutInMinutes: 120
-  #   dependsOn:
-  #   - Image_Tags_and_Ev2_Artifacts
-  #   variables:
-  #     WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
-  #     WINDOWS_2022_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2022_BASE_IMAGE_VERSION'] ]
-  #     skipComponentGovernanceDetection: true
-  #   steps:
-  #     - task: GoTool@0
-  #       displayName: "Build: specify golang version"
-  #       inputs:
-  #         version: '1.20'
+  - job: Windows2022_Prometheus_Collector
+    displayName: "Build: windows 2022 prometheus-collector image"
+    pool:
+      name: Azure-Pipelines-Windows-CI-Test-EO
+    timeoutInMinutes: 120
+    dependsOn:
+    - Image_Tags_and_Ev2_Artifacts
+    variables:
+      WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
+      WINDOWS_2022_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2022_BASE_IMAGE_VERSION'] ]
+      skipComponentGovernanceDetection: true
+    steps:
+      - task: GoTool@0
+        displayName: "Build: specify golang version"
+        inputs:
+          version: '1.20'
 
-  #     - powershell: |
-  #         ./makefile_windows.ps1
-  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/opentelemetry-collector-builder/
-  #       displayName: "Build: build otelcollector, promconfigvalidator, and fluent-bit plugin"
+      - powershell: |
+          ./makefile_windows.ps1
+        workingDirectory: $(Build.SourcesDirectory)/otelcollector/opentelemetry-collector-builder/
+        displayName: "Build: build otelcollector, promconfigvalidator, and fluent-bit plugin"
 
-  #     - powershell: |
-  #         docker build . --isolation=hyperv --file ./build/windows/Dockerfile -t $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION) --build-arg WINDOWS_VERSION=$(WINDOWS_2022_BASE_IMAGE_VERSION)
-  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/
-  #       displayName: "Build: build WS2022 image"
-  #       retryCountOnTaskFailure: 2
+      - powershell: |
+          docker build . --isolation=hyperv --file ./build/windows/Dockerfile -t $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION) --build-arg WINDOWS_VERSION=$(WINDOWS_2022_BASE_IMAGE_VERSION)
+        workingDirectory: $(Build.SourcesDirectory)/otelcollector/
+        displayName: "Build: build WS2022 image"
+        retryCountOnTaskFailure: 2
 
-  #     - powershell: |
-  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-  #         docker push $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
-  #       displayName: "Build: push image to dev ACR"
+      - powershell: |
+          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+          docker push $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
+        displayName: "Build: push image to dev ACR"
 
-  # - job: WindowsMultiArch_Prometheus_Collector
-  #   displayName: "Build: windows multi-arch prometheus-collector image"
-  #   pool:
-  #     name: Azure-Pipelines-Windows-CI-Test-EO
-  #   timeoutInMinutes: 120
-  #   dependsOn:
-  #   - Image_Tags_and_Ev2_Artifacts
-  #   - Windows2019_Prometheus_Collector
-  #   - Windows2022_Prometheus_Collector
-  #   variables:
-  #     WINDOWS_IMAGE_TAG: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_IMAGE_TAG'] ]
-  #     WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
-  #     WINDOWS_2019_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2019_BASE_IMAGE_VERSION'] ]
-  #     WINDOWS_2022_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2022_BASE_IMAGE_VERSION'] ]
-  #     skipComponentGovernanceDetection: true
-  #   steps:
-  #     - task: GoTool@0
-  #       displayName: "Build: specify golang version"
-  #       inputs:
-  #         version: '1.20'
+  - job: WindowsMultiArch_Prometheus_Collector
+    displayName: "Build: windows multi-arch prometheus-collector image"
+    pool:
+      name: Azure-Pipelines-Windows-CI-Test-EO
+    timeoutInMinutes: 120
+    dependsOn:
+    - Image_Tags_and_Ev2_Artifacts
+    - Windows2019_Prometheus_Collector
+    - Windows2022_Prometheus_Collector
+    variables:
+      WINDOWS_IMAGE_TAG: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_IMAGE_TAG'] ]
+      WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
+      WINDOWS_2019_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2019_BASE_IMAGE_VERSION'] ]
+      WINDOWS_2022_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2022_BASE_IMAGE_VERSION'] ]
+      skipComponentGovernanceDetection: true
+    steps:
+      - task: GoTool@0
+        displayName: "Build: specify golang version"
+        inputs:
+          version: '1.20'
 
-  #     - bash: |
-  #         export ACR_REPOSITORY_VAR="$(ACR_REPOSITORY)"
-  #         export ACR_REPOSITORY_WITHOUT_SLASH="${ACR_REPOSITORY_VAR:1}"
+      - bash: |
+          export ACR_REPOSITORY_VAR="$(ACR_REPOSITORY)"
+          export ACR_REPOSITORY_WITHOUT_SLASH="${ACR_REPOSITORY_VAR:1}"
 
-  #         export WINDOWS_2019_TAG="$(WINDOWS_IMAGE_TAG)-$(WINDOWS_2019_BASE_IMAGE_VERSION)"
-  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-  #         docker pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION)
-  #         if [ $? -ne 0 ]; then
-  #           echo "Failed to pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION). Checking if MCR image is published."
-  #           IMAGES_ARE_PUBLISHED=0
-  #           for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
-  #             do
-  #               output=$(curl -s https://$(MCR_REGISTRY)/v2$(MCR_REPOSITORY)/tags/list)
-  #               if (echo $output | grep $WINDOWS_2019_TAG)
-  #               then
-  #                 echo "Images are published to mcr"
-  #                 IMAGES_ARE_PUBLISHED=1
-  #                 break
-  #               fi
-  #               sleep 30
-  #             done
-  #           if [ IMAGES_ARE_PUBLISHED -eq 0 ]; then
-  #             echo "Images are not published to mcr within the timeout"
-  #             exit 1
-  #           fi
+          export WINDOWS_2019_TAG="$(WINDOWS_IMAGE_TAG)-$(WINDOWS_2019_BASE_IMAGE_VERSION)"
+          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+          docker pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION)
+          if [ $? -ne 0 ]; then
+            echo "Failed to pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION). Checking if MCR image is published."
+            IMAGES_ARE_PUBLISHED=0
+            for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+              do
+                output=$(curl -s https://$(MCR_REGISTRY)/v2$(MCR_REPOSITORY)/tags/list)
+                if (echo $output | grep $WINDOWS_2019_TAG)
+                then
+                  echo "Images are published to mcr"
+                  IMAGES_ARE_PUBLISHED=1
+                  break
+                fi
+                sleep 30
+              done
+            if [ IMAGES_ARE_PUBLISHED -eq 0 ]; then
+              echo "Images are not published to mcr within the timeout"
+              exit 1
+            fi
 
-  #           az acr import --name $(ACR_REGISTRY) --source $(MCR_REGISTRY)$(MCR_REPOSITORY):$(IMAGE_TAG) --image $(ACR_REPOSITORY_WITHOUT_SLASH):$(WINDOWS_2019_TAG)
-  #         fi
+            az acr import --name $(ACR_REGISTRY) --source $(MCR_REGISTRY)$(MCR_REPOSITORY):$(IMAGE_TAG) --image $(ACR_REPOSITORY_WITHOUT_SLASH):$(WINDOWS_2019_TAG)
+          fi
 
-  #         export WINDOWS_2022_TAG="$(WINDOWS_IMAGE_TAG)-$(WINDOWS_2022_BASE_IMAGE_VERSION)"
-  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-  #         docker pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
-  #         if [ $? -ne 0 ]; then
-  #           echo "Failed to pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION). Checking if MCR image is published."
-  #           IMAGES_ARE_PUBLISHED=0
-  #           for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
-  #             do
-  #               output=$(curl -s https://$(MCR_REGISTRY)/v2$(MCR_REPOSITORY)/tags/list)
-  #               if (echo $output | grep $WINDOWS_2022_TAG)
-  #               then
-  #                 echo "Images are published to mcr"
-  #                 IMAGES_ARE_PUBLISHED=1
-  #                 break
-  #               fi
-  #               sleep 30
-  #             done
-  #           if [ IMAGES_ARE_PUBLISHED -eq 0 ]; then
-  #             echo "Images are not published to mcr within the timeout"
-  #             exit 1
-  #           fi
+          export WINDOWS_2022_TAG="$(WINDOWS_IMAGE_TAG)-$(WINDOWS_2022_BASE_IMAGE_VERSION)"
+          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+          docker pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
+          if [ $? -ne 0 ]; then
+            echo "Failed to pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION). Checking if MCR image is published."
+            IMAGES_ARE_PUBLISHED=0
+            for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+              do
+                output=$(curl -s https://$(MCR_REGISTRY)/v2$(MCR_REPOSITORY)/tags/list)
+                if (echo $output | grep $WINDOWS_2022_TAG)
+                then
+                  echo "Images are published to mcr"
+                  IMAGES_ARE_PUBLISHED=1
+                  break
+                fi
+                sleep 30
+              done
+            if [ IMAGES_ARE_PUBLISHED -eq 0 ]; then
+              echo "Images are not published to mcr within the timeout"
+              exit 1
+            fi
 
-  #           az acr import --name $(ACR_REGISTRY) --source $(MCR_REGISTRY)$(MCR_REPOSITORY):$(IMAGE_TAG) --image $(ACR_REPOSITORY_WITHOUT_SLASH):$(WINDOWS_2022_TAG)
-  #         fi
-  #       displayName: "Build: ensure images are present in ACR"
-  #       retryCountOnTaskFailure: 3
+            az acr import --name $(ACR_REGISTRY) --source $(MCR_REGISTRY)$(MCR_REPOSITORY):$(IMAGE_TAG) --image $(ACR_REPOSITORY_WITHOUT_SLASH):$(WINDOWS_2022_TAG)
+          fi
+        displayName: "Build: ensure images are present in ACR"
+        retryCountOnTaskFailure: 3
 
-  #     - powershell: |
-  #         New-Item -Path "$(Build.ArtifactStagingDirectory)" -Name "windows" -ItemType "directory"
-  #         @{"image.name"="$(WINDOWS_FULL_IMAGE_NAME)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
-  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-  #         docker manifest create $(WINDOWS_FULL_IMAGE_NAME) $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION) $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
-  #         docker manifest push $(WINDOWS_FULL_IMAGE_NAME)
-  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/
-  #       displayName: "Build: Windows multi-arch manifest"
+      - powershell: |
+          New-Item -Path "$(Build.ArtifactStagingDirectory)" -Name "windows" -ItemType "directory"
+          @{"image.name"="$(WINDOWS_FULL_IMAGE_NAME)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
+          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+          docker manifest create $(WINDOWS_FULL_IMAGE_NAME) $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION) $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
+          docker manifest push $(WINDOWS_FULL_IMAGE_NAME)
+        workingDirectory: $(Build.SourcesDirectory)/otelcollector/
+        displayName: "Build: Windows multi-arch manifest"
 
-  #     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  #       condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
-  #       displayName: "Ev2: generate image artifacts"
-  #       inputs:
-  #         BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-  #         DockerImagesToScan: '$(WINDOWS_FULL_IMAGE_NAME)'
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
+        displayName: "Ev2: generate image artifacts"
+        inputs:
+          BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
+          DockerImagesToScan: '$(WINDOWS_FULL_IMAGE_NAME)'
 
-  #     - powershell: |
-  #         $output = docker manifest inspect -v $(WINDOWS_FULL_IMAGE_NAME) | ConvertFrom-Json
-  #         $firstManifest = $output[0]
-  #         $MEDIA_TYPE = $firstManifest.Descriptor.mediaType
-  #         $DIGEST = $firstManifest.Descriptor.digest
-  #         $SIZE = $firstManifest.Descriptor.size
-  #         $payload = @{
-  #             targetArtifact = @{
-  #                 mediaType = $MEDIA_TYPE
-  #                 digest = $DIGEST
-  #                 size = $SIZE
-  #             }
-  #         } | ConvertTo-Json
+      - powershell: |
+          $output = docker manifest inspect -v $(WINDOWS_FULL_IMAGE_NAME) | ConvertFrom-Json
+          $firstManifest = $output[0]
+          $MEDIA_TYPE = $firstManifest.Descriptor.mediaType
+          $DIGEST = $firstManifest.Descriptor.digest
+          $SIZE = $firstManifest.Descriptor.size
+          $payload = @{
+              targetArtifact = @{
+                  mediaType = $MEDIA_TYPE
+                  digest = $DIGEST
+                  size = $SIZE
+              }
+          } | ConvertTo-Json
 
-  #         $payload | Out-File -FilePath "$(Build.ArtifactStagingDirectory)/windows/payload.json"
-  #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-  #       displayName: "Build the payload json file"
-  #       condition: succeeded()
+          $payload | Out-File -FilePath "$(Build.ArtifactStagingDirectory)/windows/payload.json"
+        workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+        displayName: "Build the payload json file"
+        condition: succeeded()
 
-  #     - task: EsrpCodeSigning@5
-  #       displayName: "ESRP CodeSigning for Windows Multi-Arch Prometheus"
-  #       inputs:
-  #         ConnectedServiceName: "ESRPServiceConnectionPrometheus"  
-  #         AppRegistrationClientId: '73f8d5f9-b507-497f-b698-4ed00fcba5a3' 
-  #         AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47' 
-  #         AuthAKVName: 'ESRPPrometheusKVProd' 
-  #         AuthCertName: 'ESRPContainerImageSignCert'
-  #         AuthSignCertName: 'ESRPReqPrometheusProdCert'
-  #         FolderPath: $(Build.ArtifactStagingDirectory)/windows/
-  #         Pattern: "*.json"
-  #         signConfigType: inlineSignParams
-  #         inlineOperation: |
-  #           [
-  #             {
-  #                 "keyCode": "CP-469451",
-  #                 "operationSetCode": "NotaryCoseSign",
-  #                 "parameters": [
-  #                   {
-  #                     "parameterName": "CoseFlags",
-  #                     "parameterValue": "chainunprotected"
-  #                   }
-  #                 ],
-  #                 "toolName": "sign",
-  #                 "toolVersion": "1.0"
-  #             }
-  #           ]
-  #         SessionTimeout: '60'
-  #         MaxConcurrency: '50'
-  #         MaxRetryAttempts: '5'
-  #         PendingAnalysisWaitTimeoutMinutes: '5' 
+      - task: EsrpCodeSigning@5
+        displayName: "ESRP CodeSigning for Windows Multi-Arch Prometheus"
+        inputs:
+          ConnectedServiceName: "ESRPServiceConnectionPrometheus"  
+          AppRegistrationClientId: '73f8d5f9-b507-497f-b698-4ed00fcba5a3' 
+          AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47' 
+          AuthAKVName: 'ESRPPrometheusKVProd' 
+          AuthCertName: 'ESRPContainerImageSignCert'
+          AuthSignCertName: 'ESRPReqPrometheusProdCert'
+          FolderPath: $(Build.ArtifactStagingDirectory)/windows/
+          Pattern: "*.json"
+          signConfigType: inlineSignParams
+          inlineOperation: |
+            [
+              {
+                  "keyCode": "CP-469451",
+                  "operationSetCode": "NotaryCoseSign",
+                  "parameters": [
+                    {
+                      "parameterName": "CoseFlags",
+                      "parameterValue": "chainunprotected"
+                    }
+                  ],
+                  "toolName": "sign",
+                  "toolVersion": "1.0"
+              }
+            ]
+          SessionTimeout: '60'
+          MaxConcurrency: '50'
+          MaxRetryAttempts: '5'
+          PendingAnalysisWaitTimeoutMinutes: '5' 
 
-  #     - powershell: |
-  #         curl.exe -sLO  "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_windows_amd64.zip"
-  #         $currentDirectory = Get-Location
-  #         Expand-Archive -Path $currentDirectory\oras_1.0.0_windows_amd64.zip -DestinationPath . -Force
-  #         New-Item -ItemType Directory -Force -Path $env:USERPROFILE\bin
-  #         Copy-Item -Path $currentDirectory\oras.exe -Destination "$env:USERPROFILE\bin\"
-  #         $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
-  #         oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\""79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\""]
-  #         oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type 'application/vnd.microsoft.artifact.lifecycle' --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"          
-  #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-  #       displayName: "Download, install Oras and run oras attach"
-  #       condition: succeeded()
+      - powershell: |
+          curl.exe -sLO  "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_windows_amd64.zip"
+          $currentDirectory = Get-Location
+          Expand-Archive -Path $currentDirectory\oras_1.0.0_windows_amd64.zip -DestinationPath . -Force
+          New-Item -ItemType Directory -Force -Path $env:USERPROFILE\bin
+          Copy-Item -Path $currentDirectory\oras.exe -Destination "$env:USERPROFILE\bin\"
+          $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
+          oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\""79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\""]
+          oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type 'application/vnd.microsoft.artifact.lifecycle' --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"          
+        workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+        displayName: "Download, install Oras and run oras attach"
+        condition: succeeded()
 
-  #     - task: PublishBuildArtifacts@1
-  #       condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
-  #       displayName: "Ev2: publish image artifacts"
-  #       inputs:
-  #         pathToPublish: '$(Build.ArtifactStagingDirectory)'
-  #         artifactName: drop
+      - task: PublishBuildArtifacts@1
+        condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
+        displayName: "Ev2: publish image artifacts"
+        inputs:
+          pathToPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: drop
 
-  #     - task: AntiMalware@4
-  #       displayName: 'Run MpCmdRun.exe'
-  #       inputs:
-  #         InputType: Basic
-  #         ScanType: CustomScan
-  #         FileDirPath: '$(Build.ArtifactStagingDirectory)'
-  #         DisableRemediation: false
+      - task: AntiMalware@4
+        displayName: 'Run MpCmdRun.exe'
+        inputs:
+          InputType: Basic
+          ScanType: CustomScan
+          FileDirPath: '$(Build.ArtifactStagingDirectory)'
+          DisableRemediation: false
 
   - job: Arc_Helm_Chart
     displayName: "Package: Arc helm chart"
@@ -1408,7 +1408,7 @@ stages:
   jobs:
   - deployment: Deploy_Chart_ARC
     displayName: "Deploy: Arc dev cluster"
-    #condition: and(succeeded(), and(and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)), or(not(succeeded('Deploy_Chart_ARC')), eq(variables['System.StageAttempt'], 1))))
+    condition: and(succeeded(), and(and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)), or(not(succeeded('Deploy_Chart_ARC')), eq(variables['System.StageAttempt'], 1))))
     environment: Prometheus-Collector
     pool:
       name: Azure-Pipelines-CI-Test-EO
@@ -1478,37 +1478,37 @@ stages:
                 fi
             displayName: "Deploy: Release to dev release train"
 
-          # - task: AzureCLI@2
-          #   displayName: "Deploy: wait for ci-dev-arc-wcus cluster to be ready"
-          #   inputs:
-          #     azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
-          #     scriptType: 'bash'
-          #     scriptLocation: 'inlineScript'
-          #     inlineScript: |
-          #       for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
-          #         do
-          #           state=$(az k8s-extension show --name azuremonitor-metrics --cluster-name ci-dev-arc-wcus --resource-group ci-dev-arc-wcus --cluster-type connectedClusters | jq -r '.provisioningState')
-          #           # We want to wait in case the status is 'Creating' or 'Updating' because of another PR merged shortly before the current one.
-          #           if [ "$state" = "Succeeded" ] || [ "$state" = "Failed" ]
-          #           then
-          #             echo "Cluster is ready to install extension"
-          #             exit 0
-          #           fi
-          #           sleep 30
-          #         done
-          #         echo "Cluster is installing a different version of the extension"
-          #         exit 1
-          #     retryCountOnTaskFailure: 5
+          - task: AzureCLI@2
+            displayName: "Deploy: wait for ci-dev-arc-wcus cluster to be ready"
+            inputs:
+              azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
+              scriptType: 'bash'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+                  do
+                    state=$(az k8s-extension show --name azuremonitor-metrics --cluster-name ci-dev-arc-wcus --resource-group ci-dev-arc-wcus --cluster-type connectedClusters | jq -r '.provisioningState')
+                    # We want to wait in case the status is 'Creating' or 'Updating' because of another PR merged shortly before the current one.
+                    if [ "$state" = "Succeeded" ] || [ "$state" = "Failed" ]
+                    then
+                      echo "Cluster is ready to install extension"
+                      exit 0
+                    fi
+                    sleep 30
+                  done
+                  echo "Cluster is installing a different version of the extension"
+                  exit 1
+              retryCountOnTaskFailure: 5
 
-          # - task: AzureCLI@2
-          #   displayName: "Deploy: ci-dev-arc-wcus cluster"
-          #   inputs:
-          #     azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
-          #     scriptType: 'bash'
-          #     scriptLocation: 'inlineScript'
-          #     inlineScript: |
-          #       az config set extension.use_dynamic_install=yes_without_prompt
-          #       az k8s-extension update --name azuremonitor-metrics --resource-group ci-dev-arc-wcus --cluster-name ci-dev-arc-wcus --cluster-type connectedClusters --version $HELM_SEMVER --release-train pipeline
+          - task: AzureCLI@2
+            displayName: "Deploy: ci-dev-arc-wcus cluster"
+            inputs:
+              azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
+              scriptType: 'bash'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                az config set extension.use_dynamic_install=yes_without_prompt
+                az k8s-extension update --name azuremonitor-metrics --resource-group ci-dev-arc-wcus --cluster-name ci-dev-arc-wcus --cluster-type connectedClusters --version $HELM_SEMVER --release-train pipeline
 
   - deployment: Deploy_AKS_Chart
     displayName: "Deploy: AKS dev cluster"

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -1115,243 +1115,243 @@ stages:
         displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/linuxcfgreader/"
         condition: succeeded()
 
-  - job: Windows2019_Prometheus_Collector
-    displayName: "Build: windows 2019 prometheus-collector image"
-    pool:
-      name: Azure-Pipelines-Windows-CI-Test-EO
-    timeoutInMinutes: 120
-    dependsOn:
-    - Image_Tags_and_Ev2_Artifacts
-    variables:
-      WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
-      WINDOWS_2019_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2019_BASE_IMAGE_VERSION'] ]
-      skipComponentGovernanceDetection: true
-    steps:
-      - task: GoTool@0
-        displayName: "Build: specify golang version"
-        inputs:
-          version: '1.20'
+  # - job: Windows2019_Prometheus_Collector
+  #   displayName: "Build: windows 2019 prometheus-collector image"
+  #   pool:
+  #     name: Azure-Pipelines-Windows-CI-Test-EO
+  #   timeoutInMinutes: 120
+  #   dependsOn:
+  #   - Image_Tags_and_Ev2_Artifacts
+  #   variables:
+  #     WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
+  #     WINDOWS_2019_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2019_BASE_IMAGE_VERSION'] ]
+  #     skipComponentGovernanceDetection: true
+  #   steps:
+  #     - task: GoTool@0
+  #       displayName: "Build: specify golang version"
+  #       inputs:
+  #         version: '1.20'
 
-      - powershell: |
-          ./makefile_windows.ps1
-        workingDirectory: $(Build.SourcesDirectory)/otelcollector/opentelemetry-collector-builder/
-        displayName: "Build: build otelcollector, promconfigvalidator, and fluent-bit plugin"
+  #     - powershell: |
+  #         ./makefile_windows.ps1
+  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/opentelemetry-collector-builder/
+  #       displayName: "Build: build otelcollector, promconfigvalidator, and fluent-bit plugin"
 
-      - powershell: |
-          docker build . --isolation=hyperv --file ./build/windows/Dockerfile -t $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION) --build-arg WINDOWS_VERSION=$(WINDOWS_2019_BASE_IMAGE_VERSION)
-        workingDirectory: $(Build.SourcesDirectory)/otelcollector/
-        displayName: "Build: build WS2019 image"
-        retryCountOnTaskFailure: 2
+  #     - powershell: |
+  #         docker build . --isolation=hyperv --file ./build/windows/Dockerfile -t $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION) --build-arg WINDOWS_VERSION=$(WINDOWS_2019_BASE_IMAGE_VERSION)
+  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/
+  #       displayName: "Build: build WS2019 image"
+  #       retryCountOnTaskFailure: 2
 
-      - powershell: |
-          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-          docker push $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION)
-        displayName: "Build: push image to dev ACR"
+  #     - powershell: |
+  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+  #         docker push $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION)
+  #       displayName: "Build: push image to dev ACR"
 
-  - job: Windows2022_Prometheus_Collector
-    displayName: "Build: windows 2022 prometheus-collector image"
-    pool:
-      name: Azure-Pipelines-Windows-CI-Test-EO
-    timeoutInMinutes: 120
-    dependsOn:
-    - Image_Tags_and_Ev2_Artifacts
-    variables:
-      WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
-      WINDOWS_2022_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2022_BASE_IMAGE_VERSION'] ]
-      skipComponentGovernanceDetection: true
-    steps:
-      - task: GoTool@0
-        displayName: "Build: specify golang version"
-        inputs:
-          version: '1.20'
+  # - job: Windows2022_Prometheus_Collector
+  #   displayName: "Build: windows 2022 prometheus-collector image"
+  #   pool:
+  #     name: Azure-Pipelines-Windows-CI-Test-EO
+  #   timeoutInMinutes: 120
+  #   dependsOn:
+  #   - Image_Tags_and_Ev2_Artifacts
+  #   variables:
+  #     WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
+  #     WINDOWS_2022_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2022_BASE_IMAGE_VERSION'] ]
+  #     skipComponentGovernanceDetection: true
+  #   steps:
+  #     - task: GoTool@0
+  #       displayName: "Build: specify golang version"
+  #       inputs:
+  #         version: '1.20'
 
-      - powershell: |
-          ./makefile_windows.ps1
-        workingDirectory: $(Build.SourcesDirectory)/otelcollector/opentelemetry-collector-builder/
-        displayName: "Build: build otelcollector, promconfigvalidator, and fluent-bit plugin"
+  #     - powershell: |
+  #         ./makefile_windows.ps1
+  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/opentelemetry-collector-builder/
+  #       displayName: "Build: build otelcollector, promconfigvalidator, and fluent-bit plugin"
 
-      - powershell: |
-          docker build . --isolation=hyperv --file ./build/windows/Dockerfile -t $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION) --build-arg WINDOWS_VERSION=$(WINDOWS_2022_BASE_IMAGE_VERSION)
-        workingDirectory: $(Build.SourcesDirectory)/otelcollector/
-        displayName: "Build: build WS2022 image"
-        retryCountOnTaskFailure: 2
+  #     - powershell: |
+  #         docker build . --isolation=hyperv --file ./build/windows/Dockerfile -t $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION) --build-arg WINDOWS_VERSION=$(WINDOWS_2022_BASE_IMAGE_VERSION)
+  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/
+  #       displayName: "Build: build WS2022 image"
+  #       retryCountOnTaskFailure: 2
 
-      - powershell: |
-          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-          docker push $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
-        displayName: "Build: push image to dev ACR"
+  #     - powershell: |
+  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+  #         docker push $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
+  #       displayName: "Build: push image to dev ACR"
 
-  - job: WindowsMultiArch_Prometheus_Collector
-    displayName: "Build: windows multi-arch prometheus-collector image"
-    pool:
-      name: Azure-Pipelines-Windows-CI-Test-EO
-    timeoutInMinutes: 120
-    dependsOn:
-    - Image_Tags_and_Ev2_Artifacts
-    - Windows2019_Prometheus_Collector
-    - Windows2022_Prometheus_Collector
-    variables:
-      WINDOWS_IMAGE_TAG: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_IMAGE_TAG'] ]
-      WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
-      WINDOWS_2019_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2019_BASE_IMAGE_VERSION'] ]
-      WINDOWS_2022_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2022_BASE_IMAGE_VERSION'] ]
-      skipComponentGovernanceDetection: true
-    steps:
-      - task: GoTool@0
-        displayName: "Build: specify golang version"
-        inputs:
-          version: '1.20'
+  # - job: WindowsMultiArch_Prometheus_Collector
+  #   displayName: "Build: windows multi-arch prometheus-collector image"
+  #   pool:
+  #     name: Azure-Pipelines-Windows-CI-Test-EO
+  #   timeoutInMinutes: 120
+  #   dependsOn:
+  #   - Image_Tags_and_Ev2_Artifacts
+  #   - Windows2019_Prometheus_Collector
+  #   - Windows2022_Prometheus_Collector
+  #   variables:
+  #     WINDOWS_IMAGE_TAG: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_IMAGE_TAG'] ]
+  #     WINDOWS_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_FULL_IMAGE_NAME'] ]
+  #     WINDOWS_2019_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2019_BASE_IMAGE_VERSION'] ]
+  #     WINDOWS_2022_BASE_IMAGE_VERSION: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.WINDOWS_2022_BASE_IMAGE_VERSION'] ]
+  #     skipComponentGovernanceDetection: true
+  #   steps:
+  #     - task: GoTool@0
+  #       displayName: "Build: specify golang version"
+  #       inputs:
+  #         version: '1.20'
 
-      - bash: |
-          export ACR_REPOSITORY_VAR="$(ACR_REPOSITORY)"
-          export ACR_REPOSITORY_WITHOUT_SLASH="${ACR_REPOSITORY_VAR:1}"
+  #     - bash: |
+  #         export ACR_REPOSITORY_VAR="$(ACR_REPOSITORY)"
+  #         export ACR_REPOSITORY_WITHOUT_SLASH="${ACR_REPOSITORY_VAR:1}"
 
-          export WINDOWS_2019_TAG="$(WINDOWS_IMAGE_TAG)-$(WINDOWS_2019_BASE_IMAGE_VERSION)"
-          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-          docker pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION)
-          if [ $? -ne 0 ]; then
-            echo "Failed to pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION). Checking if MCR image is published."
-            IMAGES_ARE_PUBLISHED=0
-            for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
-              do
-                output=$(curl -s https://$(MCR_REGISTRY)/v2$(MCR_REPOSITORY)/tags/list)
-                if (echo $output | grep $WINDOWS_2019_TAG)
-                then
-                  echo "Images are published to mcr"
-                  IMAGES_ARE_PUBLISHED=1
-                  break
-                fi
-                sleep 30
-              done
-            if [ IMAGES_ARE_PUBLISHED -eq 0 ]; then
-              echo "Images are not published to mcr within the timeout"
-              exit 1
-            fi
+  #         export WINDOWS_2019_TAG="$(WINDOWS_IMAGE_TAG)-$(WINDOWS_2019_BASE_IMAGE_VERSION)"
+  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+  #         docker pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION)
+  #         if [ $? -ne 0 ]; then
+  #           echo "Failed to pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION). Checking if MCR image is published."
+  #           IMAGES_ARE_PUBLISHED=0
+  #           for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+  #             do
+  #               output=$(curl -s https://$(MCR_REGISTRY)/v2$(MCR_REPOSITORY)/tags/list)
+  #               if (echo $output | grep $WINDOWS_2019_TAG)
+  #               then
+  #                 echo "Images are published to mcr"
+  #                 IMAGES_ARE_PUBLISHED=1
+  #                 break
+  #               fi
+  #               sleep 30
+  #             done
+  #           if [ IMAGES_ARE_PUBLISHED -eq 0 ]; then
+  #             echo "Images are not published to mcr within the timeout"
+  #             exit 1
+  #           fi
 
-            az acr import --name $(ACR_REGISTRY) --source $(MCR_REGISTRY)$(MCR_REPOSITORY):$(IMAGE_TAG) --image $(ACR_REPOSITORY_WITHOUT_SLASH):$(WINDOWS_2019_TAG)
-          fi
+  #           az acr import --name $(ACR_REGISTRY) --source $(MCR_REGISTRY)$(MCR_REPOSITORY):$(IMAGE_TAG) --image $(ACR_REPOSITORY_WITHOUT_SLASH):$(WINDOWS_2019_TAG)
+  #         fi
 
-          export WINDOWS_2022_TAG="$(WINDOWS_IMAGE_TAG)-$(WINDOWS_2022_BASE_IMAGE_VERSION)"
-          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-          docker pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
-          if [ $? -ne 0 ]; then
-            echo "Failed to pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION). Checking if MCR image is published."
-            IMAGES_ARE_PUBLISHED=0
-            for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
-              do
-                output=$(curl -s https://$(MCR_REGISTRY)/v2$(MCR_REPOSITORY)/tags/list)
-                if (echo $output | grep $WINDOWS_2022_TAG)
-                then
-                  echo "Images are published to mcr"
-                  IMAGES_ARE_PUBLISHED=1
-                  break
-                fi
-                sleep 30
-              done
-            if [ IMAGES_ARE_PUBLISHED -eq 0 ]; then
-              echo "Images are not published to mcr within the timeout"
-              exit 1
-            fi
+  #         export WINDOWS_2022_TAG="$(WINDOWS_IMAGE_TAG)-$(WINDOWS_2022_BASE_IMAGE_VERSION)"
+  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+  #         docker pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
+  #         if [ $? -ne 0 ]; then
+  #           echo "Failed to pull $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION). Checking if MCR image is published."
+  #           IMAGES_ARE_PUBLISHED=0
+  #           for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+  #             do
+  #               output=$(curl -s https://$(MCR_REGISTRY)/v2$(MCR_REPOSITORY)/tags/list)
+  #               if (echo $output | grep $WINDOWS_2022_TAG)
+  #               then
+  #                 echo "Images are published to mcr"
+  #                 IMAGES_ARE_PUBLISHED=1
+  #                 break
+  #               fi
+  #               sleep 30
+  #             done
+  #           if [ IMAGES_ARE_PUBLISHED -eq 0 ]; then
+  #             echo "Images are not published to mcr within the timeout"
+  #             exit 1
+  #           fi
 
-            az acr import --name $(ACR_REGISTRY) --source $(MCR_REGISTRY)$(MCR_REPOSITORY):$(IMAGE_TAG) --image $(ACR_REPOSITORY_WITHOUT_SLASH):$(WINDOWS_2022_TAG)
-          fi
-        displayName: "Build: ensure images are present in ACR"
-        retryCountOnTaskFailure: 3
+  #           az acr import --name $(ACR_REGISTRY) --source $(MCR_REGISTRY)$(MCR_REPOSITORY):$(IMAGE_TAG) --image $(ACR_REPOSITORY_WITHOUT_SLASH):$(WINDOWS_2022_TAG)
+  #         fi
+  #       displayName: "Build: ensure images are present in ACR"
+  #       retryCountOnTaskFailure: 3
 
-      - powershell: |
-          New-Item -Path "$(Build.ArtifactStagingDirectory)" -Name "windows" -ItemType "directory"
-          @{"image.name"="$(WINDOWS_FULL_IMAGE_NAME)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
-          docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-          docker manifest create $(WINDOWS_FULL_IMAGE_NAME) $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION) $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
-          docker manifest push $(WINDOWS_FULL_IMAGE_NAME)
-        workingDirectory: $(Build.SourcesDirectory)/otelcollector/
-        displayName: "Build: Windows multi-arch manifest"
+  #     - powershell: |
+  #         New-Item -Path "$(Build.ArtifactStagingDirectory)" -Name "windows" -ItemType "directory"
+  #         @{"image.name"="$(WINDOWS_FULL_IMAGE_NAME)"} | ConvertTo-Json -Compress | Out-File -Encoding ascii $(Build.ArtifactStagingDirectory)/windows/metadata.json
+  #         docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+  #         docker manifest create $(WINDOWS_FULL_IMAGE_NAME) $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2019_BASE_IMAGE_VERSION) $(WINDOWS_FULL_IMAGE_NAME)-$(WINDOWS_2022_BASE_IMAGE_VERSION)
+  #         docker manifest push $(WINDOWS_FULL_IMAGE_NAME)
+  #       workingDirectory: $(Build.SourcesDirectory)/otelcollector/
+  #       displayName: "Build: Windows multi-arch manifest"
 
-      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-        condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
-        displayName: "Ev2: generate image artifacts"
-        inputs:
-          BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
-          DockerImagesToScan: '$(WINDOWS_FULL_IMAGE_NAME)'
+  #     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  #       condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
+  #       displayName: "Ev2: generate image artifacts"
+  #       inputs:
+  #         BuildDropPath: '$(Build.ArtifactStagingDirectory)/windows'
+  #         DockerImagesToScan: '$(WINDOWS_FULL_IMAGE_NAME)'
 
-      - powershell: |
-          $output = docker manifest inspect -v $(WINDOWS_FULL_IMAGE_NAME) | ConvertFrom-Json
-          $firstManifest = $output[0]
-          $MEDIA_TYPE = $firstManifest.Descriptor.mediaType
-          $DIGEST = $firstManifest.Descriptor.digest
-          $SIZE = $firstManifest.Descriptor.size
-          $payload = @{
-              targetArtifact = @{
-                  mediaType = $MEDIA_TYPE
-                  digest = $DIGEST
-                  size = $SIZE
-              }
-          } | ConvertTo-Json
+  #     - powershell: |
+  #         $output = docker manifest inspect -v $(WINDOWS_FULL_IMAGE_NAME) | ConvertFrom-Json
+  #         $firstManifest = $output[0]
+  #         $MEDIA_TYPE = $firstManifest.Descriptor.mediaType
+  #         $DIGEST = $firstManifest.Descriptor.digest
+  #         $SIZE = $firstManifest.Descriptor.size
+  #         $payload = @{
+  #             targetArtifact = @{
+  #                 mediaType = $MEDIA_TYPE
+  #                 digest = $DIGEST
+  #                 size = $SIZE
+  #             }
+  #         } | ConvertTo-Json
 
-          $payload | Out-File -FilePath "$(Build.ArtifactStagingDirectory)/windows/payload.json"
-        workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-        displayName: "Build the payload json file"
-        condition: succeeded()
+  #         $payload | Out-File -FilePath "$(Build.ArtifactStagingDirectory)/windows/payload.json"
+  #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+  #       displayName: "Build the payload json file"
+  #       condition: succeeded()
 
-      - task: EsrpCodeSigning@5
-        displayName: "ESRP CodeSigning for Windows Multi-Arch Prometheus"
-        inputs:
-          ConnectedServiceName: "ESRPServiceConnectionPrometheus"  
-          AppRegistrationClientId: '73f8d5f9-b507-497f-b698-4ed00fcba5a3' 
-          AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47' 
-          AuthAKVName: 'ESRPPrometheusKVProd' 
-          AuthCertName: 'ESRPContainerImageSignCert'
-          AuthSignCertName: 'ESRPReqPrometheusProdCert'
-          FolderPath: $(Build.ArtifactStagingDirectory)/windows/
-          Pattern: "*.json"
-          signConfigType: inlineSignParams
-          inlineOperation: |
-            [
-              {
-                  "keyCode": "CP-469451",
-                  "operationSetCode": "NotaryCoseSign",
-                  "parameters": [
-                    {
-                      "parameterName": "CoseFlags",
-                      "parameterValue": "chainunprotected"
-                    }
-                  ],
-                  "toolName": "sign",
-                  "toolVersion": "1.0"
-              }
-            ]
-          SessionTimeout: '60'
-          MaxConcurrency: '50'
-          MaxRetryAttempts: '5'
-          PendingAnalysisWaitTimeoutMinutes: '5' 
+  #     - task: EsrpCodeSigning@5
+  #       displayName: "ESRP CodeSigning for Windows Multi-Arch Prometheus"
+  #       inputs:
+  #         ConnectedServiceName: "ESRPServiceConnectionPrometheus"  
+  #         AppRegistrationClientId: '73f8d5f9-b507-497f-b698-4ed00fcba5a3' 
+  #         AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47' 
+  #         AuthAKVName: 'ESRPPrometheusKVProd' 
+  #         AuthCertName: 'ESRPContainerImageSignCert'
+  #         AuthSignCertName: 'ESRPReqPrometheusProdCert'
+  #         FolderPath: $(Build.ArtifactStagingDirectory)/windows/
+  #         Pattern: "*.json"
+  #         signConfigType: inlineSignParams
+  #         inlineOperation: |
+  #           [
+  #             {
+  #                 "keyCode": "CP-469451",
+  #                 "operationSetCode": "NotaryCoseSign",
+  #                 "parameters": [
+  #                   {
+  #                     "parameterName": "CoseFlags",
+  #                     "parameterValue": "chainunprotected"
+  #                   }
+  #                 ],
+  #                 "toolName": "sign",
+  #                 "toolVersion": "1.0"
+  #             }
+  #           ]
+  #         SessionTimeout: '60'
+  #         MaxConcurrency: '50'
+  #         MaxRetryAttempts: '5'
+  #         PendingAnalysisWaitTimeoutMinutes: '5' 
 
-      - powershell: |
-          curl.exe -sLO  "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_windows_amd64.zip"
-          $currentDirectory = Get-Location
-          Expand-Archive -Path $currentDirectory\oras_1.0.0_windows_amd64.zip -DestinationPath . -Force
-          New-Item -ItemType Directory -Force -Path $env:USERPROFILE\bin
-          Copy-Item -Path $currentDirectory\oras.exe -Destination "$env:USERPROFILE\bin\"
-          $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
-          oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\""79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\""]
-          oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type 'application/vnd.microsoft.artifact.lifecycle' --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"          
-        workingDirectory: $(Build.ArtifactStagingDirectory)/windows
-        displayName: "Download, install Oras and run oras attach"
-        condition: succeeded()
+  #     - powershell: |
+  #         curl.exe -sLO  "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_windows_amd64.zip"
+  #         $currentDirectory = Get-Location
+  #         Expand-Archive -Path $currentDirectory\oras_1.0.0_windows_amd64.zip -DestinationPath . -Force
+  #         New-Item -ItemType Directory -Force -Path $env:USERPROFILE\bin
+  #         Copy-Item -Path $currentDirectory\oras.exe -Destination "$env:USERPROFILE\bin\"
+  #         $env:PATH = "$env:USERPROFILE\bin;$env:PATH"
+  #         oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type application/vnd.cncf.notary.signature ./payload.json:application/cose -a io.cncf.notary.x509chain.thumbprint#S256=[\""79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\""]
+  #         oras attach $(WINDOWS_FULL_IMAGE_NAME) --artifact-type 'application/vnd.microsoft.artifact.lifecycle' --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(powershell -Command "(Get-Date).AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ')")"          
+  #       workingDirectory: $(Build.ArtifactStagingDirectory)/windows
+  #       displayName: "Download, install Oras and run oras attach"
+  #       condition: succeeded()
 
-      - task: PublishBuildArtifacts@1
-        condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
-        displayName: "Ev2: publish image artifacts"
-        inputs:
-          pathToPublish: '$(Build.ArtifactStagingDirectory)'
-          artifactName: drop
+  #     - task: PublishBuildArtifacts@1
+  #       condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
+  #       displayName: "Ev2: publish image artifacts"
+  #       inputs:
+  #         pathToPublish: '$(Build.ArtifactStagingDirectory)'
+  #         artifactName: drop
 
-      - task: AntiMalware@4
-        displayName: 'Run MpCmdRun.exe'
-        inputs:
-          InputType: Basic
-          ScanType: CustomScan
-          FileDirPath: '$(Build.ArtifactStagingDirectory)'
-          DisableRemediation: false
+  #     - task: AntiMalware@4
+  #       displayName: 'Run MpCmdRun.exe'
+  #       inputs:
+  #         InputType: Basic
+  #         ScanType: CustomScan
+  #         FileDirPath: '$(Build.ArtifactStagingDirectory)'
+  #         DisableRemediation: false
 
   - job: Arc_Helm_Chart
     displayName: "Package: Arc helm chart"
@@ -1422,7 +1422,7 @@ stages:
           - task: AzureCLI@2
             inputs:
               azureSubscription: 'prometheus-arc-dev-release-mi'
-              scriptType: 'batch'
+              scriptType: 'bash'
               scriptLocation: 'inlineScript'
               inlineScript: |
                 # Create JSON request body
@@ -1486,37 +1486,37 @@ stages:
                 fi
             displayName: "Deploy: Release to dev release train"
 
-          - task: AzureCLI@2
-            displayName: "Deploy: wait for ci-dev-arc-wcus cluster to be ready"
-            inputs:
-              azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
-              scriptType: 'bash'
-              scriptLocation: 'inlineScript'
-              inlineScript: |
-                for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
-                  do
-                    state=$(az k8s-extension show --name azuremonitor-metrics --cluster-name ci-dev-arc-wcus --resource-group ci-dev-arc-wcus --cluster-type connectedClusters | jq -r '.provisioningState')
-                    # We want to wait in case the status is 'Creating' or 'Updating' because of another PR merged shortly before the current one.
-                    if [ "$state" = "Succeeded" ] || [ "$state" = "Failed" ]
-                    then
-                      echo "Cluster is ready to install extension"
-                      exit 0
-                    fi
-                    sleep 30
-                  done
-                  echo "Cluster is installing a different version of the extension"
-                  exit 1
-              retryCountOnTaskFailure: 5
+          # - task: AzureCLI@2
+          #   displayName: "Deploy: wait for ci-dev-arc-wcus cluster to be ready"
+          #   inputs:
+          #     azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
+          #     scriptType: 'bash'
+          #     scriptLocation: 'inlineScript'
+          #     inlineScript: |
+          #       for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+          #         do
+          #           state=$(az k8s-extension show --name azuremonitor-metrics --cluster-name ci-dev-arc-wcus --resource-group ci-dev-arc-wcus --cluster-type connectedClusters | jq -r '.provisioningState')
+          #           # We want to wait in case the status is 'Creating' or 'Updating' because of another PR merged shortly before the current one.
+          #           if [ "$state" = "Succeeded" ] || [ "$state" = "Failed" ]
+          #           then
+          #             echo "Cluster is ready to install extension"
+          #             exit 0
+          #           fi
+          #           sleep 30
+          #         done
+          #         echo "Cluster is installing a different version of the extension"
+          #         exit 1
+          #     retryCountOnTaskFailure: 5
 
-          - task: AzureCLI@2
-            displayName: "Deploy: ci-dev-arc-wcus cluster"
-            inputs:
-              azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
-              scriptType: 'bash'
-              scriptLocation: 'inlineScript'
-              inlineScript: |
-                az config set extension.use_dynamic_install=yes_without_prompt
-                az k8s-extension update --name azuremonitor-metrics --resource-group ci-dev-arc-wcus --cluster-name ci-dev-arc-wcus --cluster-type connectedClusters --version $HELM_SEMVER --release-train pipeline
+          # - task: AzureCLI@2
+          #   displayName: "Deploy: ci-dev-arc-wcus cluster"
+          #   inputs:
+          #     azureSubscription: 'ContainerInsights_Build_Subscription(9b96ebbd-c57a-42d1-bbe9-b69296e4c7fb)'
+          #     scriptType: 'bash'
+          #     scriptLocation: 'inlineScript'
+          #     inlineScript: |
+          #       az config set extension.use_dynamic_install=yes_without_prompt
+          #       az k8s-extension update --name azuremonitor-metrics --resource-group ci-dev-arc-wcus --cluster-name ci-dev-arc-wcus --cluster-type connectedClusters --version $HELM_SEMVER --release-train pipeline
 
   - deployment: Deploy_AKS_Chart
     displayName: "Deploy: AKS dev cluster"

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -1454,14 +1454,6 @@ stages:
 
                 echo "Request parameter preparation, SUBSCRIPTION is $SUBSCRIPTION, RESOURCE_AUDIENCE is $RESOURCE_AUDIENCE, CHART_VERSION is $HELM_SEMVER"
 
-                echo "Login cli using MSI"
-                az login --managed-identity
-                if [ $? -eq 0 ]; then
-                  echo "Logged in successfully with MSI"
-                else
-                  echo "-e error failed to login to az with managed identity credentials"
-                  exit 1
-                fi
 
                 ACCESS_TOKEN=$(az account get-access-token --resource $RESOURCE_AUDIENCE --query accessToken -o json)
                 if [ $? -eq 0 ]; then


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

Use a dev managed identity for our private arc release for our CI/CD cluster. This uses [workload identity federation credentials](https://devblogs.microsoft.com/devops/public-preview-of-workload-identity-federation-for-azure-pipelines/) as a service connection to be able to use the managed identity in the pipeline build agent.

Use the same release managed identity we use for our other ev2 release to push the image to the prod ACR for our Arc prod release now.