### PR TITLE
fix: acstor v2 configmap file definition

### DIFF
--- a/otelcollector/shared/configmap/mp/definitions.go
+++ b/otelcollector/shared/configmap/mp/definitions.go
@@ -50,7 +50,7 @@ var (
 	networkObservabilityCiliumDefaultFileDs      = "networkobservabilityCiliumDefaultDs.yml"
 	acstorCapacityProvisionerDefaultFile         = "acstorCapacityProvisionerDefaultFile.yml"
 	acstorMetricsExporterDefaultFile             = "acstorMetricsExporterDefaultFile.yml"
-	LocalCSIDriverDefaultFile                    = "LocalCSIDriverDefaultFile.yml"
+	LocalCSIDriverDefaultFile                    = "localCSIDriverDefaultFile.yml"
 )
 
 type RegexValues struct {


### PR DESCRIPTION
This was caught by our e2e tests checking for errors in the logs