### PR TITLE
CI/CD: upgrade bot improvements from v0.131.0 PR

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,16 +1,25 @@
-name: size-label #https://github.com/kubernetes/kubernetes/labels?q=size
-on: 
-  pull_request:
-    branches:
-      - main
+name: Dependabot Auto-Merge
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
 jobs:
-  size-label:
+  dependabot-automerge:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/')
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
-      - name: size-label
-        uses: "pascalgn/size-label-action@v0.5.5"
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,25 +1,16 @@
-name: Dependabot Auto-Merge
-on:
-  pull_request_target:
-    types: [opened, synchronize]
-
+name: size-label #https://github.com/kubernetes/kubernetes/labels?q=size
+on: 
+  pull_request:
+    branches:
+      - main
 jobs:
-  dependabot-automerge:
+  size-label:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/')
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --squash "$PR_URL"
+      - name: size-label
+        uses: "pascalgn/size-label-action@v0.5.5"
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -4,6 +4,7 @@ trigger:
     - main
     - bot/otelcollector-upgrade-*
     - dependabot*
+    - grace/v0.131.0-bot-improvements
 pr:
   autoCancel: true
   branches:

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -4,7 +4,6 @@ trigger:
     - main
     - bot/otelcollector-upgrade-*
     - dependabot*
-    - grace/0.131.0-bot-improvements
 pr:
   autoCancel: true
   branches:
@@ -2372,8 +2371,8 @@ extends:
       - deployment: Testkube
         displayName: "Test: AKS testkube tests"
         environment: Prometheus-Collector
-        #dependsOn: Deploy_AKS_Chart
-        #condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
+        dependsOn: Deploy_AKS_Chart
+        condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
         variables:
           HELM_CHART_NAME: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.HELM_CHART_NAME'] ]
           HELM_SEMVER: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.SEMVER'] ]
@@ -2513,8 +2512,8 @@ extends:
       - deployment: Testkube_OTel_Upgrade
         displayName: "Test: OTel Collector Upgrade testkube tests"
         environment: Prometheus-Collector
-        #dependsOn:  Deploy_AKS_Chart_OTel_Upgrade_Cluster
-        #condition: eq(variables.IS_OTEL_UPGRADE_BRANCH, true)
+        dependsOn:  Deploy_AKS_Chart_OTel_Upgrade_Cluster
+        condition: eq(variables.IS_OTEL_UPGRADE_BRANCH, true)
         variables:
           HELM_CHART_NAME: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.HELM_CHART_NAME'] ]
           HELM_SEMVER: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.SEMVER'] ]

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2410,7 +2410,8 @@ extends:
                     "testkube-test-crs-ci-dev-aks-mac-eus.yaml" \
                     "" \
                     "" \
-                    "AKS"
+                    "AKS" \
+                    ""
                 workingDirectory: $(Build.SourcesDirectory)/otelcollector/test
                 displayName: "Run TestKube workflow"
                 continueOnError: true
@@ -2457,7 +2458,8 @@ extends:
                     "testkube-test-crs-ciprom-dev-aks-otlp.yaml" \
                     "false" \
                     "" \
-                    "OTel"
+                    "OTel" \
+                    ""
                 workingDirectory: $(Build.SourcesDirectory)/otelcollector/test
                 displayName: "Run TestKube workflow"
                 continueOnError: true
@@ -2504,7 +2506,8 @@ extends:
                   "testkube-test-crs-ci-dev-arc-wcus.yaml" \
                   "" \
                   "" \
-                  "ARC"
+                  "ARC" \
+                  ""
                 workingDirectory: $(Build.SourcesDirectory)/otelcollector/test
                 displayName: "Run TestKube workflow"
                 continueOnError: true
@@ -2547,11 +2550,12 @@ extends:
                   ./testkube/run-testkube-workflow.sh \
                     "https://ciprom-upgrade-bot-e4c4gvcgcqd7awhw.westus3.prometheus.monitor.azure.com" \
                     "3bf21bd6-3dd9-449d-8f17-5f3b1a61ecd6" \
-                    "testkube-test-crs.yaml" \
+                    "testkube-test-crs-otelcollector-upgrade.yaml" \
                     "testkube-test-crs-otel-upgrade.yaml" \
                     "" \
                     "" \
