### PR TITLE
WIP: otelcollector: add CRI metrics to default set

### DIFF
--- a/otelcollector/configmapparser/default-prom-configs/criDefaultDs.yml
+++ b/otelcollector/configmapparser/default-prom-configs/criDefaultDs.yml
@@ -1,0 +1,20 @@
+  scrape_configs:
+  - job_name: node_runtime
+    scheme: http
+    metrics_path: /v1/metrics
+    scrape_interval: $$SCRAPE_INTERVAL$$
+    label_limit: 63
+    label_name_length_limit: 511
+    label_value_length_limit: 1023
+    relabel_configs:
+    - source_labels: [__metrics_path__]
+      regex: (.*)
+      target_label: metrics_path
+    - source_labels: [__address__]
+      replacement: '$$NODE_NAME$$'
+      target_label: instance
+    - source_labels: [__address__]
+      replacement: '$$OS_TYPE$$'
+      target_label: "kubernetes_io_os"
+    static_configs:
+    - targets: ['$$NODE_IP$$:10257']

--- a/otelcollector/configmapparser/prometheus-config-merger-with-operator.rb
+++ b/otelcollector/configmapparser/prometheus-config-merger-with-operator.rb
@@ -24,6 +24,7 @@ LOGGING_PREFIX = "prometheus-config-merger-with-operator"
 @kubeletDefaultFileRsSimple = @defaultPromConfigPathPrefix + "kubeletDefaultRsSimple.yml"
 @kubeletDefaultFileRsAdvanced = @defaultPromConfigPathPrefix + "kubeletDefaultRsAdvanced.yml"
 @kubeletDefaultFileDs = @defaultPromConfigPathPrefix + "kubeletDefaultDs.yml"
+@criDefaultFileDs = @defaultPromConfigPathPrefix + "criDefaultDs.yml"
 @kubeletDefaultFileRsAdvancedWindowsDaemonset = @defaultPromConfigPathPrefix + "kubeletDefaultRsAdvancedWindowsDaemonset.yml"
 @corednsDefaultFile = @defaultPromConfigPathPrefix + "corednsDefault.yml"
 @cadvisorDefaultFileRsSimple = @defaultPromConfigPathPrefix + "cadvisorDefaultRsSimple.yml"
@@ -228,6 +229,15 @@ def populateDefaultPrometheusConfig
           contents = contents.gsub("$$OS_TYPE$$", ENV["OS_TYPE"])
           File.open(@kubeletDefaultFileDs, "w") { |file| file.puts contents }
           defaultConfigs.push(@kubeletDefaultFileDs)
+        end
+        if advancedMode == true && currentControllerType == @daemonsetControllerType && (ENV["OS_TYPE"].downcase == "linux")
+          UpdateScrapeIntervalConfig(@criDefaultFileDs, kubeletScrapeInterval)
+          contents = File.read(@criDefaultFileDs)
+          contents = contents.gsub("$$NODE_IP$$", ENV["NODE_IP"])
+          contents = contents.gsub("$$NODE_NAME$$", ENV["NODE_NAME"])
+          contents = contents.gsub("$$OS_TYPE$$", ENV["OS_TYPE"])
+          File.open(@criDefaultFileDs, "w") { |file| file.puts contents }
+          defaultConfigs.push(@criDefaultFileDs)
         end
       end
     end
