### PR TITLE
move to single quote for telegraf

### DIFF
--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -67,8 +67,8 @@ func main() {
 	shared.WaitForTokenAdapter(ccpMetricsEnabled)
 
 	if ccpMetricsEnabled != "true" {
-		shared.SetEnvAndSourceBashrc("ME_CONFIG_FILE", meConfigFile, true, false)
-		shared.SetEnvAndSourceBashrc("customResourceId", cluster, true, false)
+		shared.SetEnvAndSourceBashrc("ME_CONFIG_FILE", meConfigFile, true)
+		shared.SetEnvAndSourceBashrc("customResourceId", cluster, true)
 	} else {
 		os.Setenv("ME_CONFIG_FILE", meConfigFile)
 		os.Setenv("customResourceId", cluster)
@@ -76,7 +76,7 @@ func main() {
 
 	trimmedRegion := strings.ToLower(strings.ReplaceAll(aksRegion, " ", ""))
 	if ccpMetricsEnabled != "true" {
-		shared.SetEnvAndSourceBashrc("customRegion", trimmedRegion, true, false)
+		shared.SetEnvAndSourceBashrc("customRegion", trimmedRegion, true)
 	} else {
 		os.Setenv("customRegion", trimmedRegion)
 	}

--- a/otelcollector/shared/configmap/ccp/configmapparserforccp.go
+++ b/otelcollector/shared/configmap/ccp/configmapparserforccp.go
@@ -25,7 +25,7 @@ func Configmapparserforccp() {
 			configVersion = configVersion[:10]
 		}
 		// Set the environment variable
-		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_FILE_VERSION", configVersion, true, false)
+		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_FILE_VERSION", configVersion, true)
 	}
 
 	// Set agent config file version
@@ -41,7 +41,7 @@ func Configmapparserforccp() {
 			configSchemaVersion = configSchemaVersion[:10]
 		}
 		// Set the environment variable
-		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_SCHEMA_VERSION", configSchemaVersion, true, false)
+		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_SCHEMA_VERSION", configSchemaVersion, true)
 	}
 
 	// Parse the configmap to set the right environment variables for prometheus collector settings
@@ -65,11 +65,11 @@ func Configmapparserforccp() {
 
 	prometheusCcpConfigMerger()
 
-	shared.SetEnvAndSourceBashrc("AZMON_INVALID_CUSTOM_PROMETHEUS_CONFIG", "false", true, false)
-	shared.SetEnvAndSourceBashrc("CONFIG_VALIDATOR_RUNNING_IN_AGENT", "true", true, false)
+	shared.SetEnvAndSourceBashrc("AZMON_INVALID_CUSTOM_PROMETHEUS_CONFIG", "false", true)
+	shared.SetEnvAndSourceBashrc("CONFIG_VALIDATOR_RUNNING_IN_AGENT", "true", true)
 
 	// No need to merge custom prometheus config, only merging in the default configs
-	shared.SetEnvAndSourceBashrc("AZMON_USE_DEFAULT_PROMETHEUS_CONFIG", "true", true, false)
+	shared.SetEnvAndSourceBashrc("AZMON_USE_DEFAULT_PROMETHEUS_CONFIG", "true", true)
 	shared.StartCommandAndWait("/opt/promconfigvalidator", "--config", "/opt/defaultsMergedConfig.yml", "--output", "/opt/ccp-collector-config-with-defaults.yml", "--otelTemplate", "/opt/microsoft/otelcollector/ccp-collector-config-template.yml")
 	if !shared.Exists("/opt/ccp-collector-config-with-defaults.yml") {
 		fmt.Printf("prom-config-validator::Prometheus default scrape config validation failed. No scrape configs will be used")

--- a/otelcollector/shared/configmap/mp/configmapparser.go
+++ b/otelcollector/shared/configmap/mp/configmapparser.go
@@ -18,13 +18,13 @@ const (
 func setConfigSchemaVersionEnv() {
 	fileInfo, err := os.Stat(schemaVersionFile)
 	if err != nil || fileInfo.Size() == 0 {
-		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_SCHEMA_VERSION", defaultConfigSchemaVersion, true, false)
+		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_SCHEMA_VERSION", defaultConfigSchemaVersion, true)
 		return
 	}
 	content, err := os.ReadFile(schemaVersionFile)
 	if err != nil {
 		shared.EchoError("Error reading schema version file:" + err.Error())
-		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_SCHEMA_VERSION", defaultConfigSchemaVersion, true, false)
+		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_SCHEMA_VERSION", defaultConfigSchemaVersion, true)
 		return
 	}
 	trimmedContent := strings.TrimSpace(string(content))
@@ -32,19 +32,19 @@ func setConfigSchemaVersionEnv() {
 	if len(configSchemaVersion) > 10 {
 		configSchemaVersion = configSchemaVersion[:10]
 	}
-	shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_SCHEMA_VERSION", configSchemaVersion, true, false)
+	shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_SCHEMA_VERSION", configSchemaVersion, true)
 }
 
 func setConfigFileVersionEnv() {
 	fileInfo, err := os.Stat(configVersionFile)
 	if err != nil || fileInfo.Size() == 0 {
-		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_FILE_VERSION", defaultConfigFileVersion, true, false)
+		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_FILE_VERSION", defaultConfigFileVersion, true)
 		return
 	}
 	content, err := os.ReadFile(configVersionFile)
 	if err != nil {
 		shared.EchoError("Error reading config version file:" + err.Error())
-		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_FILE_VERSION", defaultConfigFileVersion, true, false)
+		shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_FILE_VERSION", defaultConfigFileVersion, true)
 		return
 	}
 	trimmedContent := strings.TrimSpace(string(content))
@@ -52,7 +52,7 @@ func setConfigFileVersionEnv() {
 	if len(configFileVersion) > 10 {
 		configFileVersion = configFileVersion[:10]
 	}
-	shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_FILE_VERSION", configFileVersion, true, false)
+	shared.SetEnvAndSourceBashrc("AZMON_AGENT_CFG_FILE_VERSION", configFileVersion, true)
 }
 
 func parseSettingsForPodAnnotations() {
@@ -95,9 +95,9 @@ func handlePodAnnotationsFile(filename string) {
 		value := line[index+1:]
 
 		if key == "AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX" {
-			shared.SetEnvAndSourceBashrc(key, value, false, true)
+			shared.SetEnvAndSourceBashrc(key, value, false)
 		} else {
-			shared.SetEnvAndSourceBashrc(key, value, false, false)
+			shared.SetEnvAndSourceBashrc(key, value, false)
 		}
 
 	}
@@ -158,8 +158,8 @@ func Configmapparser() {
 		prometheusConfigMerger(false)
 	}
 
-	shared.SetEnvAndSourceBashrc("AZMON_INVALID_CUSTOM_PROMETHEUS_CONFIG", "false", true, false)
-	shared.SetEnvAndSourceBashrc("CONFIG_VALIDATOR_RUNNING_IN_AGENT", "true", true, false)
+	shared.SetEnvAndSourceBashrc("AZMON_INVALID_CUSTOM_PROMETHEUS_CONFIG", "false", true)
+	shared.SetEnvAndSourceBashrc("CONFIG_VALIDATOR_RUNNING_IN_AGENT", "true", true)
 
 	// Running promconfigvalidator if promMergedConfig.yml exists
 	if shared.FileExists("/opt/promMergedConfig.yml") {
@@ -172,7 +172,7 @@ func Configmapparser() {
 			if err != nil {
 				fmt.Println("prom-config-validator::Prometheus custom config validation failed. The custom config will not be used")
 				fmt.Printf("Command execution failed: %v\n", err)
-				shared.SetEnvAndSourceBashrc("AZMON_INVALID_CUSTOM_PROMETHEUS_CONFIG", "true", true, false)
+				shared.SetEnvAndSourceBashrc("AZMON_INVALID_CUSTOM_PROMETHEUS_CONFIG", "true", true)
 				if shared.FileExists(mergedDefaultConfigPath) {
 					fmt.Println("prom-config-validator::Running validator on just default scrape configs")
 					shared.StartCommandAndWait("/opt/promconfigvalidator", "--config", mergedDefaultConfigPath, "--output", "/opt/collector-config-with-defaults.yml", "--otelTemplate", "/opt/microsoft/otelcollector/collector-config-template.yml")
@@ -182,7 +182,7 @@ func Configmapparser() {
 						shared.CopyFile("/opt/collector-config-with-defaults.yml", "/opt/microsoft/otelcollector/collector-config-default.yml")
 					}
 				}
-				shared.SetEnvAndSourceBashrc("AZMON_USE_DEFAULT_PROMETHEUS_CONFIG", "true", true, false)
+				shared.SetEnvAndSourceBashrc("AZMON_USE_DEFAULT_PROMETHEUS_CONFIG", "true", true)
 			}
 		}
 	} else if _, err := os.Stat(mergedDefaultConfigPath); err == nil {
@@ -195,11 +195,11 @@ func Configmapparser() {
 			fmt.Println("prom-config-validator::Prometheus default scrape config validation succeeded, using this as collector config")
 			shared.CopyFile("/opt/collector-config-with-defaults.yml", "/opt/microsoft/otelcollector/collector-config-default.yml")
 		}
-		shared.SetEnvAndSourceBashrc("AZMON_USE_DEFAULT_PROMETHEUS_CONFIG", "true", true, false)
+		shared.SetEnvAndSourceBashrc("AZMON_USE_DEFAULT_PROMETHEUS_CONFIG", "true", true)
 	} else {
 		// This else block is needed, when there is no custom config mounted as config map or default configs enabled
 		fmt.Println("prom-config-validator::No custom config via configmap or default scrape configs enabled.")
-		shared.SetEnvAndSourceBashrc("AZMON_USE_DEFAULT_PROMETHEUS_CONFIG", "true", true, false)
+		shared.SetEnvAndSourceBashrc("AZMON_USE_DEFAULT_PROMETHEUS_CONFIG", "true", true)
 	}
 
 	if _, err := os.Stat("/opt/microsoft/prom_config_validator_env_var"); err == nil {

--- a/otelcollector/shared/configmap/mp/tomlparser-pod-annotation-based-scraping.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-pod-annotation-based-scraping.go
@@ -51,7 +51,8 @@ func writeConfigToFile(podannotationNamespaceRegex string) error {
 		//if os.Getenv("OS_TYPE") != "" && strings.ToLower(os.Getenv("OS_TYPE")) == "linux" {
 		//	linuxPrefix = "export "
 		//}
-		envVarString := fmt.Sprintf("%s%s=\"%s\"\n", linuxPrefix, envVariableTemplateName, podannotationNamespaceRegex)
+		// Writes the variable to the file in the format: AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX='value'
+		envVarString := fmt.Sprintf("%s%s='%s'\n", linuxPrefix, envVariableTemplateName, podannotationNamespaceRegex)
 		envVarAnnotationsEnabled := fmt.Sprintf("%s%s=%s\n", linuxPrefix, envVariableAnnotationsEnabledName, "true")
 		fmt.Printf("Writing to file: %s%s", envVarString, envVarAnnotationsEnabled)
 

--- a/otelcollector/shared/file_utilities.go
+++ b/otelcollector/shared/file_utilities.go
@@ -127,7 +127,7 @@ func SetEnvVarsFromFile(filename string) error {
 		key := parts[0]
 		value := parts[1]
 
-		SetEnvAndSourceBashrc(key, value, false, false)
+		SetEnvAndSourceBashrc(key, value, false)
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/otelcollector/shared/process_utilities.go
+++ b/otelcollector/shared/process_utilities.go
@@ -73,7 +73,7 @@ func SetEnvAndSourceBashrc(key, value string, echo bool, quotes bool) error {
 
 	// Write the export statement to the .bashrc file
 	if quotes {
-		_, err = fmt.Fprintf(file, "export %s='%s'\n", key, value)
+		_, err = fmt.Fprintf(file, "export %s=%s\n", key, value)
 	} else {
 		_, err = fmt.Fprintf(file, "export %s=%s\n", key, value)
 	}

--- a/otelcollector/shared/process_utilities.go
+++ b/otelcollector/shared/process_utilities.go
@@ -44,8 +44,8 @@ func IsProcessRunning(processName string) bool {
 }
 
 // SetEnvAndSourceBashrc sets a key-value pair as an environment variable in the .bashrc file
-// and sources the file to apply changes immediately. If echo is true, it calls EchoVar. If quotes is true, it add quotes around the value
-func SetEnvAndSourceBashrc(key, value string, echo bool, quotes bool) error {
+// and sources the file to apply changes immediately. If echo is true, it calls EchoVar
+func SetEnvAndSourceBashrc(key, value string, echo bool) error {
 	// Get user's home directory
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -71,12 +71,8 @@ func SetEnvAndSourceBashrc(key, value string, echo bool, quotes bool) error {
 	}
 	defer file.Close()
 
-	// Write the export statement to the .bashrc file
-	if quotes {
-		_, err = fmt.Fprintf(file, "export %s=%s\n", key, value)
-	} else {
-		_, err = fmt.Fprintf(file, "export %s=%s\n", key, value)
-	}
+	_, err = fmt.Fprintf(file, "export %s=%s\n", key, value)
+
 	if err != nil {
 		return fmt.Errorf("failed to write to .bashrc file: %v", err)
 	}

--- a/otelcollector/shared/process_utilities.go
+++ b/otelcollector/shared/process_utilities.go
@@ -73,7 +73,7 @@ func SetEnvAndSourceBashrc(key, value string, echo bool, quotes bool) error {
 
 	// Write the export statement to the .bashrc file
 	if quotes {
-		_, err = fmt.Fprintf(file, "export %s=\\\"%s\\\"\n", key, value)
+		_, err = fmt.Fprintf(file, "export %s='%s'\n", key, value)
 	} else {
 		_, err = fmt.Fprintf(file, "export %s=%s\n", key, value)
 	}

--- a/otelcollector/shared/proxy_settings.go
+++ b/otelcollector/shared/proxy_settings.go
@@ -51,8 +51,8 @@ func addNoProxy(target string) {
 	noProxy := os.Getenv("NO_PROXY")
 	noProxy = strings.TrimSpace(noProxy)
 	noProxy += "," + target
-	SetEnvAndSourceBashrc("NO_PROXY", noProxy, true, false)
-	SetEnvAndSourceBashrc("no_proxy", noProxy, true, false)
+	SetEnvAndSourceBashrc("NO_PROXY", noProxy, true)
+	SetEnvAndSourceBashrc("no_proxy", noProxy, true)
 }
 
 func setHTTPProxyEnabled() {
@@ -60,7 +60,7 @@ func setHTTPProxyEnabled() {
 	if os.Getenv("HTTP_PROXY") != "" {
 		httpProxyEnabled = "true"
 	}
-	SetEnvAndSourceBashrc("HTTP_PROXY_ENABLED", httpProxyEnabled, true, false)
+	SetEnvAndSourceBashrc("HTTP_PROXY_ENABLED", httpProxyEnabled, true)
 }
 
 func ConfigureEnvironment() error {
@@ -69,7 +69,7 @@ func ConfigureEnvironment() error {
 	// Remove trailing '/' character from HTTP_PROXY and HTTPS_PROXY
 	proxyVariables := []string{"http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"}
 	for _, v := range proxyVariables {
-		SetEnvAndSourceBashrc(v, removeTrailingSlash(os.Getenv(v)), true, false)
+		SetEnvAndSourceBashrc(v, removeTrailingSlash(os.Getenv(v)), true)
 	}
 
 	addNoProxy("ama-metrics-operator-targets.kube-system.svc.cluster.local")
@@ -92,11 +92,11 @@ func ConfigureEnvironment() error {
 		password := base64.StdEncoding.EncodeToString([]byte(strings.SplitN(urlParts[0], ":", 2)[1]))
 		os.WriteFile("/opt/microsoft/proxy_password", []byte(password), 0644)
 
-		SetEnvAndSourceBashrc("MDSD_PROXY_MODE", "application", true, false)
-		SetEnvAndSourceBashrc("MDSD_PROXY_ADDRESS", os.Getenv("HTTPS_PROXY"), true, false)
+		SetEnvAndSourceBashrc("MDSD_PROXY_MODE", "application", true)
+		SetEnvAndSourceBashrc("MDSD_PROXY_ADDRESS", os.Getenv("HTTPS_PROXY"), true)
 		if user := strings.SplitN(urlParts[0], ":", 2)[0]; user != "" {
-			SetEnvAndSourceBashrc("MDSD_PROXY_USERNAME", user, true, false)
-			SetEnvAndSourceBashrc("MDSD_PROXY_PASSWORD_FILE", "/opt/microsoft/proxy_password", true, false)
+			SetEnvAndSourceBashrc("MDSD_PROXY_USERNAME", user, true)
+			SetEnvAndSourceBashrc("MDSD_PROXY_PASSWORD_FILE", "/opt/microsoft/proxy_password", true)
 		}
 	}
 

--- a/otelcollector/shared/telemetry.go
+++ b/otelcollector/shared/telemetry.go
@@ -45,7 +45,7 @@ func SetupTelemetry(customEnvironment string) {
 	}
 
 	// Export APPLICATIONINSIGHTS_AUTH
-	err := SetEnvAndSourceBashrc("APPLICATIONINSIGHTS_AUTH", encodedAIKey, false, false)
+	err := SetEnvAndSourceBashrc("APPLICATIONINSIGHTS_AUTH", encodedAIKey, false)
 	if err != nil {
 		fmt.Println("Error setting APPLICATIONINSIGHTS_AUTH environment variable:", err)
 		return
@@ -84,7 +84,7 @@ func SetupTelemetry(customEnvironment string) {
 	}
 	aiKey = string(aiKeyBytes)
 
-	err = SetEnvAndSourceBashrc("TELEMETRY_APPLICATIONINSIGHTS_KEY", aiKey, false, false)
+	err = SetEnvAndSourceBashrc("TELEMETRY_APPLICATIONINSIGHTS_KEY", aiKey, false)
 	if err != nil {
 		fmt.Println("Error setting TELEMETRY_APPLICATIONINSIGHTS_KEY environment variable:", err)
 		return


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

Fix image : 6.8.14-kaveesh-quote-7192024-07-19-2024-0875e04a

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
