### PR TITLE
fix: disable default remotewrite jobs + enable third workspace

### DIFF
--- a/internal/remotewrite/sidecar.yaml
+++ b/internal/remotewrite/sidecar.yaml
@@ -1,3 +1,27 @@
+defaultRules:
+  create: false
+kubelet:
+  enabled: false
+kubeApiServer:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+coreDns:
+  enabled: false
+kubeDns:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeStateMetrics:
+  enabled: false
+nodeExporter:
+  enabled: false
+alertmanager:
+  enabled: false
+grafana:
+  enabled: false
 prometheus:
   prometheusSpec:
     affinity:
@@ -46,6 +70,11 @@ prometheus:
     remoteWrite:
     - url: http://localhost:8081/api/v1/write
     - url: https://remotewritemonitor-eus2-lzt0.eastus2-1.metrics.ingest.monitor.azure.com/dataCollectionRules/dcr-c61eca33833b44fa8eddd257a0baa02a/streams/Microsoft-PrometheusMetrics/api/v1/write?api-version=2023-04-24
+      azureAd:
+        cloud: AzurePublic
+        managedIdentity:
+          clientId: $USER_ASSIGNED_MANAGED_IDENTITY_CLIENT_ID
+    - url: https://remotewritemonitor-wcus-13t6.westcentralus-1.metrics.ingest.monitor.azure.com/dataCollectionRules/dcr-315d0c9a2c5e463d8bd13cf2bcc4f875/streams/Microsoft-PrometheusMetrics/api/v1/write?api-version=2023-04-24
       azureAd:
         cloud: AzurePublic
         managedIdentity:


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
