### PR TITLE
Add arc msi support for openshift clusters

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
@@ -186,6 +186,58 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 3
         {{- if $arcExtensionSettings.isArcExtension }}
+          {{- if (eq .Values.Azure.Cluster.Distribution "openshift") }}
+        - name: msi-adapter
+          env:
+          - name: AZMON_COLLECT_ENV
+            value: "false"
+          - name: TOKEN_NAMESPACE
+            value: azure-arc
+          - name: CLUSTER_IDENTITY
+            value: "false"
+          - name: CLUSTER_TYPE
+            value: {{ (split "/" .Values.Azure.Cluster.ResourceId)._7 }}
+          - name: EXTENSION_ARMID
+            value: {{ .Values.Azure.Extension.ResourceId }}
+          - name: EXTENSION_NAME
+            value: {{ .Values.Azure.Extension.Name }}
+          - name: MSI_ADAPTER_LISTENING_PORT
+            value: "8421"
+          - name: MANAGED_IDENTITY_AUTH
+            value: "true"
+          - name: MSI_ADAPTER_LIVENESS_PORT
+            value: "9090"
+          - name: TEST_MODE
+            value: "false"
+          - name: TEST_FILE
+            value: /data/token
+          image: mcr.microsoft.com/azurearck8s/msi-adapter:1.29.3
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 9090
+              scheme: "HTTP"
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 20m
+              memory: 50Mi
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/data/msi-adapter-ready-watcher"]
+          {{- else }}
         - name: arc-msi-adapter
           imagePullPolicy: IfNotPresent
           env:
@@ -194,6 +246,7 @@ spec:
           - name: LIVENESS_PROBE_PORT
             value: "9999"
           {{-  .Values.Azure.Identity.MSIAdapterYaml | nindent 10 }}
+          {{- end }}
         {{- else }}
         - name: addon-token-adapter
           command:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
@@ -243,6 +243,58 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 3
         {{- if $arcExtensionSettings.isArcExtension }}
+          {{- if (eq .Values.Azure.Cluster.Distribution "openshift") }}
+        - name: msi-adapter
+          env:
+          - name: AZMON_COLLECT_ENV
+            value: "false"
+          - name: TOKEN_NAMESPACE
+            value: azure-arc
+          - name: CLUSTER_IDENTITY
+            value: "false"
+          - name: CLUSTER_TYPE
+            value: {{ (split "/" .Values.Azure.Cluster.ResourceId)._7 }}
+          - name: EXTENSION_ARMID
+            value: {{ .Values.Azure.Extension.ResourceId }}
+          - name: EXTENSION_NAME
+            value: {{ .Values.Azure.Extension.Name }}
+          - name: MSI_ADAPTER_LISTENING_PORT
+            value: "8421"
+          - name: MANAGED_IDENTITY_AUTH
+            value: "true"
+          - name: MSI_ADAPTER_LIVENESS_PORT
+            value: "9090"
+          - name: TEST_MODE
+            value: "false"
+          - name: TEST_FILE
+            value: /data/token
+          image: mcr.microsoft.com/azurearck8s/msi-adapter:1.29.3
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 9090
+              scheme: "HTTP"
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 20m
+              memory: 50Mi
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/data/msi-adapter-ready-watcher"]
+          {{- else }}
         - name: arc-msi-adapter
           imagePullPolicy: IfNotPresent
           env:
@@ -251,6 +303,7 @@ spec:
           - name: LIVENESS_PROBE_PORT
             value: "9999"
           {{-  .Values.Azure.Identity.MSIAdapterYaml | nindent 10 }}
+          {{- end }}
         {{- else }}
         - name: addon-token-adapter
           command:
@@ -404,4 +457,3 @@ spec:
             secretName: ama-metrics-proxy-cert
             optional: true
         {{- end }}
-        

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-scc.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-scc.yaml
@@ -1,0 +1,27 @@
+{{- if eq .Values.Azure.Cluster.Distribution "openshift" }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: ama-metrics-scc
+allowPrivilegedContainer: true
+allowPrivilegeEscalation: true
+allowHostDirVolumePlugin: true
+allowedCapabilities:
+- NET_ADMIN
+- NET_RAW
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- hostPath
+- configMap
+- secret
+users:
+- system:serviceaccount:kube-system:ama-metrics-serviceaccount
+{{- end }}


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

Longw/arc openshift add support. For OpenShift clusters, the Kubernetes Security Context Constraints (SCC) block NET_ADMIN permissions by default on the msi-adapter. To work around this limitation, extensions need to mark the msi-adapter as privileged: true. 
And to get the latest token adapter image version, the extension config will also need to be modified with "extensionSystemParameters": {
  "ForceUpdateMsiAdapter": "true"
}

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
