### PR TITLE
Update Prometheus Alert Rules names

### DIFF
--- a/GeneratedMonitoringArtifacts/Default/recommendedMetricAlerts.json
+++ b/GeneratedMonitoringArtifacts/Default/recommendedMetricAlerts.json
@@ -27,14 +27,14 @@
     },
     "variables": {
         "clusterName": "[last(split(parameters('clusterResourceId'), '/'))]",
-        "kubernetesAlertRuleGroup": "KubernetesAlert-RecommendedMetricAlerts",
-        "kubernetesAlertRuleGroupName": "[concat(variables('kubernetesAlertRuleGroup'), variables('clusterName'))]",
+        "kubernetesAlertRuleGroup": "Prometheus Recommended",
+        "kubernetesAlertRuleGroupName": "[concat(variables('kubernetesAlertRuleGroup'))]",
         "kubernetesAlertRuleGroupDescription": "Kubernetes Alert RuleGroup-RecommendedMetricAlerts",
         "version": " - 0.1"
     },
     "resources": [
         {
-            "name": "[concat(variables('kubernetesAlertRuleGroupName'), '-Cluster-level')]",
+            "name": "[concat(variables('kubernetesAlertRuleGroupName'), ' Cluster level Alerts - ', variables('clusterName'))]",
             "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
             "apiVersion": "2023-03-01",
             "location": "[parameters('location')]",
@@ -293,7 +293,7 @@
             }
         },
         {
-            "name": "[concat(variables('kubernetesAlertRuleGroupName'), '-Node-level')]",
+            "name": "[concat(variables('kubernetesAlertRuleGroupName'), ' Node level Alerts - ', variables('clusterName'))]",
             "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
             "apiVersion": "2023-03-01",
             "location": "[parameters('location')]",
@@ -376,7 +376,7 @@
             }
         },
         {
-            "name": "[concat(variables('kubernetesAlertRuleGroupName'), '-Pod-level')]",
+            "name": "[concat(variables('kubernetesAlertRuleGroupName'), ' Pod level Alerts - ', variables('clusterName'))]",
             "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
             "apiVersion": "2023-03-01",
             "location": "[parameters('location')]",


### PR DESCRIPTION
Update Prometheus Alert Rules names.

When enabled Prometheus recommended alert rules using ARM or Bicep template, the button to enable these alert rules still appearing.
<img width="916" height="497" alt="image" src="https://github.com/user-attachments/assets/44de5816-bcce-457e-b286-ebe7abfa702b" />

If we enable recommended alert rules using the ARM or Bicep template, the alert rules are created with name "_KubernetesAlert-RecommendedMetricAlerts****_", are not reflected in the UI and the button still appearing.

The button only disappear if we click in the button and the alerts are "Already created".
Also, the new alert rules are created with same rules but with different names.
<img width="497" height="128" alt="image" src="https://github.com/user-attachments/assets/3103ae4f-8726-4f4c-bb9d-c3aa074799a9" />
<img width="1639" height="441" alt="image" src="https://github.com/user-attachments/assets/cb5aad1e-52d0-4178-b999-05fcc53dc170" />

I did a change in the template and the issue is solved. The alert rules are created with the "acceptable names", is reflected in the UI and the button disappear.





