### PR TITLE
fix: update code for win supp in sovereign clouds, ca cert bootstrap

### DIFF
--- a/otelcollector/main/main.go
+++ b/otelcollector/main/main.go
@@ -31,6 +31,7 @@ func main() {
 	osType := os.Getenv("OS_TYPE")
 
 	if osType == "windows" {
+		shared.BootstrapCACertificates()
 		shared.SetEnvVariablesForWindows()
 	}
 

--- a/otelcollector/shared/bootstrap_certificates_windows.go
+++ b/otelcollector/shared/bootstrap_certificates_windows.go
@@ -1,0 +1,98 @@
+package shared
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func BootstrapCACertificates() {
+	certMountPath := `C:\ca`
+
+	files, err := os.ReadDir(certMountPath)
+	if err != nil {
+		fmt.Printf("Unable to read certificate directory %s: %v\n", certMountPath, err)
+		return
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		absolutePath := filepath.Join(certMountPath, file.Name())
+		fmt.Printf("Processing certificate: %s\n", absolutePath)
+
+		data, err := os.ReadFile(absolutePath)
+		if err != nil {
+			fmt.Printf("  Failed to read file: %v\n", err)
+			continue
+		}
+
+		block, _ := pem.Decode(data)
+		if block == nil || block.Type != "CERTIFICATE" {
+			fmt.Printf("  Skipping invalid or non-certificate PEM block.\n")
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			fmt.Printf("  Certificate parse error: %v\n", err)
+			continue
+		}
+
+		if err := addCertToRootStore(cert.Raw); err != nil {
+			fmt.Printf("  Import failed: %v\n", err)
+		} else {
+			fmt.Printf("  Certificate imported successfully.\n")
+		}
+	}
+}
+
+func addCertToRootStore(certDER []byte) error {
+	const ROOT_STORE = `ROOT`
+
+	storeNamePtr, err := windows.UTF16PtrFromString(ROOT_STORE)
+	if err != nil {
+		return fmt.Errorf("failed to encode store name: %w", err)
+	}
+
+	store, err := windows.CertOpenStore(
+		windows.CERT_STORE_PROV_SYSTEM,
+		0,
+		0,
+		windows.CERT_SYSTEM_STORE_LOCAL_MACHINE,
+		uintptr(unsafe.Pointer(storeNamePtr)), // ✅ cast to uintptr
+	)
+	if err != nil {
+		return fmt.Errorf("opening root store: %w", err)
+	}
+	defer windows.CertCloseStore(store, 0)
+
+	certContext, err := windows.CertCreateCertificateContext(
+		windows.X509_ASN_ENCODING,
+		&certDER[0],
+		uint32(len(certDER)),
+	)
+	if err != nil {
+		return fmt.Errorf("creating certificate context: %w", err)
+	}
+	defer windows.CertFreeCertificateContext(certContext)
+
+	err = windows.CertAddCertificateContextToStore(
+		store,
+		certContext,
+		windows.CERT_STORE_ADD_REPLACE_EXISTING,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("adding certificate to store failed: %w", err)
+	}
+
+	return nil
+}

--- a/otelcollector/shared/go.mod
+++ b/otelcollector/shared/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.2
 
 require (
 	github.com/prometheus/common v0.62.0
+	golang.org/x/sys v0.31.0
 	k8s.io/apimachinery v0.32.0
 )
 

--- a/otelcollector/shared/go.sum
+++ b/otelcollector/shared/go.sum
@@ -66,6 +66,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
