### PR TITLE
test: support two shards for e2e tests

### DIFF
--- a/otelcollector/test/ginkgo-e2e/prometheusui/prometheus_ui_test.go
+++ b/otelcollector/test/ginkgo-e2e/prometheusui/prometheus_ui_test.go
@@ -13,46 +13,65 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/install" // Register service discovery implementations.
 )
 
+var _ = Describe("The Prometheus UI API", func() {
+	Context("for all replicaset pods", func() {
+		It("should return the scrape pools for all replicaset pods", func() {
+			// Test that the Prometheus UI /scrape_pools API endpoint returns a list that contains at least the default targets.
+			var apiResponses = make([]*utils.APIResponse, 2)
+			err := utils.QueryPromUIFromPods(K8sClient, Cfg, "kube-system", "rsName", "ama-metrics", "prometheus-collector", "/api/v1/scrape_pools", true, true, apiResponses)
+			Expect(err).NotTo(HaveOccurred())
+
+			allScrapePools := make([]string, 0)
+			for _, apiResponse := range apiResponses {
+				Expect(apiResponse).NotTo(BeNil())
+				Expect(apiResponse.Data).NotTo(BeNil())
+
+				var scrapePoolData utils.ScrapePoolData
+				json.Unmarshal([]byte(apiResponse.Data), &scrapePoolData)
+				Expect(scrapePoolData).NotTo(BeNil())
+				allScrapePools = append(allScrapePools, scrapePoolData.ScrapePools...)
+			}
+
+			Expect(allScrapePools).To(ContainElements("kube-state-metrics", "kubernetes-pods", "prometheus_ref_app"))
+		})
+	})
+})
+
 /*
  * Test that the Prometheus UI /scrape_pools API endpoint returns a list that contains at least the default targets.
  */
 var _ = DescribeTable("The Prometheus UI API should return the scrape pools",
-  func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool, expected []string) {
-    var apiResponse utils.APIResponse
-    err := utils.QueryPromUIFromPod(K8sClient, Cfg, namespace, controllerLabelName, controllerLabelValue, containerName, "/api/v1/scrape_pools", isLinux, &apiResponse)
-    Expect(err).NotTo(HaveOccurred())
-    Expect(apiResponse.Data).NotTo(BeNil())
+	func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool, expected []string) {
+		time.Sleep(60 * time.Second)
+		var apiResponse utils.APIResponse
+		err := utils.QueryPromUIFromPod(K8sClient, Cfg, namespace, controllerLabelName, controllerLabelValue, containerName, "/api/v1/scrape_pools", isLinux, &apiResponse)
+		Expect(err).NotTo(HaveOccurred())
 
-    var scrapePoolData utils.ScrapePoolData
-    json.Unmarshal([]byte(apiResponse.Data), &scrapePoolData)
-    Expect(scrapePoolData).NotTo(BeNil())
-    Expect(scrapePoolData.ScrapePools).To(ContainElements(expected))
-  },
-  Entry("when called inside the ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector",
+		Expect(apiResponse).NotTo(BeNil())
+		Expect(apiResponse.Data).NotTo(BeNil())
+
+		var scrapePoolData utils.ScrapePoolData
+		json.Unmarshal([]byte(apiResponse.Data), &scrapePoolData)
+		Expect(scrapePoolData).NotTo(BeNil())
+		Expect(scrapePoolData.ScrapePools).To(ContainElements(expected))
+	},
+	Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector",
 		true,
