### PR TITLE
Fix helpers for hpa where previous max was not getting updated

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/_ama-metrics-helpers.tpl
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/_ama-metrics-helpers.tpl
@@ -9,6 +9,8 @@
 {{- $amaMetricsHpaName := "ama-metrics-hpa" }}
 {{- $amaMetricsAutoscaleMin := 2 -}}
 {{- $amaMetricsAutoscaleMax := 12 -}}
+{{- $amaMetricsAutoscaleMaxPrevious := 8 -}}
+
 
 amaMetricsMinReplicasFromHelper: 2
 amaMetricsMaxReplicasFromHelper: 12
@@ -28,7 +30,8 @@ amaMetricsMinReplicasFromHelper: {{ $amaMetricsMinReplicasFromCurrentSpec }}
   {{- end }}
 
   {{- if and ($amaMetricsMaxReplicasFromCurrentSpec) (gt (int $amaMetricsMaxReplicasFromCurrentSpec) 0) }}
-    {{- if le (int $amaMetricsMaxReplicasFromCurrentSpec) $amaMetricsAutoscaleMax }}
+{{/* Adding this check to make sure the previous default max is updated with the new update  */}}
+    {{- if  and (le (int $amaMetricsMaxReplicasFromCurrentSpec) $amaMetricsAutoscaleMax) (ne (int $amaMetricsMaxReplicasFromCurrentSpec) $amaMetricsAutoscaleMaxPrevious) }}
 amaMetricsMaxReplicasFromHelper: {{ $amaMetricsMaxReplicasFromCurrentSpec }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description
If we update the HPA max from 12 to something else, the chart doesnt update thinking that this was set by the user. Making a fix to handle this.

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [X] List telemetry added about the feature. - Have telemetry in AKSClusterMetrics to track max set for the HPA
- [X] Link to the one-pager about the feature. - https://github.com/Azure/prometheus-collector/blob/main/internal/docs/HPA.md
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