@@ -596,7 +606,7 @@ end
 
 def setDefaultFileScrapeInterval(scrapeInterval)
   defaultFilesArray = [
-    @kubeletDefaultFileRsSimple, @kubeletDefaultFileRsAdvanced, @kubeletDefaultFileDs, @kubeletDefaultFileRsAdvancedWindowsDaemonset,
+    @kubeletDefaultFileRsSimple, @kubeletDefaultFileRsAdvanced, @kubeletDefaultFileDs, @criDefaultFileDs, @kubeletDefaultFileRsAdvancedWindowsDaemonset,
     @corednsDefaultFile, @cadvisorDefaultFileRsSimple, @cadvisorDefaultFileRsAdvanced, @cadvisorDefaultFileDs, @kubeproxyDefaultFile,
     @apiserverDefaultFile, @kubestateDefaultFile, @nodeexporterDefaultFileRsSimple, @nodeexporterDefaultFileRsAdvanced, @nodeexporterDefaultFileDs,
     @prometheusCollectorHealthDefaultFile, @windowsexporterDefaultRsSimpleFile, @windowsexporterDefaultDsFile,

--- a/otelcollector/configmapparser/prometheus-config-merger.rb
+++ b/otelcollector/configmapparser/prometheus-config-merger.rb
@@ -23,6 +23,7 @@ LOGGING_PREFIX = "prometheus-config-merger"
 @kubeletDefaultFileRsSimple = @defaultPromConfigPathPrefix + "kubeletDefaultRsSimple.yml"
 @kubeletDefaultFileRsAdvanced = @defaultPromConfigPathPrefix + "kubeletDefaultRsAdvanced.yml"
 @kubeletDefaultFileDs = @defaultPromConfigPathPrefix + "kubeletDefaultDs.yml"
+@criDefaultFileDs = @defaultPromConfigPathPrefix + "criDefaultDs.yml"
 @kubeletDefaultFileRsAdvancedWindowsDaemonset = @defaultPromConfigPathPrefix + "kubeletDefaultRsAdvancedWindowsDaemonset.yml"
 @corednsDefaultFile = @defaultPromConfigPathPrefix + "corednsDefault.yml"
 @cadvisorDefaultFileRsSimple = @defaultPromConfigPathPrefix + "cadvisorDefaultRsSimple.yml"
@@ -209,6 +210,15 @@ def populateDefaultPrometheusConfig
           contents = contents.gsub("$$OS_TYPE$$", ENV["OS_TYPE"])
           File.open(@kubeletDefaultFileDs, "w") { |file| file.puts contents }
           defaultConfigs.push(@kubeletDefaultFileDs)
+        end
+        if advancedMode == true && (ENV["OS_TYPE"].downcase == "linux")
+          UpdateScrapeIntervalConfig(@criDefaultFileDs, kubeletScrapeInterval)
+          contents = File.read(@criDefaultFileDs)
+          contents = contents.gsub("$$NODE_IP$$", ENV["NODE_IP"])
+          contents = contents.gsub("$$NODE_NAME$$", ENV["NODE_NAME"])
+          contents = contents.gsub("$$OS_TYPE$$", ENV["OS_TYPE"])
+          File.open(@criDefaultFileDs, "w") { |file| file.puts contents }
+          defaultConfigs.push(@criDefaultFileDs)
         end
       end
     end
@@ -574,7 +584,7 @@ end
 
 def setDefaultFileScrapeInterval(scrapeInterval)
   defaultFilesArray = [
-    @kubeletDefaultFileRsSimple, @kubeletDefaultFileRsAdvanced, @kubeletDefaultFileDs, @kubeletDefaultFileRsAdvancedWindowsDaemonset,
+    @kubeletDefaultFileRsSimple, @kubeletDefaultFileRsAdvanced, @kubeletDefaultFileDs, @criDefaultFileDs, @kubeletDefaultFileRsAdvancedWindowsDaemonset,
     @corednsDefaultFile, @cadvisorDefaultFileRsSimple, @cadvisorDefaultFileRsAdvanced, @cadvisorDefaultFileDs, @kubeproxyDefaultFile,
     @apiserverDefaultFile, @kubestateDefaultFile, @nodeexporterDefaultFileRsSimple, @nodeexporterDefaultFileRsAdvanced, @nodeexporterDefaultFileDs,
     @prometheusCollectorHealthDefaultFile, @windowsexporterDefaultRsSimpleFile, @windowsexporterDefaultDsFile,

--- a/otelcollector/shared/configmap/mp/definitions.go
+++ b/otelcollector/shared/configmap/mp/definitions.go
@@ -24,6 +24,7 @@ var (
 	kubeletDefaultFileRsSimple                   = "kubeletDefaultRsSimple.yml"
 	kubeletDefaultFileRsAdvanced                 = "kubeletDefaultRsAdvanced.yml"
 	kubeletDefaultFileDs                         = "kubeletDefaultDs.yml"
+	criDefaultFileDs                             = "criDefaultDs.yml"
 	kubeletDefaultFileRsAdvancedWindowsDaemonset = "kubeletDefaultRsAdvancedWindowsDaemonset.yml"
 	coreDNSDefaultFile                           = "corednsDefault.yml"
 	cadvisorDefaultFileRsSimple                  = "cadvisorDefaultRsSimple.yml"

--- a/otelcollector/shared/configmap/mp/prometheus-config-merger.go
+++ b/otelcollector/shared/configmap/mp/prometheus-config-merger.go
@@ -299,6 +299,19 @@ func populateDefaultPrometheusConfig() {
 					}
 				}
 			}
+			if advancedMode && (strings.ToLower(os.Getenv("OS_TYPE")) == "linux") {
+				UpdateScrapeIntervalConfig(criDefaultFileDs, kubeletScrapeInterval)
+				contents, err := os.ReadFile(criDefaultFileDs)
+				if err == nil {
+					contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_IP$$", os.Getenv("NODE_IP")))
+					contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_NAME$$", os.Getenv("NODE_NAME")))
+					contents = []byte(strings.ReplaceAll(string(contents), "$$OS_TYPE$$", os.Getenv("OS_TYPE")))
+					err = os.WriteFile(criDefaultFileDs, contents, 0644)
+					if err == nil {
+						defaultConfigs = append(defaultConfigs, criDefaultFileDs)
+					}
+				}
+			}
 		}
 	}
 