-                    "OTelCollector-Upgrade"
+                    "OTelCollector-Upgrade" \
+                    "$(System.PullRequest.SourceBranch)"
                 workingDirectory: $(Build.SourcesDirectory)/otelcollector/test
                 displayName: "Run TestKube workflow"
                 continueOnError: true
@@ -2621,7 +2625,7 @@ extends:
           displayName: 'Download TestKube OTelCollector Upgrade Results'
           condition: always() 
           inputs:
-            artifactName: 'testkube-results-OTel-Upgrade'
+            artifactName: 'testkube-results-OTelCollector-Upgrade'
             targetPath: '$(Pipeline.Workspace)/testkube-results'
           continueOnError: true
         - bash: |

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2372,7 +2372,7 @@ extends:
       - deployment: Testkube
         displayName: "Test: AKS testkube tests"
         environment: Prometheus-Collector
-        dependsOn: Deploy_AKS_Chart
+        #dependsOn: Deploy_AKS_Chart
         #condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
         variables:
           HELM_CHART_NAME: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.HELM_CHART_NAME'] ]
@@ -2513,7 +2513,7 @@ extends:
       - deployment: Testkube_OTel_Upgrade
         displayName: "Test: OTel Collector Upgrade testkube tests"
         environment: Prometheus-Collector
-        dependsOn:  Deploy_AKS_Chart_OTel_Upgrade_Cluster
+        #dependsOn:  Deploy_AKS_Chart_OTel_Upgrade_Cluster
         #condition: eq(variables.IS_OTEL_UPGRADE_BRANCH, true)
         variables:
           HELM_CHART_NAME: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.HELM_CHART_NAME'] ]

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2372,7 +2372,7 @@ extends:
         displayName: "Test: AKS testkube tests"
         environment: Prometheus-Collector
         dependsOn: Deploy_AKS_Chart
-        condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
+        #condition: and(succeeded(), and(eq(variables.IS_PR, false), eq(variables.IS_MAIN_BRANCH, true)))
         variables:
           HELM_CHART_NAME: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.HELM_CHART_NAME'] ]
           HELM_SEMVER: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.SEMVER'] ]
@@ -2410,8 +2410,7 @@ extends:
                     "testkube-test-crs-ci-dev-aks-mac-eus.yaml" \
                     "" \
                     "" \
-                    "AKS" \
-                    ""
+                    "AKS"
                 workingDirectory: $(Build.SourcesDirectory)/otelcollector/test
                 displayName: "Run TestKube workflow"
                 continueOnError: true
@@ -2458,8 +2457,7 @@ extends:
                     "testkube-test-crs-ciprom-dev-aks-otlp.yaml" \
                     "false" \
                     "" \
-                    "OTel" \
-                    ""
+                    "OTel"
                 workingDirectory: $(Build.SourcesDirectory)/otelcollector/test
                 displayName: "Run TestKube workflow"
                 continueOnError: true
@@ -2506,8 +2504,7 @@ extends:
                   "testkube-test-crs-ci-dev-arc-wcus.yaml" \
                   "" \
                   "" \
-                  "ARC" \
-                  ""
+                  "ARC"
                 workingDirectory: $(Build.SourcesDirectory)/otelcollector/test
                 displayName: "Run TestKube workflow"
                 continueOnError: true
@@ -2516,7 +2513,7 @@ extends:
         displayName: "Test: OTel Collector Upgrade testkube tests"
         environment: Prometheus-Collector
         dependsOn:  Deploy_AKS_Chart_OTel_Upgrade_Cluster
-        condition: eq(variables.IS_OTEL_UPGRADE_BRANCH, true)
+        #condition: eq(variables.IS_OTEL_UPGRADE_BRANCH, true)
         variables:
           HELM_CHART_NAME: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.HELM_CHART_NAME'] ]
           HELM_SEMVER: $[ stageDependencies.Build.Image_Tags_and_Ev2_Artifacts.outputs['setup.SEMVER'] ]

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -4,7 +4,7 @@ trigger:
     - main
     - bot/otelcollector-upgrade-*
     - dependabot*
