### PR TITLE
fix troubleshooting script for hpa and remove uneeded login check

### DIFF
--- a/internal/scripts/troubleshoot/TroubleshootError.ps1
+++ b/internal/scripts/troubleshoot/TroubleshootError.ps1
@@ -239,29 +239,6 @@ if (($null -eq $azAksModule) -or ($null -eq $azARGModule) -or ($null -eq $azAcco
         }
     }
 }
-#
-# login
-#
-try {
-    Write-Host("")
-    Write-Host("Trying to get the current Az login context...")
-    $account = Get-AzContext -ErrorAction Stop
-    Write-Host("Successfully fetched current Az context...") -ForegroundColor Green
-    # Check if the context's token expiration time has passed
-    if ($account.Account.ExpiresOn -lt (Get-Date)) {
-        Write-Host "Azure context has expired."
-        $account = $null
-    }
-    else {
-        Write-Host "Azure context is still valid."
-    }
-    Write-Host("")
-}
-catch {
-    Write-Host("")
-    Write-Host("Could not fetch AzContext..." ) -ForegroundColor Red
-    Write-Host("")
-}
 
 $ClusterSubscriptionId = $ClusterResourceId.split("/")[2]
 $ClusterResourceGroupName = $ClusterResourceId.split("/")[4]
@@ -414,86 +391,90 @@ catch {
 }
 
 #
