### PR TITLE
fix: broken windows tests

### DIFF
--- a/otelcollector/build/windows/Dockerfile
+++ b/otelcollector/build/windows/Dockerfile
@@ -35,7 +35,7 @@ COPY ./fluent-bit/fluent-bit-windows.conf $tmpdir/fluent-bit/
 COPY ./fluent-bit/fluent-bit-parsers.conf $tmpdir/fluent-bit/
 COPY ./fluent-bit/src/out_appinsights.so $tmpdir/fluent-bit/bin/
 COPY ./main/main.exe $tmpdir/microsoft
-COPY ./react /Users/ContainerAdministrator/Documents/static/react
+COPY ./react /static/react
 COPY ./LICENSE $tmpdir/microsoft
 COPY ./NOTICE $tmpdir/microsoft
 

--- a/otelcollector/build/windows/scripts/setup.ps1
+++ b/otelcollector/build/windows/scripts/setup.ps1
@@ -12,6 +12,7 @@ New-Item -Type Directory -Path /opt/microsoft/liveness -ErrorAction SilentlyCont
 New-Item -Type Directory -Path /opt/genevamonitoringagent -ErrorAction SilentlyContinue
 New-Item -Type Directory -Path /opt/genevamonitoringagent/datadirectory -ErrorAction SilentlyContinue
 New-Item -Type Directory -Path /etc/genevamonitoringagent
+New-Item -Type Directory -Path /static/react -Force -ErrorAction SilentlyContinue
 ############################################################################################
 Write-Host ('Installing Metrics Extension');
 try {

--- a/otelcollector/shared/telemetry.go
+++ b/otelcollector/shared/telemetry.go
@@ -51,6 +51,13 @@ func SetupTelemetry(customEnvironment string) {
 		return
 	}
 
+	// Export APPLICATIONINSIGHTS_ENDPOINT
+	err = SetEnvAndSourceBashrcOrPowershell("APPLICATIONINSIGHTS_ENDPOINT", aiEndpoint , false)
+	if err != nil {
+		fmt.Println("Error setting APPLICATIONINSIGHTS_ENDPOINT environment variable:", err)
+		return
+	}
+
 	// Setting TELEMETRY_APPLICATIONINSIGHTS_KEY
 	aiKeyBytes, err := base64.StdEncoding.DecodeString(encodedAIKey)
 	if err != nil {

--- a/otelcollector/shared/telemetry.go
+++ b/otelcollector/shared/telemetry.go
@@ -51,31 +51,6 @@ func SetupTelemetry(customEnvironment string) {
 		return
 	}
 
-	// Append export commands to .bashrc file
-	bashrcPath := os.Getenv("HOME") + "/.bashrc"
-	bashrcFile, err := os.OpenFile(bashrcPath, os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		fmt.Println("Error opening .bashrc file:", err)
-		return
-	}
-	defer bashrcFile.Close()
-
-	exportAIKeyCommand := fmt.Sprintf("export APPLICATIONINSIGHTS_AUTH=%s\n", encodedAIKey)
-	_, err = bashrcFile.WriteString(exportAIKeyCommand)
-	if err != nil {
-		fmt.Println("Error writing to .bashrc file:", err)
-		return
-	}
-
-	if aiEndpoint != "" {
-		exportEndpointCommand := fmt.Sprintf("export APPLICATIONINSIGHTS_ENDPOINT=\"%s\"\n", aiEndpoint)
-		_, err = bashrcFile.WriteString(exportEndpointCommand)
-		if err != nil {
-			fmt.Println("Error writing to .bashrc file:", err)
-			return
-		}
-	}
-
 	// Setting TELEMETRY_APPLICATIONINSIGHTS_KEY
 	aiKeyBytes, err := base64.StdEncoding.DecodeString(encodedAIKey)
 	if err != nil {
@@ -90,10 +65,4 @@ func SetupTelemetry(customEnvironment string) {
 		return
 	}
 
-	exportTelegrafCommand := fmt.Sprintf("export TELEMETRY_APPLICATIONINSIGHTS_KEY=%s\n", aiKey)
-	_, err = bashrcFile.WriteString(exportTelegrafCommand)
-	if err != nil {
-		fmt.Println("Error writing to .bashrc file:", err)
-		return
-	}
 }


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