-    - grace/v0.131.0-bot-improvements
+    - grace/0.131.0-bot-improvements
 pr:
   autoCancel: true
   branches:

--- a/internal/otel-upgrade-scripts/README.md
+++ b/internal/otel-upgrade-scripts/README.md
@@ -73,3 +73,101 @@ Example agent prompt with context pointing to `upgrade.sh` and `UpgradeotelCol.m
 The updates made to the script can be tested locally by running `internal/otel-upgrade-scripts/check-otel-version.sh`.
 
 The changes to the script are usually a starting point and may require some tweaking such as what the regex is for the existing line to add the new code after it. Anything too specific might not work if the existing code gets updated in the future.
+
+## Script Enhancement Prompt Examples
+- **Prompt**:
+   ```
+   Currently this script in # Step 5, updates the golang version based on opentelemetry-collector-contrib/go.mod. We need to actually take the highest version between otel-allocator/go.mod or opentelemetry-collector-contrib/go.mod
+   ```
+- **Results**:
+   - Removed the original Step 5 that only looked at `opentelemetry-collector-contrib/go.mod`
+   - Added a new Step 8 that runs after both the `opentelemetry-collector-contrib` and `otel-allocator` updates are complete
+   - Created a version comparison function that properly compares version strings
+   - Extracts Go versions from both `go.mod` files:
+      - `opentelemetry-collector-contrib/go.mod`
+      -` otel-allocator/go.mod`
+   - Compares the versions and selects the highest one
+   Updates the pipeline file only if the `major.minor` version changes
+- **Prompt**
+   ```
+   Now if the golang version does need to be changed, find what patch version to use based on the latest patch version tag available from the image repository mcr.microsoft.com/oss/go/microsoft/golang
+   ```
+- **Results**:
+   - **Tool Check**: The script now checks for `curl` and `jq` availability
+   - **Registry Query**: Uses curl to query the MCR API endpoint: `https://mcr.microsoft.com/v2/oss/go/microsoft/golang/tags/list`
+   - **JSON Parsing**: The response is parsed with `jq` to extract the tags array
+   - **Version Selection**: The same logic as before finds the highest patch version for the given `major.minor` version
+   - **Fallback**: If the registry is unreachable or tools are missing, it falls back to using the version from the `go.mod` files
+
+- **Prompt**:
+   ```
+   Do not use skopeo, just curl the endpoint and parse the json with jq
+   ```
+- **Results**:
+   - **Tool Replacement**: Replaced skopeo dependency with curl and jq approach
+   - **Direct API Access**: Uses curl to directly query the MCR REST API
+   - **JSON Processing**: Leverages jq for robust JSON parsing and filtering
+   - **Simplified Dependencies**: Removes the need for container registry tools, using only standard HTTP tools
+
+- **Prompt**:
+   ```
+   I need the prometheus package versions to be updated in go.mod to be the same as those in the opentelemetry-collector and the otel-allocator
+   ```
+- **Results**:
+   - **Added Step 7.1**: New step to synchronize Prometheus dependencies in test utils
+   - **Version Extraction**: Extracts Prometheus package versions from both main modules:
+     - `github.com/prometheus/client_golang`
+     - `github.com/prometheus/common`
+     - `github.com/prometheus/client_model`
+   - **Version Comparison**: Uses highest version between otel-builder and otel-allocator
+   - **Target Module**: Updates `otelcollector/test/ginkgo-e2e/utils/go.mod`
+
+- **Prompt**:
+   ```
+   After updating in the utils directory, it also nede to be updated in the prometheusui go.mod
+   ```
+- **Results**:
+   - **Added Step 7.2**: Extended Prometheus synchronization to prometheusui module
+   - **Additional Package**: Also handles `github.com/prometheus/prometheus` package
+   - **Version Reuse**: Leverages variables from Step 7.1 to avoid code duplication
+   - **Target Module**: Updates `otelcollector/test/ginkgo-e2e/prometheusui/go.mod`
+   - **Special Handling**: Includes regex escaping for complex version strings with special characters
+
+- **Prompt**:
+   ```
+   You don't need to do the same code twice for 7.2 to get the versions
+   ```
+- **Results**:
+   - **Code Optimization**: Eliminated duplicate version extraction code
+   - **Variable Reuse**: Step 7.2 now reuses variables calculated in Step 7.1
+   - **Improved Maintainability**: Single source of truth for Prometheus version selection
+   - **Performance**: Reduced redundant operations and improved script efficiency
+
+- **Prompt**:
+   ```
+   The script is getting way more versions than we want in the grep such as: Using Go version from otel-allocator: 1.24.0 v1.1.12 v0.32.3 v1.2.2...
+   ```
+- **Results**:
+   - **Grep Pattern Fix**: Changed from `grep "go "` to `grep "^go "` 
+   - **Anchor Matching**: Added `^` to ensure pattern only matches lines starting with "go "
+   - **False Positive Prevention**: Avoids matching dependency lines containing "go" in package names
+   - **Precise Extraction**: Only captures the actual Go version declaration line
+
+- **Prompt**:
+   ```
+   The script is now failing with these logs: ... sed: -e expression #1, char 110: unknown option to `s'
+   ```
+- **Results**:
+   - **Pipeline Extraction Fix**: Added `head -1` to extract only the first `GOLANG_VERSION` match
+   - **Multi-line Prevention**: Prevents capturing multiple lines that could break sed commands
+   - **Improved Regex**: Enhanced sed pattern from `s/GOLANG_VERSION: '//;s/'//g` to `s/.*GOLANG_VERSION: '//;s/'.*//g`
+
+- **Prompt**:
+   ```
+   The script is upgrading the build version for other lines we don't want like FLUENTBIT_GOLANG_VERSION and TESTKUBE_GOLANG_VERSION
+   ```
+- **Results**:
+   - **Precise Pattern Matching**: Changed sed pattern to `s/^  GOLANG_VERSION: '.*'/  GOLANG_VERSION: '${FINAL_GO_VERSION}'/g`
+   - **Indentation Awareness**: Added `^  ` to match exact YAML indentation
+   - **False Match Prevention**: Ensures only the main `GOLANG_VERSION` line is updated
+   - **YAML Formatting**: Preserves proper indentation in the replacement string