@@ -731,6 +744,19 @@ func populateDefaultPrometheusConfigWithOperator() {
 					err = os.WriteFile(kubeletDefaultFileDs, contents, 0644)
 					if err == nil {
 						defaultConfigs = append(defaultConfigs, kubeletDefaultFileDs)
+					}
+				}
+			}
+			if advancedMode && currentControllerType == daemonsetControllerType && (strings.ToLower(os.Getenv("OS_TYPE")) == "linux") {
+				UpdateScrapeIntervalConfig(criDefaultFileDs, kubeletScrapeInterval)
+				contents, err := os.ReadFile(criDefaultFileDs)
+				if err == nil {
+					contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_IP$$", os.Getenv("NODE_IP")))
+					contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_NAME$$", os.Getenv("NODE_NAME")))
+					contents = []byte(strings.ReplaceAll(string(contents), "$$OS_TYPE$$", os.Getenv("OS_TYPE")))
+					err = os.WriteFile(criDefaultFileDs, contents, 0644)
+					if err == nil {
+						defaultConfigs = append(defaultConfigs, criDefaultFileDs)
 					}
 				}
 			}
@@ -1209,7 +1235,7 @@ func writeDefaultScrapeTargetsFile(operatorEnabled bool) map[interface{}]interfa
 
 func setDefaultFileScrapeInterval(scrapeInterval string) {
 	defaultFilesArray := []string{
-		kubeletDefaultFileRsSimple, kubeletDefaultFileRsAdvanced, kubeletDefaultFileDs,
+		kubeletDefaultFileRsSimple, kubeletDefaultFileRsAdvanced, kubeletDefaultFileDs, criDefaultFileDs,
 		kubeletDefaultFileRsAdvancedWindowsDaemonset, coreDNSDefaultFile,
 		cadvisorDefaultFileRsSimple, cadvisorDefaultFileRsAdvanced, cadvisorDefaultFileDs,
 		kubeProxyDefaultFile, apiserverDefaultFile, kubeStateDefaultFile,


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
