### PR TITLE
Handle SIGTERM and exit when encountered restarting the pod

### DIFF
--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -280,7 +280,6 @@ func handleShutdown() {
 	// Block until a signal is received
 	<-shutdownChan
 	fmt.Println("shutting down")
-	os.Exit(0) // Exit the application gracefully
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {

--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
+	"syscall"
 
 	shared "github.com/prometheus-collector/shared"
 	ccpconfigmapsettings "github.com/prometheus-collector/shared/configmap/ccp"
@@ -33,8 +35,8 @@ func main() {
 	}
 
 	if osType == "linux" {
-		outputFile := "/opt/inotifyoutput.txt" 
-		
+		outputFile := "/opt/inotifyoutput.txt"
+
 		if ccpMetricsEnabled != "true" { //data-plane
 
 			if err := shared.Inotify(outputFile, "/etc/config/settings"); err != nil {
@@ -278,8 +280,7 @@ func handleShutdown() {
 	// Block until a signal is received
 	<-shutdownChan
 	fmt.Println("shutting down")
-	// Perform any cleanup tasks here if needed
-	os.Exit(0) // Exit the application
+	os.Exit(0) // Exit the application gracefully
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {

--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -280,6 +280,7 @@ func handleShutdown() {
 	// Block until a signal is received
 	<-shutdownChan
 	fmt.Println("shutting down")
+	os.Exit(0) // Exit the application
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {

--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -18,7 +18,8 @@ import (
 
 func main() {
 
-	
+	// Handle SIGTERM
+	go handleShutdown()
 
 	controllerType := shared.GetControllerType()
 	cluster := shared.GetEnv("CLUSTER", "")
@@ -267,6 +268,18 @@ func main() {
 	// Expose a health endpoint for liveness probe
 	http.HandleFunc("/health", healthHandler)
 	http.ListenAndServe(":8080", nil)
+}
+
+// handleShutdown listens for SIGTERM signals and handles cleanup.
+func handleShutdown() {
+	shutdownChan := make(chan os.Signal, 1)
+	signal.Notify(shutdownChan, syscall.SIGTERM)
+
+	// Block until a signal is received
+	<-shutdownChan
+	fmt.Println("shutting down")
+	// Perform any cleanup tasks here if needed
+	os.Exit(0) // Exit the application
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

This PR aims to handle the SIGTERM event similar to how we were doing it [here](https://github.com/Azure/prometheus-collector/blob/00a1e4bb0402b78d0739dd033352679ea08bc644/otelcollector/scripts/main.sh#L322C1-L326C24) when we were using the main.sh script.

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