-    []string {
-      "kube-state-metrics",
-      "kubernetes-pods",
-      "prometheus_ref_app",
-    },
-  ),
-  Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector",
-		true,
-    []string {
-      "cadvisor",
-      "kubelet",
-      "networkobservability-cilium",
-      "networkobservability-hubble",
-      "networkobservability-retina",
-      "node",
-    },
-  ),
+		[]string{
+			"cadvisor",
+			"kubelet",
+			"networkobservability-cilium",
+			"networkobservability-hubble",
+			"networkobservability-retina",
+			"node",
+		},
+	),
 	Entry("when checking the ama-metrics-win-node", "kube-system", "dsName", "ama-metrics-win-node", "prometheus-collector",
 		false,
-		[]string {
+		[]string{
 			"kappie-basic",
-      "kubelet",
-      "networkobservability-retina",
+			"kubelet",
+			"networkobservability-retina",
 		},
 		Label(utils.WindowsLabel),
 	),
@@ -62,24 +81,24 @@ var _ = DescribeTable("The Prometheus UI API should return the scrape pools",
  * Test that the Prometheus UI /config API endpoint returns a Prometheus config that can be unmarshaled.
  */
 var _ = DescribeTable("The Prometheus UI API should return a valid config",
-  func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool) {
-		time.Sleep(30 * time.Second)
-    var apiResponse utils.APIResponse
-    err := utils.QueryPromUIFromPod(K8sClient, Cfg, namespace, controllerLabelName, controllerLabelValue, containerName, "/api/v1/status/config", isLinux, &apiResponse)
-    Expect(err).NotTo(HaveOccurred())
-    Expect(apiResponse.Data).NotTo(BeNil())
+	func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool) {
+		time.Sleep(120 * time.Second)
+		var apiResponse utils.APIResponse
+		err := utils.QueryPromUIFromPod(K8sClient, Cfg, namespace, controllerLabelName, controllerLabelValue, containerName, "/api/v1/status/config", isLinux, &apiResponse)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(apiResponse.Data).NotTo(BeNil())
 
-    var prometheusConfigResult v1.ConfigResult
-    json.Unmarshal([]byte(apiResponse.Data), &prometheusConfigResult)
-    Expect(prometheusConfigResult).NotTo(BeNil())
-    Expect(prometheusConfigResult.YAML).NotTo(BeEmpty())
+		var prometheusConfigResult v1.ConfigResult
+		json.Unmarshal([]byte(apiResponse.Data), &prometheusConfigResult)
+		Expect(prometheusConfigResult).NotTo(BeNil())
+		Expect(prometheusConfigResult.YAML).NotTo(BeEmpty())
 
-    prometheusConfig, err := config.Load(prometheusConfigResult.YAML, true, nil)
-    Expect(err).NotTo(HaveOccurred())
-    Expect(prometheusConfig).NotTo(BeNil())
-  },
-  Entry("when called inside ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true),
-  Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true),
+		prometheusConfig, err := config.Load(prometheusConfigResult.YAML, true, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(prometheusConfig).NotTo(BeNil())
+	},
+	Entry("when called inside ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true),
+	Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true),
 	Entry("when checking the ama-metrics-win-node", "kube-system", "dsName", "ama-metrics-win-node", "prometheus-collector", false, Label(utils.WindowsLabel)),
 )
 
@@ -87,28 +106,28 @@ var _ = DescribeTable("The Prometheus UI API should return a valid config",
  * Test that the Prometheus UI /targets API endpoint returns a list of active and dropped targets.
  */
 var _ = DescribeTable("The Prometheus UI API should return the targets",
-  func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool) {
-		time.Sleep(60 * time.Second)
+	func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool) {
+		time.Sleep(180 * time.Second)
 
-    var apiResponse utils.APIResponse
-    err := utils.QueryPromUIFromPod(K8sClient, Cfg, namespace, controllerLabelName, controllerLabelValue, containerName, "/api/v1/targets", isLinux, &apiResponse)
-    Expect(err).NotTo(HaveOccurred())
-    Expect(apiResponse.Data).NotTo(BeNil())
+		var apiResponse utils.APIResponse
+		err := utils.QueryPromUIFromPod(K8sClient, Cfg, namespace, controllerLabelName, controllerLabelValue, containerName, "/api/v1/targets", isLinux, &apiResponse)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(apiResponse.Data).NotTo(BeNil())
 
-    var targetsResult v1.TargetsResult
-    json.Unmarshal([]byte(apiResponse.Data), &targetsResult)
+		var targetsResult v1.TargetsResult
+		json.Unmarshal([]byte(apiResponse.Data), &targetsResult)
 
-    Expect(targetsResult).NotTo(BeNil())
-    Expect(targetsResult.Active).NotTo(BeNil())
-    Expect(targetsResult.Dropped).NotTo(BeNil())
-    for _, target := range targetsResult.Active {
-      Expect(target.DiscoveredLabels).NotTo(BeNil())
-      Expect(target.Labels).NotTo(BeNil())
-    }
-    Expect(targetsResult.Dropped).NotTo(BeNil())
-  },
-  Entry("when called inside ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true),
-  Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true),
+		Expect(targetsResult).NotTo(BeNil())
+		Expect(targetsResult.Active).NotTo(BeNil())
+		Expect(targetsResult.Dropped).NotTo(BeNil())
+		for _, target := range targetsResult.Active {
+			Expect(target.DiscoveredLabels).NotTo(BeNil())
+			Expect(target.Labels).NotTo(BeNil())
+		}
+		Expect(targetsResult.Dropped).NotTo(BeNil())
+	},
+	Entry("when called inside ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true),
+	Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true),
 	Entry("when checking the ama-metrics-win-node", "kube-system", "dsName", "ama-metrics-win-node", "prometheus-collector", false, Label(utils.WindowsLabel)),
 )
 
