### PR TITLE
fix: typo in default otelcollector yaml

### DIFF
--- a/otelcollector/opentelemetry-collector-builder/collector-config-default.yml
+++ b/otelcollector/opentelemetry-collector-builder/collector-config-default.yml
@@ -2,7 +2,7 @@ exporters:
   prometheus:
     endpoint: "127.0.0.1:9091"
     const_labels:
-      cluster: ${nev:AZMON_CLUSTER_LABEL}
+      cluster: ${env:AZMON_CLUSTER_LABEL}
   otlp:
     endpoint: 127.0.0.1:55680
     tls:


### PR DESCRIPTION
This affects clusters where no custom config exists