### PR TITLE
release: add retries for oras copy

### DIFF
--- a/.pipelines/deployment/ServiceGroupRoot/RolloutSpecs/RolloutSpecs.json
+++ b/.pipelines/deployment/ServiceGroupRoot/RolloutSpecs/RolloutSpecs.json
@@ -89,9 +89,6 @@
         "Shell/PushAgentToACR"
       ],
       "dependsOn": [
-        "PushLinuxAgent",
-        "PushLinuxCCPAgent",
-        "PushWindowsAgent",
         "PushKSMChart",
         "PushNEChart"
       ]


### PR DESCRIPTION
- Add retries for the oras copy that is flaky.
- Arc chart only depends on dependent charts to push. Don't depend on other images just because currently all need to pass in order to push arc chart