@@ -116,113 +135,113 @@ var _ = DescribeTable("The Prometheus UI API should return the targets",
  * Test that the Prometheus UI /targets/metadata API endpoiont returns a list of targets with metadata.
  */
 var _ = DescribeTable("The Prometheus UI API should return the targets metadata",
-  func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool) {
-    time.Sleep(90 * time.Second)
+	func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool) {
+		time.Sleep(240 * time.Second)
 
-    var apiResponse utils.APIResponse
+		var apiResponse utils.APIResponse
 		queryPath := "/api/v1/targets/metadata?match_target=\\{job=\\\"prometheus_ref_app\\\"\\}"
 		if !isLinux {
 			queryPath = "/api/v1/targets/metadata?match_target={job=`\"kubelet`\"}"
 		}
-    err := utils.QueryPromUIFromPod(K8sClient, Cfg, namespace, controllerLabelName, controllerLabelValue, containerName,
-      queryPath, isLinux,
-      &apiResponse,
-    )
-    Expect(err).NotTo(HaveOccurred())
-    Expect(apiResponse.Data).NotTo(BeNil())
+		err := utils.QueryPromUIFromPod(K8sClient, Cfg, namespace, controllerLabelName, controllerLabelValue, containerName,
+			queryPath, isLinux,
+			&apiResponse,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(apiResponse.Data).NotTo(BeNil())
 
-    var metricMetadataResult []v1.MetricMetadata
-    json.Unmarshal([]byte(apiResponse.Data), &metricMetadataResult)
+		var metricMetadataResult []v1.MetricMetadata
+		json.Unmarshal([]byte(apiResponse.Data), &metricMetadataResult)
 
-    Expect(metricMetadataResult).NotTo(BeNil())
-    for _, metricMetadata := range metricMetadataResult {
-      Expect(metricMetadata.Target).NotTo(BeNil())
-      Expect(metricMetadata.Metric).NotTo(BeEmpty())
-      Expect(metricMetadata.Type).NotTo(BeEmpty())
-    }
-  },
-  Entry("when called inside ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true),
-  Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true),
+		Expect(metricMetadataResult).NotTo(BeNil())
+		for _, metricMetadata := range metricMetadataResult {
+			Expect(metricMetadata.Target).NotTo(BeNil())
+			Expect(metricMetadata.Metric).NotTo(BeEmpty())
+			Expect(metricMetadata.Type).NotTo(BeEmpty())
+		}
+	},
+	Entry("when called inside ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true),
+	Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true),
 	Entry("when checking the ama-metrics-win-node", "kube-system", "dsName", "ama-metrics-win-node", "prometheus-collector", false, Label(utils.WindowsLabel)),
 )
 
 /*
  * Test that the Prometheus UI /metrics endpoiont returns the Prometheus metrics.
  */
