### PR TITLE
remove both double and single quotes

### DIFF
--- a/otelcollector/shared/configmap/mp/prometheus-config-merger.go
+++ b/otelcollector/shared/configmap/mp/prometheus-config-merger.go
@@ -1083,10 +1083,13 @@ func populateDefaultPrometheusConfigWithOperator() {
 			if podannotationMetricsKeepListRegex != "" {
 				AppendMetricRelabelConfig(podAnnotationsDefaultFile, podannotationMetricsKeepListRegex)
 			}
-			// Trim the first and last escaped quotes
+			// Trim the first and last escaped quotes if they exist
 			if len(podannotationNamespacesRegex) > 1 && podannotationNamespacesRegex[0] == '"' && podannotationNamespacesRegex[len(podannotationNamespacesRegex)-1] == '"' {
 				podannotationNamespacesRegex = podannotationNamespacesRegex[1 : len(podannotationNamespacesRegex)-1]
 			}
+			// Additional trim to remove single quotes if present
+			podannotationNamespacesRegex = strings.Trim(podannotationNamespacesRegex, "'")
+
 			if podannotationNamespacesRegex != "" {
 				relabelConfig := []map[string]interface{}{
 					{"source_labels": []string{"__meta_kubernetes_namespace"}, "action": "keep", "regex": podannotationNamespacesRegex},

--- a/otelcollector/shared/configmap/mp/prometheus-config-merger.go
+++ b/otelcollector/shared/configmap/mp/prometheus-config-merger.go
@@ -639,16 +639,19 @@ func populateDefaultPrometheusConfig() {
 			podannotationMetricsKeepListRegex := regexHash["POD_ANNOTATION_METRICS_KEEP_LIST_REGEX"]
 			podannotationScrapeInterval, intervalExists := intervalHash["POD_ANNOTATION_SCRAPE_INTERVAL"]
 
-			// Print the value of podannotationNamespacesRegex
-			fmt.Printf("podannotationNamespacesRegex: %q\n", podannotationNamespacesRegex)
-			fmt.Printf("AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX: %q\n", os.Getenv("AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX"))
-
 			if intervalExists {
 				UpdateScrapeIntervalConfig(podAnnotationsDefaultFile, podannotationScrapeInterval)
 			}
 			if podannotationMetricsKeepListRegex != "" {
 				AppendMetricRelabelConfig(podAnnotationsDefaultFile, podannotationMetricsKeepListRegex)
 			}
+			// Trim the first and last escaped quotes if they exist
+			if len(podannotationNamespacesRegex) > 1 && podannotationNamespacesRegex[0] == '"' && podannotationNamespacesRegex[len(podannotationNamespacesRegex)-1] == '"' {
+				podannotationNamespacesRegex = podannotationNamespacesRegex[1 : len(podannotationNamespacesRegex)-1]
+			}
+			// Additional trim to remove single quotes if present
+			podannotationNamespacesRegex = strings.Trim(podannotationNamespacesRegex, "'")
+
 			if podannotationNamespacesRegex != "" {
 				relabelConfig := []map[string]interface{}{
 					{"source_labels": []string{"__meta_kubernetes_namespace"}, "action": "keep", "regex": podannotationNamespacesRegex},

--- a/otelcollector/shared/configmap/mp/prometheus-config-merger.go
+++ b/otelcollector/shared/configmap/mp/prometheus-config-merger.go
@@ -1073,10 +1073,6 @@ func populateDefaultPrometheusConfigWithOperator() {
 			podannotationMetricsKeepListRegex := regexHash["POD_ANNOTATION_METRICS_KEEP_LIST_REGEX"]
 			podannotationScrapeInterval, intervalExists := intervalHash["POD_ANNOTATION_SCRAPE_INTERVAL"]
 
-			// Print the value of podannotationNamespacesRegex
-			fmt.Printf("..podannotationNamespacesRegex: %q\n", podannotationNamespacesRegex)
-			fmt.Printf("..AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX: %q\n", os.Getenv("AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX"))
-
 			if intervalExists {
 				UpdateScrapeIntervalConfig(podAnnotationsDefaultFile, podannotationScrapeInterval)
 			}

--- a/otelcollector/shared/configmap/mp/prometheus-config-merger.go
+++ b/otelcollector/shared/configmap/mp/prometheus-config-merger.go
@@ -639,6 +639,10 @@ func populateDefaultPrometheusConfig() {
 			podannotationMetricsKeepListRegex := regexHash["POD_ANNOTATION_METRICS_KEEP_LIST_REGEX"]
 			podannotationScrapeInterval, intervalExists := intervalHash["POD_ANNOTATION_SCRAPE_INTERVAL"]
 
+			// Print the value of podannotationNamespacesRegex
+			fmt.Printf("podannotationNamespacesRegex: %q\n", podannotationNamespacesRegex)
+			fmt.Printf("AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX: %q\n", os.Getenv("AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX"))
+
 			if intervalExists {
 				UpdateScrapeIntervalConfig(podAnnotationsDefaultFile, podannotationScrapeInterval)
 			}

--- a/otelcollector/shared/configmap/mp/prometheus-config-merger.go
+++ b/otelcollector/shared/configmap/mp/prometheus-config-merger.go
@@ -1073,6 +1073,10 @@ func populateDefaultPrometheusConfigWithOperator() {
 			podannotationMetricsKeepListRegex := regexHash["POD_ANNOTATION_METRICS_KEEP_LIST_REGEX"]
 			podannotationScrapeInterval, intervalExists := intervalHash["POD_ANNOTATION_SCRAPE_INTERVAL"]
 
+			// Print the value of podannotationNamespacesRegex
+			fmt.Printf("..podannotationNamespacesRegex: %q\n", podannotationNamespacesRegex)
+			fmt.Printf("..AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX: %q\n", os.Getenv("AZMON_PROMETHEUS_POD_ANNOTATION_NAMESPACES_REGEX"))
+
 			if intervalExists {
 				UpdateScrapeIntervalConfig(podAnnotationsDefaultFile, podannotationScrapeInterval)
 			}


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