--- a/otelcollector/test/testkube/run-testkube-workflow.sh
+++ b/otelcollector/test/testkube/run-testkube-workflow.sh
@@ -22,6 +22,7 @@ TARGET_OUTPUT="$4"
 APPLY_SETTINGS_CONFIGMAP="${5:-true}"
 SLEEP_DURATION="${6:-360}"
 TARGET_ENV="${7:-Unknown}"
+BRANCH_NAME="${8:-main}"
 
 # Define shared results file  
 RESULTS_FILE="${BUILD_ARTIFACTSTAGINGDIRECTORY}/testkube-results-${TARGET_ENV}.json"
@@ -78,6 +79,7 @@ echo "Target output: $TARGET_OUTPUT"
 # Export environment variables for envsubst
 export AMW_QUERY_ENDPOINT
 export AZURE_CLIENT_ID
+export BRANCH_NAME
 
 # Generate the test CRs from template
 envsubst < "./testkube/$SOURCE_TEMPLATE" > "./testkube/$TARGET_OUTPUT"

--- a/otelcollector/test/testkube/testkube-test-crs-otelcollector-upgrade.yaml
+++ b/otelcollector/test/testkube/testkube-test-crs-otelcollector-upgrade.yaml
@@ -1,0 +1,170 @@
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: containerstatus
+  namespace: testkube
+  labels:
+    executor: ginkgo-executor
+    test-type: ginkgo-test
+spec:
+  type: ginkgo/test
+  content:
+    type: git
+    repository:
+      type: git
+      uri: https://github.com/Azure/prometheus-collector
+      branch: $BRANCH_NAME
+      path: otelcollector/test/ginkgo-e2e
+  executionRequest:
+    args:
+      - "--label-filter"
+      - "!(arc-extension,linux-daemonset-custom-config,otlp)"
+      - "./containerstatus"
+    executePostRunScriptBeforeScraping: false
+---
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: livenessprobe
+  namespace: testkube
+  labels:
+    executor: ginkgo-executor
+    test-type: ginkgo-test
+spec:
+  type: ginkgo/test
+  content:
+    type: git
+    repository:
+      type: git
+      uri: https://github.com/Azure/prometheus-collector
+      branch: $BRANCH_NAME
+      path: otelcollector/test/ginkgo-e2e
+  executionRequest:
+    args:
+      - "--label-filter"
+      - "!(arc-extension,linux-daemonset-custom-config,otlp)"
+      - "./livenessprobe"
+    executePostRunScriptBeforeScraping: false
+---
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: prometheusui
+  namespace: testkube
+  labels:
+    executor: ginkgo-executor
+    test-type: ginkgo-test
+spec:
+  type: ginkgo/test
+  content:
+    type: git
+    repository:
+      type: git
+      uri: https://github.com/Azure/prometheus-collector
+      branch: $BRANCH_NAME
+      path: otelcollector/test/ginkgo-e2e
+  executionRequest:
+    args:
+      - "--label-filter"
+      - "!(arc-extension,linux-daemonset-custom-config,otlp)"
+      - "./prometheusui"
+    executePostRunScriptBeforeScraping: false
+---
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: operator
+  namespace: testkube
+  labels:
+    executor: ginkgo-executor
+    test-type: ginkgo-test
+spec:
+  type: ginkgo/test
+  content:
+    type: git
+    repository:
+      type: git
+      uri: https://github.com/Azure/prometheus-collector
+      branch: $BRANCH_NAME
+      path: otelcollector/test/ginkgo-e2e
+  executionRequest:
+    args:
+      - "--ldflags"
+      - "-s -X github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring.GroupName=azmonitoring.coreos.com"
+      - "./operator"
+    executePostRunScriptBeforeScraping: false
+---
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: querymetrics
+  namespace: testkube
+  labels:
+    executor: ginkgo-executor
+    test-type: ginkgo-test
+spec:
+  type: ginkgo/test
+  content:
+    type: git
+    repository:
+      type: git
+      uri: https://github.com/Azure/prometheus-collector
+      branch: $BRANCH_NAME
+      path: otelcollector/test/ginkgo-e2e
+  executionRequest:
+    variables:
+      AMW_QUERY_ENDPOINT:
+        name: AMW_QUERY_ENDPOINT
+        value: "$AMW_QUERY_ENDPOINT"
+        type: basic
+      AZURE_CLIENT_ID:
+        name: AZURE_CLIENT_ID
+        value: "$AZURE_CLIENT_ID"
+        type: basic
+    args:
+      - "--label-filter"
+      - "!(arc-extension,linux-daemonset-custom-config,otlp)"
+      - "./querymetrics"
+    executePostRunScriptBeforeScraping: false
+---
+apiVersion: tests.testkube.io/v3
+kind: TestSuite
+metadata:
+  name: e2e-tests-nightly
+  namespace: testkube
+spec:
+  steps:
+  - stopOnFailure: false
+    execute:
+    - test: containerstatus
+    - test: prometheusui
+    - test: operator
+  - stopOnFailure: false
+    execute:
+    - delay: 2m0s
+  - stopOnFailure: false
+    execute:
+    - test: querymetrics
+  - stopOnFailure: false
+    execute:
+    - test: livenessprobe
+  schedule: "0 7 * * *"
+---
+apiVersion: tests.testkube.io/v3
+kind: TestSuite
+metadata:
+  name: e2e-tests-merge
+  namespace: testkube
+spec:
+  steps:
+  - stopOnFailure: false
+    execute:
+    - test: containerstatus
+    - test: prometheusui
+    - test: operator
+  - stopOnFailure: false
+    execute:
+    - delay: 2m0s
+  - stopOnFailure: false
+    execute:
+    - test: querymetrics


### PR DESCRIPTION

* Updated the otelcollector upgrade script to also update the Prometheus package versions in `test/ginkgo-e2e/utils/go.mod` and `test/ginkgo-e2e/prometheusui/go.mod` to match those used by the otelcollector and targetallocator. This is necessary for the config validation tests to have the same version
*  Added a check for the targetallocator in addition to the otelcollector to see if the major.minor golang version in the build pipeline needs to be updated. Curl the MCR repository for golang images to get the latest patch version
* Add a new test CR template for the upgrade cluster so that the tests point to the ginkgo changes in the branch and not in the main branch
* Added the prompts I used and the results from Copilot to update the script as examples for the future