### PR TITLE
fix: move first hash call to after MA, ME startup

### DIFF
--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -51,9 +51,6 @@ func main() {
 				log.Fatal(err)
 			}
 		}
-	} else if osType == "windows" {
-		fmt.Println("Called shared.CheckForFilesystemChanges() once to set the hash for comparison")
-		shared.CheckForFilesystemChanges()
 	}
 
 	if ccpMetricsEnabled != "true" && osType == "linux" {
@@ -139,6 +136,13 @@ func main() {
 		}
 	} else {
 		shared.StartMetricsExtensionWithConfigOverridesForUnderlay(meConfigFile)
+	}
+
+	// note : this has to be after MA start so that the TokenConfig.json file is already in place
+	// otherwise the hash generated will be different and cause a restart.
+	if osType == "windows" {
+		fmt.Println("Called shared.CheckForFilesystemChanges() once to set the hash for comparison")
+		shared.CheckForFilesystemChanges()
 	}
 
 	// Start otelcollector

--- a/otelcollector/shared/filesystemwatcher_utility.go
+++ b/otelcollector/shared/filesystemwatcher_utility.go
@@ -77,10 +77,12 @@ func CheckForFilesystemChanges() {
 
 	// Compare with last stored hash
 	lastHashBytes, err := os.ReadFile(hashStore)
+	lastHash := ""
 	if err != nil {
 		debug("Could not read last hash from %s: %v", hashStore, err)
+	} else {
+		lastHash = strings.TrimSpace(string(lastHashBytes))
 	}
-	lastHash := strings.TrimSpace(string(lastHashBytes))
 	debug("Previous hash: %s", lastHash)
 
 	if lastHash == "" {

--- a/otelcollector/shared/filesystemwatcher_utility.go
+++ b/otelcollector/shared/filesystemwatcher_utility.go
@@ -27,7 +27,16 @@ func CheckForFilesystemChanges() {
 	debug := func(format string, a ...any) {
 		msg := fmt.Sprintf(format, a...)
 		msg = time.Now().Format("2006-01-02 15:04:05") + " " + msg + "\n"
-		os.WriteFile(debugLog, []byte(msg), os.ModeAppend|0644)
+
+		f, err := os.OpenFile(debugLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			// Fallback to stdout if file can't be written
+			fmt.Printf("Failed to write debug log: %v\n", err)
+			return
+		}
+		defer f.Close()
+
+		f.WriteString(msg)
 	}
 
 	debug("Starting CheckForFilesystemChanges")


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
