### PR TITLE
chart: Match AKS RP chart for values and daemonset yaml

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
@@ -134,11 +134,22 @@ spec:
             - name: MINIMAL_INGESTION_PROFILE
               value: "true" # only supported value is the string "true"
             - name: APPMONITORING_AUTOINSTRUMENTATION_ENABLED
-              value: "{{ .Values.AzureMonitorMetrics.IsAppMonitoringAutoInstrumentationEnabled }}"
+              value: "{{ $.Values.AppmonitoringAgent.enabled }}"
             - name: APPMONITORING_OPENTELEMETRYMETRICS_ENABLED
-              value: "{{ .Values.AzureMonitorMetrics.IsAppMonitoringOpenTelemetryMetricsEnabled }}"
+              value: "{{ $.Values.AppmonitoringAgent.isOpenTelemetryMetricsEnabled | default false }}"
             - name: APPMONITORING_OPENTELEMETRYMETRICS_PORT
-              value: "{{ .Values.AzureMonitorMetrics.OpenTelemetryMetricsPort }}"
+              value: "{{ $.Values.AppmonitoringAgent.openTelemetryMetricsPort | default 28333 }}"
+          {{- if $.Values.AppmonitoringAgent.isOpenTelemetryMetricsEnabled | default false }}
+          ports:
+            - name: otlp-http-port
+              containerPort: 56681
+              hostPort: {{ $.Values.AppmonitoringAgent.openTelemetryMetricsPort | default 28333 }}
+              protocol: TCP
+            - name: otlp-grpc-port
+              containerPort: 56680
+              hostPort: 28334
+              protocol: TCP
+          {{- end }}
           securityContext:
             privileged: false
             capabilities:
@@ -414,11 +425,22 @@ spec:
             - name: MINIMAL_INGESTION_PROFILE
               value: "true" # only supported value is the string "true"
             - name: APPMONITORING_AUTOINSTRUMENTATION_ENABLED
-              value: "{{ .Values.AzureMonitorMetrics.IsAppMonitoringAutoInstrumentationEnabled }}"
+              value: "{{ .Values.AppmonitoringAgent.enabled }}"
             - name: APPMONITORING_OPENTELEMETRYMETRICS_ENABLED
-              value: "{{ .Values.AzureMonitorMetrics.IsAppMonitoringOpenTelemetryMetricsEnabled }}"
+              value: "{{ .Values.AppmonitoringAgent.isOpenTelemetryMetricsEnabled | default false }}"
             - name: APPMONITORING_OPENTELEMETRYMETRICS_PORT
-              value: "{{ .Values.AzureMonitorMetrics.OpenTelemetryMetricsPort }}"
+              value: "{{ .Values.AppmonitoringAgent.openTelemetryMetricsPort | default 28333 }}"
+          {{- if .Values.AppmonitoringAgent.isOpenTelemetryMetricsEnabled | default false }}
+          ports:
+            - name: otlp-http-port
+              containerPort: 56681
+              hostPort: {{ .Values.AppmonitoringAgent.openTelemetryMetricsPort | default 28333 }}
+              protocol: TCP
+            - name: otlp-grpc-port
+              containerPort: 56680
+              hostPort: 28334
+              protocol: TCP
+          {{- end }}
           securityContext:
             privileged: false
             capabilities:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -67,6 +67,11 @@ AzureMonitorMetrics:
   IsAppMonitoringAutoInstrumentationEnabled: false
   IsAppMonitoringOpenTelemetryMetricsEnabled: false
   OpenTelemetryMetricsPort: "28333"
+  AppmonitoringAgent:
+      enabled: false
+      isOpenTelemetryLogsEnabled: false
+      isOpenTelemetryMetricsEnabled: false
+      openTelemetryMetricsPort: 28333
   # The below 2 settings are not Azure Monitor Metrics adapter chart. They are substituted in a different manner.
   # Please update these with the latest ones from here so that you get the image that is currently deployed by the AKS RP -
   # Repository: https://msazure.visualstudio.com/CloudNativeCompute/_git/aks-rp?path=/ccp/charts/addon-charts/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml&version=GBrashmi/prom-addon-arm64&line=136&lineEnd=136&lineStartColumn=56&lineEndColumn=85&lineStyle=plain&_a=contents


### PR DESCRIPTION
- Chart needs to match AKS RP changes for the extension migration bug bash
- Both ports are there currently since those were the initial changes. I will remove grpc port for public preview with next addon release until we have in the API that that port is configurable
- The structure of the adapter chart for the values.yaml had been changed too, this now matches that