### PR TITLE
build: change windows addon-token-adapter image repository to match AKS prod

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -74,7 +74,7 @@ AzureMonitorMetrics:
     ImageRegistry: mcr.microsoft.com
     ImageRepository: "/aks/msi/addon-token-adapter"
     ImageTag: "master.250423.2"
-    ImageRepositoryWin: "/aks/hcp/addon-token-adapter"
+    ImageRepositoryWin: "/aks/msi/addon-token-adapter"
     ImageTagWin: "master.250423.2"
   ArcExtension: ${ARC_EXTENSION}
   ArcEnableOperator: true


### PR DESCRIPTION
The tests were still failing with the image pull fail, so I checked what image was running in a prod cluster; looks like they changed the image repository to be the same as linux