### PR TITLE
fix: Mariner CA cert volume mounts to match aks-rp

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
@@ -297,7 +297,7 @@ spec:
         {{- if $arcExtensionSettings.mountMarinerCerts }}
         - name: anchors-mariner
           hostPath:
-            path: /etc/pki/ca-trust/anchors/
+            path: /etc/pki/ca-trust/source/anchors/
             type: DirectoryOrCreate
         {{- end }}
         {{- if $arcExtensionSettings.mountUbuntuCerts }}

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
@@ -372,7 +372,7 @@ spec:
         {{- if $arcExtensionSettings.mountMarinerCerts }}
         - name: anchors-mariner
           hostPath:
-            path: /etc/pki/ca-trust/anchors/
+            path: /etc/pki/ca-trust/source/anchors/
             type: DirectoryOrCreate
         {{- end }}
         - name: ama-metrics-tls-secret-volume

--- a/otelcollector/deploy/addon-chart/ccp-metrics-plugin/templates/ama-metrics-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/ccp-metrics-plugin/templates/ama-metrics-deployment.yaml
@@ -214,7 +214,7 @@ spec:
             optional: true
         - name: anchors-mariner
           hostPath:
-            path: /etc/pki/ca-trust/anchors/
+            path: /etc/pki/ca-trust/source/anchors/
             type: DirectoryOrCreate
         - name: anchors-ubuntu
           hostPath:


### PR DESCRIPTION
# PR Description

In specific sovereign and disconnected scenarios ama-metrics pods need to load the cloud-specific CA roots and intermediates from the AKS host nodes. For Mariner the correct path to use is
/etc/pki/ca-trust/source/anchors.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
