### PR TITLE
fix: respect minimalingestionprofile when no configmap is present

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,12 +2,15 @@
 # targetallocator
 CVE-2025-22869 # golang.org/x/crypto
 CVE-2025-30204 # github.com/golang-jwt/jwt/v5
+
 # MEDIUM
 # otelcollector
 CVE-2025-22872 # golang.org/x/net
 # promconfigvalidator
 CVE-2025-22872 # golang.org/x/net
+CVE-2025-0913  # stdlib
+CVE-2025-4673  # stdlib
 # prometheusui
 CVE-2025-22872 # golang.org/x/net
 # targetallocator
-CVE-2025-22870 # golang.org/x/net 
+CVE-2025-22870 # golang.org/x/net

--- a/otelcollector/shared/configmap/ccp/tomlparser-ccp-default-scrape-settings.go
+++ b/otelcollector/shared/configmap/ccp/tomlparser-ccp-default-scrape-settings.go
@@ -18,7 +18,6 @@ func (fcl *FilesystemConfigLoader) SetDefaultScrapeSettings() (map[string]string
 	config["controlplane-kube-scheduler"] = "false"
 	config["controlplane-kube-controller-manager"] = "false"
 	config["controlplane-etcd"] = "true"
-	config["minimalingestionprofile"] = "true"
 
 	return config, nil
 }
@@ -32,7 +31,6 @@ func (fcl *FilesystemConfigLoader) ParseConfigMapForDefaultScrapeSettings(metric
 	config["controlplane-kube-scheduler"] = "false"
 	config["controlplane-kube-controller-manager"] = "false"
 	config["controlplane-etcd"] = "true"
-	config["minimalingestionprofile"] = "true"
 
 	// Override defaults with values from metricsConfigBySection
 	if schemaVersion == "v1" {

--- a/otelcollector/shared/configmap/ccp/tomlparser-ccp-default-scrape-settings.go
+++ b/otelcollector/shared/configmap/ccp/tomlparser-ccp-default-scrape-settings.go
@@ -18,6 +18,7 @@ func (fcl *FilesystemConfigLoader) SetDefaultScrapeSettings() (map[string]string
 	config["controlplane-kube-scheduler"] = "false"
 	config["controlplane-kube-controller-manager"] = "false"
 	config["controlplane-etcd"] = "true"
+	config["minimalingestionprofile"] = "true"
 
 	return config, nil
 }
@@ -31,6 +32,7 @@ func (fcl *FilesystemConfigLoader) ParseConfigMapForDefaultScrapeSettings(metric
 	config["controlplane-kube-scheduler"] = "false"
 	config["controlplane-kube-controller-manager"] = "false"
 	config["controlplane-etcd"] = "true"
+	config["minimalingestionprofile"] = "true"
 
 	// Override defaults with values from metricsConfigBySection
 	if schemaVersion == "v1" {

--- a/otelcollector/shared/configmap/ccp/tomlparser-ccp-default-targets-metrics-keep-list.go
+++ b/otelcollector/shared/configmap/ccp/tomlparser-ccp-default-targets-metrics-keep-list.go
@@ -42,6 +42,8 @@ func getStringValue(value interface{}) string {
 // parseConfigMapForKeepListRegex extracts the control plane metrics keep list from metricsConfigBySection.
 func parseConfigMapForKeepListRegex(metricsConfigBySection map[string]map[string]string, schemaVersion string) map[string]interface{} {
 	configMap := make(map[string]interface{})
+	// set default to true in case there is no configmap
+	configMap["minimalingestionprofile"] = "true"
 
 	fmt.Printf("parseConfigMapForKeepListRegex::schemaVersion: %s\n", schemaVersion)
 

--- a/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
@@ -27,6 +27,8 @@ func (fcl *FilesystemConfigLoader) SetDefaultScrapeSettings() (map[string]string
 	config["noDefaultsEnabled"] = "false"
 	config["acstor-capacity-provisioner"] = "true"
 	config["acstor-metrics-exporter"] = "true"
+	config["minimalingestionprofile "] = "true"
+
 	return config, nil
 }
 
@@ -50,10 +52,11 @@ func (fcl *FilesystemConfigLoader) ParseConfigMapForDefaultScrapeSettings(metric
 	config["noDefaultsEnabled"] = "false"
 	config["acstor-capacity-provisioner"] = "true"
 	config["acstor-metrics-exporter"] = "true"
+	config["minimalingestionprofile "] = "true"
 
 	configSectionName := "default-scrape-settings-enabled"
 	if schemaVersion == "v2" {
-          configSectionName = "default-targets-scrape-enabled"
+		configSectionName = "default-targets-scrape-enabled"
 	}
 	// Override defaults with values from metricsConfigBySection
 	if settings, ok := metricsConfigBySection[configSectionName]; ok {

--- a/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
@@ -27,7 +27,6 @@ func (fcl *FilesystemConfigLoader) SetDefaultScrapeSettings() (map[string]string
 	config["noDefaultsEnabled"] = "false"
 	config["acstor-capacity-provisioner"] = "true"
 	config["acstor-metrics-exporter"] = "true"
-	config["minimalingestionprofile "] = "true"
 
 	return config, nil
 }
@@ -52,7 +51,6 @@ func (fcl *FilesystemConfigLoader) ParseConfigMapForDefaultScrapeSettings(metric
 	config["noDefaultsEnabled"] = "false"
 	config["acstor-capacity-provisioner"] = "true"
 	config["acstor-metrics-exporter"] = "true"
-	config["minimalingestionprofile "] = "true"
 
 	configSectionName := "default-scrape-settings-enabled"
 	if schemaVersion == "v2" {


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
