### PR TITLE
fix: very high CPU issue with openmetrics exposition

### DIFF
--- a/otelcollector/prometheusreceiver/metrics_receiver.go
+++ b/otelcollector/prometheusreceiver/metrics_receiver.go
@@ -167,7 +167,7 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, logger *slog.L
 		HTTPClientOptions: []commonconfig.HTTPClientOption{
 			commonconfig.WithUserAgent(r.settings.BuildInfo.Command + "/" + r.settings.BuildInfo.Version),
 		},
-		EnableCreatedTimestampZeroIngestion: true,
+		EnableCreatedTimestampZeroIngestion: useCreatedMetricGate.IsEnabled(),
 	}
 
 	if enableNativeHistogramsGate.IsEnabled() {


### PR DESCRIPTION
Change the `EnableCreatedTimestampZeroIngestion` setting in the prometheus scrape manager to use the otelcollector feature flag that has the same name and is disabled by default.

This had introduced new parsing during a scrape loop that resulted in very high CPU at higher metric volumes.

Reverts this PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36660 so that the functionality for this is the same as before v0.121.0``