### PR TITLE
fix : update if condition to do proper checks for networkobs fields + no quotes needed for golang podannotation

### DIFF
--- a/otelcollector/shared/configmap/mp/prometheus-config-merger.go
+++ b/otelcollector/shared/configmap/mp/prometheus-config-merger.go
@@ -15,12 +15,12 @@ import (
 )
 
 const (
-	configMapMountPath                           = "/etc/config/settings/prometheus/prometheus-config"
-	replicasetControllerType                     = "replicaset"
-	daemonsetControllerType                      = "daemonset"
-	configReaderSidecarContainerType             = "configreadersidecar"
-	supportedSchemaVersion                       = true
-	sendDSUpMetric                               = false
+	configMapMountPath               = "/etc/config/settings/prometheus/prometheus-config"
+	replicasetControllerType         = "replicaset"
+	daemonsetControllerType          = "daemonset"
+	configReaderSidecarContainerType = "configreadersidecar"
+	supportedSchemaVersion           = true
+	sendDSUpMetric                   = false
 )
 
 var (
@@ -447,7 +447,7 @@ func populateDefaultPrometheusConfig() {
 	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_KAPPIEBASIC_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
 		kappiebasicMetricsKeepListRegex, exists := regexHash["KAPPIEBASIC_METRICS_KEEP_LIST_REGEX"]
 		kappiebasicScrapeInterval := intervalHash["KAPPIEBASIC_SCRAPE_INTERVAL"]
-		if currentControllerType != replicasetControllerType {
+		if currentControllerType == replicasetControllerType {
 			// Do nothing - Kappie is not supported to be scrapped automatically outside ds.
 			// If needed, the customer can disable this ds target and enable rs scraping through custom config map
 		} else {
@@ -472,7 +472,7 @@ func populateDefaultPrometheusConfig() {
 	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_NETWORKOBSERVABILITYRETINA_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
 		networkobservabilityRetinaMetricsKeepListRegex, exists := regexHash["NETWORKOBSERVABILITYRETINA_METRICS_KEEP_LIST_REGEX"]
 		networkobservabilityRetinaScrapeInterval, intervalExists := intervalHash["NETWORKOBSERVABILITYRETINA_SCRAPE_INTERVAL"]
-		if currentControllerType != replicasetControllerType {
+		if currentControllerType == replicasetControllerType {
 			// Do nothing - Network observability Retina is not supported to be scrapped automatically outside ds.
 			// If needed, the customer can disable this ds target and enable rs scraping through custom config map
 		} else {
@@ -499,7 +499,7 @@ func populateDefaultPrometheusConfig() {
 	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_NETWORKOBSERVABILITYHUBBLE_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
 		networkobservabilityHubbleMetricsKeepListRegex, exists := regexHash["NETWORKOBSERVABILITYHUBBLE_METRICS_KEEP_LIST_REGEX"]
 		networkobservabilityHubbleScrapeInterval, intervalExists := intervalHash["NETWORKOBSERVABILITYHUBBLE_SCRAPE_INTERVAL"]
-		if currentControllerType != replicasetControllerType {
+		if currentControllerType == replicasetControllerType {
 			// Do nothing - Network observability Hubble is not supported to be scrapped automatically outside ds.
 			// If needed, the customer can disable this ds target and enable rs scraping through custom config map
 		} else {
@@ -526,7 +526,7 @@ func populateDefaultPrometheusConfig() {
 	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_NETWORKOBSERVABILITYCILIUM_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
 		networkobservabilityCiliumMetricsKeepListRegex, exists := regexHash["NETWORKOBSERVABILITYCILIUM_METRICS_KEEP_LIST_REGEX"]
 		networkobservabilityCiliumScrapeInterval, intervalExists := intervalHash["NETWORKOBSERVABILITYCILIUM_SCRAPE_INTERVAL"]
-		if currentControllerType != replicasetControllerType {
+		if currentControllerType == replicasetControllerType {
 			// Do nothing - Network observability Cilium is not supported to be scrapped automatically outside ds.
 			// If needed, the customer can disable this ds target and enable rs scraping through custom config map
 		} else {

--- a/otelcollector/shared/configmap/mp/tomlparser-pod-annotation-based-scraping.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-pod-annotation-based-scraping.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	LOGGING_PREFIX                     = "pod-annotation-based-scraping"
-	envVariableTemplateName            = "AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX"
-	envVariableAnnotationsEnabledName  = "AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED"
+	LOGGING_PREFIX                    = "pod-annotation-based-scraping"
+	envVariableTemplateName           = "AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX"
+	envVariableAnnotationsEnabledName = "AZMON_PROMETHEUS_POD_ANNOTATION_SCRAPING_ENABLED"
 )
 
 func parseConfigMapForPodAnnotations() (map[string]interface{}, error) {
@@ -51,7 +51,7 @@ func writeConfigToFile(podannotationNamespaceRegex string) error {
 		//if os.Getenv("OS_TYPE") != "" && strings.ToLower(os.Getenv("OS_TYPE")) == "linux" {
 		//	linuxPrefix = "export "
 		//}
-		envVarString := fmt.Sprintf("%s%s='%s'\n", linuxPrefix, envVariableTemplateName, podannotationNamespaceRegex)
+		envVarString := fmt.Sprintf("%s%s=%s\n", linuxPrefix, envVariableTemplateName, podannotationNamespaceRegex)
 		envVarAnnotationsEnabled := fmt.Sprintf("%s%s=%s\n", linuxPrefix, envVariableAnnotationsEnabledName, "true")
 		fmt.Printf("Writing to file: %s%s", envVarString, envVarAnnotationsEnabled)
 
@@ -69,7 +69,7 @@ func writeConfigToFile(podannotationNamespaceRegex string) error {
 
 func configurePodAnnotationSettings() error {
 	parsedConfig, err := parseConfigMapForPodAnnotations()
-	if err != nil || parsedConfig == nil{
+	if err != nil || parsedConfig == nil {
 		return err
 	}
 	podannotationNamespaceRegex, err := populatePodAnnotationNamespaceFromConfigMap(parsedConfig)


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