- var _ = DescribeTable("The Prometheus UI should return the /metrics data",
- func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool) {
+var _ = DescribeTable("The Prometheus UI should return the /metrics data",
+	func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool) {
 
-	time.Sleep(120 * time.Second)
+		time.Sleep(300 * time.Second)
 
-	pods, err := utils.GetPodsWithLabel(K8sClient, namespace, controllerLabelName, controllerLabelValue)
-	Expect(err).NotTo(HaveOccurred())
-
-	for _, pod := range pods {
-		// Execute the command and capture the output
-		var command []string
-		if isLinux {
-			command = []string{"sh", "-c", "curl \"http://localhost:9090/metrics\""}
-		} else {
-			command = []string{"powershell", "-c", "(curl \"http://localhost:9090/metrics\" -UseBasicParsing).Content"}
-		}
-		stdout, _, err := utils.ExecCmd(K8sClient, Cfg, pod.Name, containerName, namespace, command)
+		pods, err := utils.GetPodsWithLabel(K8sClient, namespace, controllerLabelName, controllerLabelValue)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(stdout).NotTo(BeEmpty())
-		Expect(stdout).NotTo(ContainSubstring("404 page not found"))
-		Expect(stdout).To(ContainSubstring("prometheus_target_scrape_pool_targets"))
-	}
-	
-	return
-},
- Entry("when called inside ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true),
- Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true),
- Entry("when checking the ama-metrics-win-node", "kube-system", "dsName", "ama-metrics-win-node", "prometheus-collector", false, Label(utils.WindowsLabel)),
+
+		for _, pod := range pods {
+			// Execute the command and capture the output
+			var command []string
+			if isLinux {
+				command = []string{"sh", "-c", "curl \"http://localhost:9090/metrics\""}
+			} else {
+				command = []string{"powershell", "-c", "(curl \"http://localhost:9090/metrics\" -UseBasicParsing).Content"}
+			}
+			stdout, _, err := utils.ExecCmd(K8sClient, Cfg, pod.Name, containerName, namespace, command)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stdout).NotTo(BeEmpty())
+			Expect(stdout).NotTo(ContainSubstring("404 page not found"))
+			Expect(stdout).To(ContainSubstring("prometheus_target_scrape_pool_targets"))
+		}
+
+		return
+	},
+	Entry("when called inside ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true),
+	Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true),
+	Entry("when checking the ama-metrics-win-node", "kube-system", "dsName", "ama-metrics-win-node", "prometheus-collector", false, Label(utils.WindowsLabel)),
 )
 
 /*
  * Test that the Prometheus UI does not return a 404 for each UI page.
  */
 var _ = DescribeTable("The Prometheus UI should return a 200 for its UI pages",
-  func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool, uiPaths []string) {
+	func(namespace string, controllerLabelName string, controllerLabelValue string, containerName string, isLinux bool, uiPaths []string) {
 
-		time.Sleep(180 * time.Second)
-    pods, err := utils.GetPodsWithLabel(K8sClient, namespace, controllerLabelName, controllerLabelValue)
-    Expect(err).NotTo(HaveOccurred())
-  
-    for _, pod := range pods {
-      // Execute the command and capture the output
-      for _, uiPath := range uiPaths {
+		time.Sleep(360 * time.Second)
+		pods, err := utils.GetPodsWithLabel(K8sClient, namespace, controllerLabelName, controllerLabelValue)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, pod := range pods {
+			// Execute the command and capture the output
+			for _, uiPath := range uiPaths {
 				var command []string
 				if isLinux {
 					command = []string{"sh", "-c", fmt.Sprintf("curl \"http://localhost:9090%s\"", uiPath)}
 				} else {
 					command = []string{"powershell", "-c", fmt.Sprintf("(curl \"http://localhost:9090/%s\" -UseBasicParsing).Content", uiPath)}
 				}
-        stdout, _, err := utils.ExecCmd(K8sClient, Cfg, pod.Name, containerName, namespace, command)
-        Expect(err).NotTo(HaveOccurred())
-        Expect(stdout).NotTo(BeEmpty())
-        Expect(stdout).NotTo(ContainSubstring("404 page not found"))
-      }
+				stdout, _, err := utils.ExecCmd(K8sClient, Cfg, pod.Name, containerName, namespace, command)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).NotTo(BeEmpty())
+				Expect(stdout).NotTo(ContainSubstring("404 page not found"))
+			}
 
 			return
-    }
-  },
-  Entry("when called inside the ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true,
-    []string{
-      "/agent",
-      "/config",
-      "/targets",
-      "/service-discovery",
-    },
-  ),
-  Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true,
-    []string{
-      "/agent",
-      "/config",
-      "/targets",
-      "/service-discovery",
-    },
-  ),
+		}
+	},
+	Entry("when called inside the ama-metrics replica pod", "kube-system", "rsName", "ama-metrics", "prometheus-collector", true,
+		[]string{
+			"/agent",
+			"/config",
+			"/targets",
+			"/service-discovery",
+		},
+	),
+	Entry("when called inside the ama-metrics-node pod", "kube-system", "dsName", "ama-metrics-node", "prometheus-collector", true,
+		[]string{
+			"/agent",
+			"/config",
+			"/targets",
+			"/service-discovery",
+		},
+	),
 	Entry("when called inside the ama-metrics-win-node pod", "kube-system", "dsName", "ama-metrics-win-node", "prometheus-collector", false,
 		[]string{
 			"/agent",
@@ -231,5 +250,5 @@ var _ = DescribeTable("The Prometheus UI should return a 200 for its UI pages",
 			"/service-discovery",
 		},
 		Label(utils.WindowsLabel),
-  ),
+	),
 )