-#    Check Agent pods running as expected
+#    Check Agent pods running as expected with HPA
 #
 try {
     Write-Host("Getting Kubeconfig of the cluster...")
     Import-AzAksCredential -Id $ClusterResourceId -Force -ErrorAction Stop
     Write-Host("Successfully got the Kubeconfig of the cluster.")
 
-    Write-Host("Switch to cluster context to:", $ClusterName )
+    Write-Host("Switching to cluster context:", $ClusterName)
     kubectl config use-context $ClusterName
     Write-Host("Successfully switched current context of the k8s cluster to:", $ClusterName)
 
-    Write-Host("Check whether the ama-metrics replicaset pod running correctly ...")
-    $rsPod = kubectl get deployments ama-metrics -n kube-system -o json | ConvertFrom-Json
-    if ($null -eq $rsPod) {
-        Write-Host( "ama-metrics replicaset pod not scheduled or failed to scheduled.") -ForegroundColor Red
-        Write-Host("Please refer to the following documentation to onboard and validate:") -ForegroundColor Red
-        Write-Host($AksOptInLink) -ForegroundColor Red
-        Write-Host($contactUSMessage)
-        Stop-Transcript
+    Write-Host("Fetching ama-metrics deployment status with HPA...")
+    $hpa = kubectl get hpa ama-metrics-hpa -n kube-system -o json | ConvertFrom-Json
+    if ($null -eq $hpa) {
+        Write-Host("HPA configuration for ama-metrics not found.") -ForegroundColor Red
+        Write-Host("Please ensure HPA is enabled and properly configured.") -ForegroundColor Red
         exit 1
     }
 
-    $rsPodStatus = $rsPod.status
-    if ((($rsPodStatus.availableReplicas -eq 1) -and
-                ($rsPodStatus.readyReplicas -eq 1 ) -and
-                ($rsPodStatus.replicas -eq 1 )) -eq $false
-    ) {
-        Write-Host("ama-metrics replicaset pod not scheduled or failed to scheduled.") -ForegroundColor Red
-        Write-Host("Available ama-metrics replicas:", $rsPodStatus.availableReplicas)
-        Write-Host("Ready ama-metrics replicas:", $rsPodStatus.readyReplicas)
-        Write-Host("Total ama-metrics replicas:", $rsPodStatus.replicas)
-        Write-Host($rsPod) -ForegroundColor Red
-        Write-Host("get ama-metrics rs pod details ...")
-        $amaMetricsRsPod = kubectl get pods -n kube-system -l rsName=ama-metrics -o json | ConvertFrom-Json
-        Write-Host("status of the ama-metrics rs pod is :", $amaMetricsRsPod.Items[0].status.conditions) -ForegroundColor Red
-        Write-Host("successfully got ama-metrics rs pod details ...")
-        Write-Host("Please refer to the following documentation to onboard and validate:") -ForegroundColor Red
-        Write-Host($AksOptInLink) -ForegroundColor Red
-        Write-Host($contactUSMessage)
-        Stop-Transcript
+    $hpaStatus = $hpa.status
+    $currentReplicas = $hpaStatus.currentReplicas
+    $desiredReplicas = $hpaStatus.desiredReplicas
+
+    Write-Host("Current replicas:", $currentReplicas)
+    Write-Host("Desired replicas:", $desiredReplicas)
+
+    # Check if current replicas do not match desired replicas
+    if ($currentReplicas -ne $desiredReplicas) {
+        Write-Error "Mismatch detected! Current replicas ($currentReplicas) do not match desired replicas ($desiredReplicas)."
+    }
+    else {
+        Write-Host "Replica counts match. No issues detected."
+    }
+
+    if ($currentReplicas -lt $hpa.spec.minReplicas) {
+        Write-Host("Current replicas are less than the minimum replicas configured.") -ForegroundColor Red
         exit 1
     }
 
-    $amaMetricsRsPod = kubectl get pods -n kube-system -l rsName=ama-metrics -o json | ConvertFrom-Json
-    $podName = $amaMetricsRsPod.Items[0].metadata.name
-    # Copy MetricsExtensionConsoleDebugLog.log from container to debuglogs directory
-    kubectl cp kube-system/$($podName):/MetricsExtensionConsoleDebugLog.log ./$debuglogsDir/MetricsExtensionConsoleDebugLog_$($podName).log
-    Write-Host("MetricsExtensionConsoleDebugLog$($podName).log copied to debuglogs directory.") -ForegroundColor Green
+    Write-Host("Checking the status of pods for ama-metrics deployment...")
+    $rsPods = kubectl get pods -n kube-system -l rsName=ama-metrics -o json | ConvertFrom-Json
+    if ($null -eq $rsPods.Items -or $rsPods.Items.Count -lt $currentReplicas) {
+        Write-Host("Not all ama-metrics pods are scheduled or running.") -ForegroundColor Red
+        Write-Host("Expected replicas:", $currentReplicas)
+        Write-Host("Scheduled pods:", $rsPods.Items.Count)
+        exit 1
+    }
 
-    # Copy MDSD log from container to debuglogs directory
-    kubectl cp kube-system/$($podName):/opt/microsoft/linuxmonagent/mdsd.qos ./$debuglogsDir/mdsd_qos_$($podName).log
-    Write-Host("mdsd_qos_$($podName).log copied to debuglogs directory.") -ForegroundColor Green
+    foreach ($pod in $rsPods.Items) {
+        $podStatus = $pod.status.conditions
+        if (-not ($podStatus | Where-Object { $_.type -eq "Ready" -and $_.status -eq "True" })) {
+            Write-Host("Pod $($pod.metadata.name) is not ready.") -ForegroundColor Red
+            exit 1
+        }
+    }
 
-    # Copy MDSD log from container to debuglogs directory
-    kubectl cp kube-system/$($podName):/opt/microsoft/linuxmonagent/mdsd.info ./$debuglogsDir/mdsd_info_$($podName).log
-    Write-Host("mdsd_info_$($podName).log copied to debuglogs directory.") -ForegroundColor Green
+    Write-Host("All ama-metrics pods are running as expected.") -ForegroundColor Green
 
-    # Copy MDSD log from container to debuglogs directory
-    kubectl cp kube-system/$($podName):/opt/microsoft/linuxmonagent/mdsd.warn ./$debuglogsDir/mdsd_warn_$($podName).log
-    Write-Host("mdsd_warn_$($podName).log copied to debuglogs directory.") -ForegroundColor Green
+    foreach ($pod in $rsPods.Items) {
+        $podName = $pod.metadata.name
 
-    # Copy MDSD log from container to debuglogs directory
-    kubectl cp kube-system/$($podName):/opt/microsoft/linuxmonagent/mdsd.err ./$debuglogsDir/mdsd_err_$($podName).log
-    Write-Host("mdsd_err_$($podName).log copied to debuglogs directory.") -ForegroundColor Green
+        # Copy logs from the pod to debuglogs directory
+        kubectl cp kube-system/$($podName):/MetricsExtensionConsoleDebugLog.log ./$debuglogsDir/MetricsExtensionConsoleDebugLog_$($podName).log
+        kubectl cp kube-system/$($podName):/opt/microsoft/linuxmonagent/mdsd.qos ./$debuglogsDir/mdsd_qos_$($podName).log
+        kubectl cp kube-system/$($podName):/opt/microsoft/linuxmonagent/mdsd.info ./$debuglogsDir/mdsd_info_$($podName).log
+        kubectl cp kube-system/$($podName):/opt/microsoft/linuxmonagent/mdsd.warn ./$debuglogsDir/mdsd_warn_$($podName).log
+        kubectl cp kube-system/$($podName):/opt/microsoft/linuxmonagent/mdsd.err ./$debuglogsDir/mdsd_err_$($podName).log
 
-    # Get logs from prometheus-collector container and store in a file
-    $promCollectorLogPath = "$debuglogsDir/$($podName)_promcollector.log"
-    kubectl logs $($amaMetricsRsPod.Items[0].metadata.name) -n kube-system -c prometheus-collector > $promCollectorLogPath
+        # Collect prometheus-collector container logs
+        $promCollectorLogPath = "$debuglogsDir/$($podName)_promcollector.log"
+        kubectl logs $($podName) -n kube-system -c prometheus-collector > $promCollectorLogPath
 
-    # Get logs from prometheus-collector container and store in a file
-    $promCollectorLogPath = "$debuglogsDir/$($podName)_addontokenadapter.log"
-    kubectl logs $($podName) -n kube-system -c addon-token-adapter > $promCollectorLogPath
+        # Collect addon-token-adapter container logs
+        $addonTokenLogPath = "$debuglogsDir/$($podName)_addontokenadapter.log"
+        kubectl logs $($podName) -n kube-system -c addon-token-adapter > $addonTokenLogPath
+    }
 
-    Write-Host( "ama-metrics replicaset pod running OK.") -ForegroundColor Green
+    Write-Host("Logs for all ama-metrics pods have been successfully copied.") -ForegroundColor Green
 }
 catch {
-    Write-Host ("Failed to get ama-metrics replicatset pod info using kubectl get rs  : '" + $Error[0] + "' ") -ForegroundColor Red
-    Stop-Transcript
+    Write-Host("Failed to validate ama-metrics pods: '" + $Error[0] + "'") -ForegroundColor Red
     exit 1
 }
+
 
 Write-Host("Checking whether the ama-metrics-node linux daemonset pod running correctly ...")
 try {


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
