### PR TITLE
CCP scrape config + adding metrics_relabel_config to end of the config

### DIFF
--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -64,6 +64,6 @@ scrape_configs:
     source_labels:
     - __name__
   - action: drop
-    regex: apiserver_request_duration_seconds_bucket|apiserver_request_sli_duration_seconds_bucket <- added this to configmap for testing
+    regex: apiserver_request_duration_seconds_bucket|apiserver_request_sli_duration_seconds_bucket
     source_labels:
     - __name__

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -36,23 +36,34 @@ scrape_configs:
       target_label: instance
       action: replace
   metric_relabel_configs:
-    # Generate host alias
-    - source_labels: [ host ]
-      action: hashmod
-      regex: (.+)
-      modulus: 10000000000000000000 # take last 19 digits of the MD5 hash. (Prom won't let us take more than this)
-      target_label: hostalias
-    - source_labels: [ host ]
-      regex: ^(localhost|\[::1\]):443$
-      target_label: hostalias
-      replacement: kube-apiserver
-    # Replace the host with hostalias
-    - source_labels: [ hostalias, host ]
-      regex: ^(.+);(.+)$
-      action: replace
-      target_label: host
-    - source_labels: [ __name__ ]
-      action: drop
-      regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
-    - action: labeldrop
-      regex: hostalias
+  - action: hashmod
+    modulus: 10000000000000000000
+    regex: (.+)
+    source_labels:
+    - host
+    target_label: hostalias
+  - regex: ^(localhost|\[::1\]):443$
+    replacement: kube-apiserver
+    source_labels:
+    - host
+    target_label: hostalias
+  - action: replace
+    regex: ^(.+);(.+)$
+    source_labels:
+    - hostalias
+    - host
+    target_label: host
+  - action: drop
+    regex: (go_.*|process_(cpu|max|resident|virtual|open)_.*)
+    source_labels:
+    - __name__
+  - action: labeldrop
+    regex: hostalias
+  - action: keep
+    regex: apiserver_request_sli_duration_seconds_bucket|go_cpu_classes_gc_mark_dedicated_cpu_seconds_total
+    source_labels:
+    - __name__
+  - action: drop
+    regex: apiserver_request_duration_seconds_bucket|apiserver_request_sli_duration_seconds_bucket <- added this to configmap for testing
+    source_labels:
+    - __name__

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -59,7 +59,3 @@ scrape_configs:
     - __name__
   - action: labeldrop
     regex: hostalias
-  - action: drop
-    regex: apiserver_request_duration_seconds_bucket|apiserver_request_sli_duration_seconds_bucket
-    source_labels:
-    - __name__

--- a/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
+++ b/otelcollector/configmapparser/default-prom-configs/controlplane_apiserver.yml
@@ -59,10 +59,6 @@ scrape_configs:
     - __name__
   - action: labeldrop
     regex: hostalias
-  - action: keep
-    regex: apiserver_request_sli_duration_seconds_bucket|go_cpu_classes_gc_mark_dedicated_cpu_seconds_total
-    source_labels:
-    - __name__
   - action: drop
     regex: apiserver_request_duration_seconds_bucket|apiserver_request_sli_duration_seconds_bucket
     source_labels:

--- a/otelcollector/configmapparser/default-prom-configs/kubeletDefaultDs.yml
+++ b/otelcollector/configmapparser/default-prom-configs/kubeletDefaultDs.yml
@@ -1,4 +1,4 @@
-scrape_configs:
+  scrape_configs:
   - job_name: kubelet
     scheme: https
     metrics_path: /metrics
@@ -11,19 +11,14 @@ scrape_configs:
       insecure_skip_verify: true
     bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
     relabel_configs:
-      - source_labels: [__metrics_path__]
-        regex: (.*)
-        target_label: metrics_path
-      - source_labels: [__address__]
-        replacement: '$$NODE_NAME$$'
-        target_label: instance
-      - source_labels: [__address__]
-        replacement: '$$OS_TYPE$$'
-        target_label: "kubernetes_io_os"
-    metric_relabel_configs:
-      - source_labels: [__name__]
-        regex: ".*"  # Matches all metrics
-        action: replace
-        target_label: __name__  # No-op relabeling
+    - source_labels: [__metrics_path__]
+      regex: (.*)
+      target_label: metrics_path
+    - source_labels: [__address__]
+      replacement: '$$NODE_NAME$$'
+      target_label: instance
+    - source_labels: [__address__]
+      replacement: '$$OS_TYPE$$'
+      target_label: "kubernetes_io_os"
     static_configs:
-      - targets: ['$$NODE_IP$$:10250']
+    - targets: ['$$NODE_IP$$:10250']

--- a/otelcollector/configmapparser/default-prom-configs/kubeletDefaultDs.yml
+++ b/otelcollector/configmapparser/default-prom-configs/kubeletDefaultDs.yml
@@ -1,4 +1,4 @@
-  scrape_configs:
+scrape_configs:
   - job_name: kubelet
     scheme: https
     metrics_path: /metrics
@@ -11,14 +11,19 @@
       insecure_skip_verify: true
     bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
     relabel_configs:
-    - source_labels: [__metrics_path__]
-      regex: (.*)
-      target_label: metrics_path
-    - source_labels: [__address__]
-      replacement: '$$NODE_NAME$$'
-      target_label: instance
-    - source_labels: [__address__]
-      replacement: '$$OS_TYPE$$'
-      target_label: "kubernetes_io_os"
+      - source_labels: [__metrics_path__]
+        regex: (.*)
+        target_label: metrics_path
+      - source_labels: [__address__]
+        replacement: '$$NODE_NAME$$'
+        target_label: instance
+      - source_labels: [__address__]
+        replacement: '$$OS_TYPE$$'
+        target_label: "kubernetes_io_os"
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: ".*"  # Matches all metrics
+        action: replace
+        target_label: __name__  # No-op relabeling
     static_configs:
-    - targets: ['$$NODE_IP$$:10250']
+      - targets: ['$$NODE_IP$$:10250']

--- a/otelcollector/shared/configmap/mp/prometheus-config-merger.go
+++ b/otelcollector/shared/configmap/mp/prometheus-config-merger.go
@@ -181,8 +181,10 @@ func AppendMetricRelabelConfig(yamlConfigFile, keepListRegex string) error {
 				// Update or add metric_relabel_configs
 				if metricRelabelCfgs, ok := stringScfgMap["metric_relabel_configs"].([]interface{}); ok {
 					stringScfgMap["metric_relabel_configs"] = append(metricRelabelCfgs, keepListMetricRelabelConfig)
+					fmt.Printf("Updated metric_relabel_configs after append: %+v\n", stringScfgMap["metric_relabel_configs"])
 				} else {
 					stringScfgMap["metric_relabel_configs"] = []interface{}{keepListMetricRelabelConfig}
+					fmt.Printf("Created new metric_relabel_configs: %+v\n", stringScfgMap["metric_relabel_configs"])
 				}
 
 				// Convert back to map[interface{}]interface{} for YAML marshalling


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

This PR updated the scrape config for the controlplane-apiserver job and also makes sure that the prometheus merger actually merged the keeplist at the end of the metric_relabel_config.

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