--- a/otelcollector/test/ginkgo-e2e/utils/prometheus_ui_api_utils.go
+++ b/otelcollector/test/ginkgo-e2e/utils/prometheus_ui_api_utils.go
@@ -16,64 +16,106 @@ import (
  * The format of the response from the Prometheus UI API paths: /api/v1/*
  */
 type APIResponse struct {
-  Status    string          `json:"status"`
-  Data      json.RawMessage `json:"data"`
-  ErrorType v1.ErrorType    `json:"errorType"`
-  Error     string          `json:"error"`
-  Warnings  []string        `json:"warnings,omitempty"`
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data"`
+	ErrorType v1.ErrorType    `json:"errorType"`
+	Error     string          `json:"error"`
+	Warnings  []string        `json:"warnings,omitempty"`
 }
 
 /*
  * The scrape pool data from the API response.
  */
 type ScrapePoolData struct {
-  ScrapePools []string `json:"scrapePools"`
+	ScrapePools []string `json:"scrapePools"`
 }
 
 /*
  * The Prometheus Config from the API response.
  */
 type PrometheusConfigData struct {
-  PrometheusConfigYAML string `json:"yaml"`
+	PrometheusConfigYAML string `json:"yaml"`
 }
 
 /*
  * Exec into the container in a pod with the specified namespace and label and curl the Prometheus UI with the specified path.
  */
-func QueryPromUIFromPod(clientset *kubernetes.Clientset, cfg *rest.Config, namespace string, labelKey string, labelValue string, containerName string, queryPath string, isLinux bool, result *APIResponse) (error) {
-  pods, err := GetPodsWithLabel(clientset, namespace, labelKey, labelValue)
-  if err != nil {
-    return err
-  }
+func QueryPromUIFromPod(clientset *kubernetes.Clientset, cfg *rest.Config, namespace string, labelKey string, labelValue string, containerName string, queryPath string, isLinux bool, result *APIResponse) error {
+	pods, err := GetPodsWithLabel(clientset, namespace, labelKey, labelValue)
+	if err != nil {
+		return err
+	}
 
-  for _, pod := range pods {
-    // Execute the command and capture the output
+	for _, pod := range pods {
+		// Execute the command and capture the output
 		var command []string
 		if isLinux {
 			command = []string{"sh", "-c", fmt.Sprintf("curl \"http://localhost:9090%s\"", queryPath)}
 		} else {
 			command = []string{"powershell", "-c", fmt.Sprintf("(curl \"http://localhost:9090%s\" %s).Content", queryPath, "-UseBasicParsing")}
 		}
-    stdout, _, err := ExecCmd(clientset, cfg, pod.Name, containerName, namespace, command)
-    if err != nil {
-      return err
-    }
+		stdout, _, err := ExecCmd(clientset, cfg, pod.Name, containerName, namespace, command)
+		if err != nil {
+			return err
+		}
 
-    if stdout == "" {
-      return fmt.Errorf("Curl for %s was empty", queryPath)
-    }
+		if stdout == "" {
+			return fmt.Errorf("Curl for %s was empty", queryPath)
+		}
 
-    err = json.Unmarshal([]byte(stdout), &result)
-    if err != nil {
-      return fmt.Errorf("Failed to unmarshal the json: %s", err.Error())
-    }
-  
-    if result.Status != "success" {
-      return fmt.Errorf("Failed to query from Prometheus UI: %s", stdout)
-    }
+		err = json.Unmarshal([]byte(stdout), &result)
+		if err != nil {
+			return fmt.Errorf("Failed to unmarshal the json: %s", err.Error())
+		}
 
-    return nil
-  }
+		if result.Status != "success" {
+			return fmt.Errorf("Failed to query from Prometheus UI: %s", stdout)
+		}
 
-  return nil
+	}
+
+	return nil
+}
+
+/*
+ * Exec into the container in a pod with the specified namespace and label and curl the Prometheus UI with the specified path.
+ */
+func QueryPromUIFromPods(clientset *kubernetes.Clientset, cfg *rest.Config, namespace string, labelKey string, labelValue string, containerName string, queryPath string, isLinux bool, isReplicaSet bool, result []*APIResponse) error {
+	pods, err := GetPodsWithLabel(clientset, namespace, labelKey, labelValue)
+	if err != nil {
+		return err
+	}
+
+	for i, pod := range pods {
+		// Execute the command and capture the output
+		var command []string
+		if isLinux {
+			command = []string{"sh", "-c", fmt.Sprintf("curl \"http://localhost:9090%s\"", queryPath)}
+		} else {
+			command = []string{"powershell", "-c", fmt.Sprintf("(curl \"http://localhost:9090%s\" %s).Content", queryPath, "-UseBasicParsing")}
+		}
+		stdout, _, err := ExecCmd(clientset, cfg, pod.Name, containerName, namespace, command)
+		if err != nil {
+			return err
+		}
+
+		if stdout == "" {
+			return fmt.Errorf("Curl for %s was empty", queryPath)
+		}
+
+		err = json.Unmarshal([]byte(stdout), &result[i])
+		if err != nil {
+			return fmt.Errorf("Failed to unmarshal the json: %s", err.Error())
+		}
+
+		if result[i].Status != "success" {
+			return fmt.Errorf("Failed to query from Prometheus UI: %s", stdout)
+		}
+
+		if !isReplicaSet {
+			return nil
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description
The Prometheus UI tests check all replicaset shards to make sure all expected scrape targets are discovered.

Adds a timeout to the exec util
