### PR TITLE
build: fix issue with 1ES scanning

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -1857,6 +1857,8 @@ extends:
             ScanType: CustomScan
             FileDirPath: '$(Build.ArtifactStagingDirectory)'
             DisableRemediation: false
+            AcceptableOutdatedSignatureInHours: 24
+            TreatAcceptableOutdatedSignatureAs: Warning
       - job: Arc_Helm_Chart
         displayName: "Package: Arc helm chart"
         pool:


### PR DESCRIPTION
- Fixing the build errors with the antimalware scan following this TSG: aka.ms/gdn-azdo-antimalware. It has to do with issues of when the hosted agentpool to run the build was last updated