### PR TITLE
Update DCRA for private linked cluster and create new DCE when cluster and workspace do not match

### DIFF
--- a/AddonTerraformTemplate/main.tf
+++ b/AddonTerraformTemplate/main.tf
@@ -92,12 +92,13 @@ resource "azurerm_monitor_data_collection_rule_association" "dcra" {
 
 resource "azurerm_monitor_data_collection_rule_association" "dcraprivatelink" {
   count = var.useAzureMonitorPrivateLinkScope && azurerm_kubernetes_cluster.k8s.location == azurerm_monitor_workspace.amw.location ? 1 : 0
-  name                = "${azurerm_kubernetes_cluster.k8s.id}/providers/microsoft.insights/dataCollectionRuleAssociations/configurationAccessEndpoint"
-  data_collection_rule_id = azurerm_monitor_data_collection_rule.dcr.id
+  data_collection_endpoint_id = azurerm_monitor_data_collection_endpoint.dce.id
   target_resource_id  = azurerm_kubernetes_cluster.k8s.id
   description             = "Association of data collection rule. Deleting this association will break the data collection for this AKS Cluster."
   depends_on = [
-    azurerm_monitor_data_collection_endpoint.dce
+    azurerm_monitor_data_collection_endpoint.dce,
+    azurerm_monitor_data_collection_rule.dcr,
+    azurerm_kubernetes_cluster.k8s
   ]
 }
 

--- a/AddonTerraformTemplate/main.tf
+++ b/AddonTerraformTemplate/main.tf
@@ -90,6 +90,17 @@ resource "azurerm_monitor_data_collection_rule_association" "dcra" {
   ]
 }
 
+resource "azurerm_monitor_data_collection_rule_association" "dcraprivatelink" {
+  count = var.useAzureMonitorPrivateLinkScope && azurerm_kubernetes_cluster.k8s.location == azurerm_monitor_workspace.amw.location ? 1 : 0
+  name                = "${azurerm_kubernetes_cluster.k8s.id}/providers/microsoft.insights/dataCollectionRuleAssociations/configurationAccessEndpoint"
+  data_collection_rule_id = azurerm_monitor_data_collection_rule.dcr.id
+  target_resource_id  = azurerm_kubernetes_cluster.k8s.id
+  description             = "Association of data collection rule. Deleting this association will break the data collection for this AKS Cluster."
+  depends_on = [
+    azurerm_monitor_data_collection_endpoint.dce
+  ]
+}
+
 resource "azurerm_dashboard_grafana" "grafana" {
   name                = var.grafana_name
   resource_group_name = azurerm_resource_group.rg.name

--- a/AddonTerraformTemplate/variables.tf
+++ b/AddonTerraformTemplate/variables.tf
@@ -37,3 +37,8 @@ variable "resource_group_location" {
   default     = "eastus"
   description = "Location of the resource group."
 }
+
+variable "useAzureMonitorPrivateLinkScope" {
+  description = "Condition to use Azure Monitor Private Link Scope"
+  type        = bool
+}

--- a/AddonTerraformTemplate/variables.tf
+++ b/AddonTerraformTemplate/variables.tf
@@ -42,3 +42,9 @@ variable "useAzureMonitorPrivateLinkScope" {
   description = "Condition to use Azure Monitor Private Link Scope"
   type        = bool
 }
+
+variable "private_link_dce_id" {
+  description = "Data Collection Endpoint ID to use if cluster and workspace regions do not match"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description
This change updates DCRA for private linked cluster based on flag and create new DCE when cluster and workspace do not match.
The manual linking for the DCE to the cluster resource is no longer needed after this change.
After manual linking , a PUT request is made to create a DCRA with name "configurationAccessEndpoint".
This change makes sure this new DCRA(configurationAccessEndpoint) is created and linking is done only if useAzureMonitorPrivateLinkScope flag is enabled and if DCE and cluster are in same region.
Below are screenshots of the linking:

Step showing network capture while manually adding DCRA
<img width="1895" alt="priavatelinktest" src="https://github.com/user-attachments/assets/64ed37fe-aba2-4c2a-bbfb-ac86e922d42d">


Step showing creation of DCRA . Name defaults to configurationAccessEndpoint -> [doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_data_collection_rule_association).
<img width="1762" alt="priavatelinktest1" src="https://github.com/user-attachments/assets/dbd0e62c-f536-4152-9395-82c093eca2db">



Step showing creation of DCRA in portal.
<img width="1864" alt="priavatelinktest2" src="https://github.com/user-attachments/assets/b0dc42c5-853a-4a60-aa66-f09bd019a4d3">


[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
