### PR TITLE
Pinning Dependencies for Enhanced Security

### DIFF
--- a/.github/workflows/build-and-push-dependent-helm-charts.yml
+++ b/.github/workflows/build-and-push-dependent-helm-charts.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Set-MCR-HELM-CHART-Repository-Root
         run: echo "MCR_REPOSITORY_ROOT=mcr.microsoft.com/azuremonitor/containerinsights/cidev/" >> $GITHUB_ENV
       - name: Checkout-code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Lint-HELM-Chart
         run: helm lint ./otelcollector/deploy/dependentcharts/${{ github.event.inputs.dependentHelmChartName }}/
       - name: Run-trivy-scanner-on-HELM-chart-fs
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
         with:
           scan-type: 'fs'
           scan-ref: "./otelcollector/deploy/dependentcharts/${{ github.event.inputs.dependentHelmChartName }}/"

--- a/.github/workflows/build-and-release-mixin.yml
+++ b/.github/workflows/build-and-release-mixin.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Set-commit-sha
         run: echo "COMMIT_SHA=${GITHUB_SHA::8}" >> $GITHUB_ENV
       - name: get-go-version-greater-than-1-16
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: '^1.17.3' 
       - name: Checkout-code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set-HELM-Chart-Version
         run: version=$(cat ./otelcollector/VERSION) && echo "HELM_CHART_VERSION=${version}" >> $GITHUB_ENV
       - name: Set-semver
@@ -70,7 +70,7 @@ jobs:
       #    timeout: '5m0s'
       - name: Create-release
         id: create-release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         if: github.event_name != 'pull_request' # && env.BRANCH_NAME == 'vishwa-dash'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +86,7 @@ jobs:
           prerelease: true
       - name: Upload-Release-Asset
         id: upload-Release-Asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         if: github.event_name != 'pull_request' # && env.BRANCH_NAME == 'vishwa-dash'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scan-released-image.yml
+++ b/.github/workflows/scan-released-image.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run-trivy-scanner-on-last-released-docker-image
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
         with:
           image-ref: "mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/images:5.0.0-main-09-15-2022-c5d54419"
           format: 'table'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set-workflow-initiator
         run: echo "Initiated by - ${GITHUB_ACTOR}"
       - name: Run-trivy-scanner-on-docker-image
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
         with:
           image-ref: "${{ github.event.inputs.imageToScan }}"
           format: 'table'

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -11,6 +11,6 @@ jobs:
       pull-requests: write
     steps:
       - name: size-label
-        uses: "pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348" # v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -11,6 +11,6 @@ jobs:
       pull-requests: write
     steps:
       - name: size-label
-        uses: "pascalgn/size-label-action@v0.5.5"
+        uses: "pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348" # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 #v9.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-issue-stale: 7


### PR DESCRIPTION
This pull request updates various GitHub Actions in multiple workflow files to use specific commit SHAs instead of branch names. This change ensures the actions are using a fixed version, which enhances stability and reproducibility.

### Updates to GitHub Actions:

* [`.github/workflows/build-and-push-dependent-helm-charts.yml`](diffhunk://#diff-c82a8f48b3656db8e09f9bdbeaea8c77d2c174f6cb82a2a2c0d344c5d3fe53edL25-R29): Updated `actions/checkout` to `v4.2.2` and `aquasecurity/trivy-action` to `v0.29.0`.
* [`.github/workflows/build-and-release-mixin.yml`](diffhunk://#diff-9d13049e653e652eb18165ac8f28c21a02a95eb5b01c69196baec41ffb3747f8L32-R36): Updated `actions/setup-go` to `v5.3.0`, `actions/checkout` to `v4.2.2`, `actions/create-release` to `v1.1.4`, and `actions/upload-release-asset` to `v1.0.2`. [[1]](diffhunk://#diff-9d13049e653e652eb18165ac8f28c21a02a95eb5b01c69196baec41ffb3747f8L32-R36) [[2]](diffhunk://#diff-9d13049e653e652eb18165ac8f28c21a02a95eb5b01c69196baec41ffb3747f8L73-R73) [[3]](diffhunk://#diff-9d13049e653e652eb18165ac8f28c21a02a95eb5b01c69196baec41ffb3747f8L89-R89)
* [`.github/workflows/scan-released-image.yml`](diffhunk://#diff-be6285b440cfe6fe87e68c8a2d8e3cf521a1ca40a9b7ce9b61d0f294b4ee8affL11-R11): Updated `aquasecurity/trivy-action` to `v0.29.0`.
* [`.github/workflows/scan.yml`](diffhunk://#diff-246cd0c2f7db532638dd80a92ac011f49b3d26038983a4c0169ea8f8a5c39280L15-R15): Updated `aquasecurity/trivy-action` to `v0.29.0`.
* [`.github/workflows/size.yml`](diffhunk://#diff-ab3f5b60872918a1c25509bb83b3b8d9cc624aa42a4550df3ac019c559d82ce5L14-R14): Updated `pascalgn/size-label-action` to a specific commit SHA for `v0.5.5`.
* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894L16-R16): Updated `actions/stale` to `v9.1.0`.