### PR TITLE
fix: only setup arc for linux + set env variable for windows correctly

### DIFF
--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -56,7 +56,7 @@ func main() {
 		shared.StartCommand("powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "C:\\opt\\scripts\\filesystemwatcher.ps1")
 	}
 
-	if ccpMetricsEnabled != "true" {
+	if ccpMetricsEnabled != "true" && osType == "linux" {
 		if err := shared.SetupArcEnvironment(); err != nil {
 			shared.EchoError(err.Error())
 		}

--- a/otelcollector/shared/configmap/mp/configmapparser.go
+++ b/otelcollector/shared/configmap/mp/configmapparser.go
@@ -239,18 +239,17 @@ func Configmapparser() {
 		}
 
 		// Source prom_config_validator_env_var
-		cmd := exec.Command("bash", "-c", "source /opt/microsoft/prom_config_validator_env_var && env")
-		if err := cmd.Run(); err != nil {
-			shared.EchoError("Error sourcing env file:" + err.Error())
-			return
-		}
+		filename := "/opt/microsoft/prom_config_validator_env_var"
+	  err = shared.SetEnvVarsFromFile(filename)
+	  if err != nil {
+		  fmt.Printf("Error when settinng env for /opt/microsoft/prom_config_validator_env_var: %v\n", err)
+	  }
 
-		// Source envvars.env
-		cmd = exec.Command("bash", "-c", "source /opt/envvars.env && env")
-		if err := cmd.Run(); err != nil {
-			shared.EchoError("Error sourcing envvars.env:" + err.Error())
-			return
-		}
+		filename = "/opt/envvars.env"
+	  err = shared.SetEnvVarsFromFile(filename)
+	  if err != nil {
+		  fmt.Printf("Error when settinng env for /opt/envvars.env: %v\n", err)
+	  }		
 	}
 
 	fmt.Printf("prom-config-validator::Use default prometheus config: %s\n", os.Getenv("AZMON_USE_DEFAULT_PROMETHEUS_CONFIG"))

--- a/otelcollector/shared/configmap/mp/configmapparser.go
+++ b/otelcollector/shared/configmap/mp/configmapparser.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/prometheus-collector/shared"


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
