### PR TITLE
fix: KSM on Arc, CI/CD retina version, release prod cluster deployment

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -247,9 +247,10 @@ extends:
           inputs:
             helmVersionToInstall: 3.12.3
         - bash: |
-            RETINA_VERSION=$( curl -sL https://api.github.com/repos/microsoft/retina/releases/latest | jq -r .name)
+            # Get all releases and filter for proper semver versions (no pre-release tags)
+            RETINA_VERSION=$(curl -sL https://api.github.com/repos/microsoft/retina/releases | jq -r '[.[] | select(.name | ("^[0-9]+\\.[0-9]+\\.[0-9]+$") and (contains("-") | not))][0].name')
             echo "##vso[task.setvariable variable=RETINA_VERSION]$RETINA_VERSION"
-            echo $RETINA_VERSION
+            echo $RETINA_VERSION 
             helm pull oci://ghcr.io/microsoft/retina/charts/retina --version $RETINA_VERSION --untar --untardir $(Build.SourcesDirectory)/otelcollector/deploy/retina/chart
             mv $(Build.SourcesDirectory)/otelcollector/deploy/retina/custom-files/network-observability-service.yaml $(Build.SourcesDirectory)/otelcollector/deploy/retina/chart/retina/templates/
             echo "##vso[task.setvariable variable=RETINA_VERSION;isOutput=true]$RETINA_VERSION"

--- a/.pipelines/azure-pipeline-release.yml
+++ b/.pipelines/azure-pipeline-release.yml
@@ -94,7 +94,7 @@ extends:
                 onlyCCPRelease: "${{ lower(parameters.onlyCCPRelease) }}"
     - stage: Deploy_to_Prod_Clusters
       displayName: Deploy to Prod Clusters
-      dependsOn: Push_Images
+      trigger: none
       pool:
         name: Azure-Pipelines-CI-Test-EO
         image: ci-1es-managed-windows-2022
@@ -129,6 +129,8 @@ extends:
               done
               echo "Sleep completed."
         - task: HelmInstaller@1
+          inputs: 
+            helmVersionToInstall: 3.19.0  # Latest installs 4.0.0-alpha which has issues with some commands
           target:
             container: host
           displayName: Install Helm

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-deployment.yaml
@@ -140,9 +140,9 @@ spec:
           effect: NoExecute
         - operator: "Exists"
           effect: NoSchedule
+      {{- end }}
       volumes:
         - name: settings-vol-config
           configMap:
             name: ama-metrics-settings-configmap
             optional: true
-      {{- end }}


### PR DESCRIPTION
- Move the new optional settings config for KSM outside of the isArcExtension check so that it is also available for Arc. The install was failing on our CI/CD arc cluster
- Retina has added pre-release versions to their github that broke our CI/CD release handling. Get the latest excluding these versions that don't have the container image version available
- Fix some issues with the release deploying to the CI/CD prod clusters. We cannot automatically deploy after the image push task because that waits 24 hours for SDP

Added a task to add dry-run here: https://dev.azure.com/msazure/InfrastructureInsights/_sprints/taskboard/VMICIAndProm/InfrastructureInsights/Bromine/CY25Q3/Monthly/09%20Sep%20(Sep%2001%20-%20Sep%2030)?workitem=35049643