### PR TITLE
Print fluent-bit and telegraf version for windows

### DIFF
--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -140,18 +140,6 @@ func main() {
 	} else {
 		shared.StartMetricsExtensionWithConfigOverridesForUnderlay(meConfigFile)
 	}
-	// ME_PID, err := shared.StartMetricsExtensionForOverlay(meConfigFile)
-	// if err != nil {
-	// 	fmt.Printf("Error starting MetricsExtension: %v\n", err)
-	// 	return
-	// }
-	// fmt.Printf("ME_PID: %d\n", ME_PID)
-
-	// // Modify fluentBitConfigFile using ME_PID
-	// err = shared.ModifyConfigFile(fluentBitConfigFile, ME_PID, "${ME_PID}")
-	// if err != nil {
-	// 	fmt.Printf("Error modifying config file: %v\n", err)
-	// }
 
 	// Start otelcollector
 	azmonOperatorEnabled := os.Getenv("AZMON_OPERATOR_ENABLED")
@@ -180,18 +168,6 @@ func main() {
 
 	fmt.Println("startCommand otelcollector")
 	_, err := shared.StartCommandWithOutputFile("/opt/microsoft/otelcollector/otelcollector", []string{"--config", collectorConfig}, "/opt/microsoft/otelcollector/collector-log.txt")
-	// OTEL_PID, err := shared.StartCommandWithOutputFile("/opt/microsoft/otelcollector/otelcollector", []string{"--config", collectorConfig}, "/opt/microsoft/otelcollector/collector-log.txt")
-	// if err != nil {
-	// 	fmt.Printf("Error starting command: %v\n", err)
-	// 	return
-	// }
-	// fmt.Printf("OTEL_PID: %d\n", OTEL_PID)
-
-	// // Modify fluentBitConfigFile using OTEL_PID
-	// err = shared.ModifyConfigFile(fluentBitConfigFile, OTEL_PID, "${OTEL_PID}")
-	// if err != nil {
-	// 	fmt.Printf("Error modifying config file: %v\n", err)
-	// }
 
 	if osType == "linux" {
 		shared.LogVersionInfo()
@@ -202,6 +178,13 @@ func main() {
 		// Run the command and capture the output
 		if osType == "linux" {
 			cmd := exec.Command("fluent-bit", "--version")
+			fluentBitVersion, err := cmd.Output()
+			if err != nil {
+				log.Fatalf("failed to run command: %v", err)
+			}
+			shared.EchoVar("FLUENT_BIT_VERSION", string(fluentBitVersion))
+		} else if osType == "windows" {
+			cmd := exec.Command("C:\\opt\\fluent-bit\\bin\\fluent-bit.exe", "--version")
 			fluentBitVersion, err := cmd.Output()
 			if err != nil {
 				log.Fatalf("failed to run command: %v", err)

--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -193,6 +193,14 @@ func main() {
 		}
 
 		shared.StartTelegraf()
+		// Print Telegraf version
+		versionCmd := exec.Command("C:\\opt\\telegraf\\telegraf.exe", "--version")
+		versionOutput, err := versionCmd.Output()
+		if err != nil {
+			log.Printf("Error fetching Telegraf version: %v\n", err)
+		} else {
+			fmt.Printf("TELEGRAF_VERSION=%s\n", string(versionOutput))
+		}
 
 	}
 

--- a/otelcollector/shared/helpers.go
+++ b/otelcollector/shared/helpers.go
@@ -129,6 +129,15 @@ func StartTelegraf() {
 			log.Fatalf("Error installing Telegraf service: %v\n", err)
 		}
 
+		// Print Telegraf version
+		versionCmd := exec.Command(telegrafPath, "--version")
+		versionOutput, err := versionCmd.CombinedOutput()
+		if err != nil {
+			log.Printf("Error fetching Telegraf version: %v\n", err)
+		} else {
+			fmt.Printf("TELEGRAF_VERSION=%s\n", string(versionOutput))
+		}
+
 		// Set delayed start if POD_NAME is set
 		serverName := os.Getenv("POD_NAME")
 		if serverName != "" {

--- a/otelcollector/shared/helpers.go
+++ b/otelcollector/shared/helpers.go
@@ -129,15 +129,6 @@ func StartTelegraf() {
 			log.Fatalf("Error installing Telegraf service: %v\n", err)
 		}
 
-		// Print Telegraf version
-		versionCmd := exec.Command(telegrafPath, "--version")
-		versionOutput, err := versionCmd.CombinedOutput()
-		if err != nil {
-			log.Printf("Error fetching Telegraf version: %v\n", err)
-		} else {
-			fmt.Printf("TELEGRAF_VERSION=%s\n", string(versionOutput))
-		}
-
 		// Set delayed start if POD_NAME is set
 		serverName := os.Getenv("POD_NAME")
 		if serverName != "" {
@@ -163,6 +154,15 @@ func StartTelegraf() {
 		startCmd := exec.Command(telegrafPath, "--service", "start")
 		if err := startCmd.Run(); err != nil {
 			log.Printf("Error starting Telegraf service: %v\n", err)
+		}
+
+		// Print Telegraf version
+		versionCmd := exec.Command("C:\\opt\\telegraf\\telegraf.exe", "--version")
+		versionOutput, err := versionCmd.Output()
+		if err != nil {
+			log.Printf("Error fetching Telegraf version: %v\n", err)
+		} else {
+			fmt.Printf("TELEGRAF_VERSION=%s\n", string(versionOutput))
 		}
 
 		// Check if Telegraf is running, retry if necessary

--- a/otelcollector/shared/helpers.go
+++ b/otelcollector/shared/helpers.go
@@ -156,15 +156,6 @@ func StartTelegraf() {
 			log.Printf("Error starting Telegraf service: %v\n", err)
 		}
 
-		// Print Telegraf version
-		versionCmd := exec.Command("C:\\opt\\telegraf\\telegraf.exe", "--version")
-		versionOutput, err := versionCmd.Output()
-		if err != nil {
-			log.Printf("Error fetching Telegraf version: %v\n", err)
-		} else {
-			fmt.Printf("TELEGRAF_VERSION=%s\n", string(versionOutput))
-		}
-
 		// Check if Telegraf is running, retry if necessary
 		for {
 			statusCmd := exec.Command("sc.exe", "query", "telegraf")


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

This PR makes it so that the kubectl logs of the windows pods will now contain the fluent-bit and telegraf version similar to linux.

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
