### PR TITLE
Add Istio CNI and Ztunnel targets

### DIFF
--- a/otelcollector/configmapparser/default-prom-configs/istioCniDefault.yml
+++ b/otelcollector/configmapparser/default-prom-configs/istioCniDefault.yml
@@ -1,0 +1,27 @@
+scrape_configs:
+  - job_name: istio-cni
+    honor_labels: true
+    scrape_interval: $$SCRAPE_INTERVAL$$
+    scheme: http
+    label_limit: 63
+    label_name_length_limit: 511
+    label_value_length_limit: 1023
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - applink-system
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace]
+        action: keep
+        regex: applink-system
+      - source_labels: [__meta_kubernetes_pod_label_k8s_app]
+        action: keep
+        regex: istio-cni-node
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: metrics
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: instance
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: node

--- a/otelcollector/configmapparser/default-prom-configs/ztunnelDefault.yml
+++ b/otelcollector/configmapparser/default-prom-configs/ztunnelDefault.yml
@@ -1,0 +1,27 @@
+scrape_configs:
+  - job_name: ztunnel
+    honor_labels: true
+    scrape_interval: $$SCRAPE_INTERVAL$$
+    scheme: http
+    label_limit: 63
+    label_name_length_limit: 511
+    label_value_length_limit: 1023
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - applink-system
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace]
+        action: keep
+        regex: applink-system
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: ztunnel
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: ztunnel-stats
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: instance
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: node

--- a/otelcollector/configmaps/ama-metrics-settings-configmap-v1.yaml
+++ b/otelcollector/configmaps/ama-metrics-settings-configmap-v1.yaml
@@ -34,6 +34,8 @@ data:
     acstor-capacity-provisioner = true
     acstor-metrics-exporter = true
     local-csi-driver = true
+    ztunnel = false
+    istio-cni = false
   # Regex for which namespaces to scrape through pod annotation based scraping.
   # This is none by default.
   # Ex: Use 'namespace1|namespace2' to scrape the pods in the namespaces 'namespace1' and 'namespace2'.
@@ -63,6 +65,8 @@ data:
     acstor-capacity-provisioner = ""
     acstor-metrics-exporter = ""
     local-csi-driver = ""
+    ztunnel = ""
+    istio-cni = ""
     minimalingestionprofile = true
   default-targets-scrape-interval-settings: |-
     kubelet = "30s"
@@ -82,6 +86,8 @@ data:
     acstor-capacity-provisioner = "30s"
     acstor-metrics-exporter = "30s"
     local-csi-driver = "30s"
+    ztunnel = "30s"
+    istio-cni = "30s"
     podannotations = "30s"
   debug-mode: |-
     enabled = false

--- a/otelcollector/configmaps/ama-metrics-settings-configmap-v2.yaml
+++ b/otelcollector/configmaps/ama-metrics-settings-configmap-v2.yaml
@@ -25,6 +25,8 @@ data:
       acstor-capacity-provisioner = true
       acstor-metrics-exporter = true
       local-csi-driver = true
+      ztunnel = false
+      istio-cni = false
       prometheuscollectorhealth = false
     pod-annotation-based-scraping: |-
       podannotationnamespaceregex = ""
@@ -46,6 +48,8 @@ data:
       acstor-capacity-provisioner = ""
       acstor-metrics-exporter = ""
       local-csi-driver = ""
+      ztunnel = ""
+      istio-cni = ""
     minimal-ingestion-profile: |-
       enabled = true
     default-targets-scrape-interval-settings: |-
@@ -64,7 +68,9 @@ data:
       networkobservabilityCilium = "30s"
       acstor-capacity-provisioner = "30s"
       acstor-metrics-exporter = "30s"
-      local-csi-driver = "30s"
+      local-csi-driver = "30s"  
+      ztunnel = "30s"
+      istio-cni = "30s"
       prometheuscollectorhealth = "30s"
       podannotations = "30s"
   controlplane-metrics: |-

--- a/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
+++ b/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
@@ -34,6 +34,8 @@ data:
     acstor-capacity-provisioner = true
     acstor-metrics-exporter = true
     local-csi-driver = true
+    ztunnel = false
+    istio-cni = false
   # Regex for which namespaces to scrape through pod annotation based scraping.
   # This is none by default.
   # Ex: Use 'namespace1|namespace2' to scrape the pods in the namespaces 'namespace1' and 'namespace2'.
@@ -63,6 +65,8 @@ data:
     acstor-capacity-provisioner = ""
     acstor-metrics-exporter = ""
     local-csi-driver = ""
+    ztunnel = ""
+    istio-cni = ""
     minimalingestionprofile = true
   default-targets-scrape-interval-settings: |-
     kubelet = "30s"
@@ -82,6 +86,8 @@ data:
     acstor-capacity-provisioner = "30s"
     acstor-metrics-exporter = "30s"
     local-csi-driver = "30s"
+    ztunnel = "30s"
+    istio-cni = "30s"
     podannotations = "30s"
   debug-mode: |-
     enabled = false

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -74,6 +74,10 @@ var (
 	AcstorMetricsExporterKeepListRegex string
 	// Local CSI Driver  keep list regex
 	LocalCSIDriverKeepListRegex string
+	// Ztunnel metrics keep list regex
+	ZtunnelKeepListRegex string
+	// Istio CNI metrics keep list regex
+	IstioCniKeepListRegex string
 	// Network Observability Cilium metrics keep list regex
 	NetworkObservabilityCiliumKeepListRegex string
 	// Network Observability Hubble metrics keep list regex
@@ -111,6 +115,10 @@ var (
 	AcstorMetricsExporterScrapeInterval string
 	// Local CSI Driver  scrape interval
 	LocalCSIDriverScrapeInterval string
+	// Ztunnel scrape interval
+	ZtunnelScrapeInterval string
+	// Istio CNI scrape interval
+	IstioCniScrapeInterval string
 	// Network Observability Cilium metrics scrape interval
 	NetworkObservabilityCiliumScrapeInterval string
 	// Network Observability Hubble metrics scrape interval
@@ -366,6 +374,8 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 			AcstorCapacityProvisionerKeepListRegex = regexHash["ACSTORCAPACITYPROVISONER_KEEP_LIST_REGEX"]
 			AcstorMetricsExporterKeepListRegex = regexHash["ACSTORMETRICSEXPORTER_KEEP_LIST_REGEX"]
 			LocalCSIDriverKeepListRegex = regexHash["LOCALCSIDRIVER_KEEP_LIST_REGEX"]
+			ZtunnelKeepListRegex = regexHash["ZTUNNEL_METRICS_KEEP_LIST_REGEX"]
+			IstioCniKeepListRegex = regexHash["ISTIOCNI_METRICS_KEEP_LIST_REGEX"]
 			NetworkObservabilityCiliumKeepListRegex = regexHash["NETWORKOBSERVABILITYCILIUM_METRICS_KEEP_LIST_REGEX"]
 			NetworkObservabilityHubbleKeepListRegex = regexHash["NETWORKOBSERVABILITYHUBBLE_METRICS_KEEP_LIST_REGEX"]
 			NetworkObservabilityRetinaKeepListRegex = regexHash["NETWORKOBSERVABILITYRETINA_METRICS_KEEP_LIST_REGEX"]
@@ -398,6 +408,8 @@ func InitializeTelemetryClient(agentVersion string) (int, error) {
 			AcstorCapacityProvisionerScrapeInterval = intervalHash["ACSTORCAPACITYPROVISIONER_SCRAPE_INTERVAL"]
 			AcstorMetricsExporterScrapeInterval = intervalHash["ACSTORMETRICSEXPORTER_SCRAPE_INTERVAL"]
 			LocalCSIDriverScrapeInterval = intervalHash["LOCALCSIDRIVER_SCRAPE_INTERVAL"]
+			ZtunnelScrapeInterval = intervalHash["ZTUNNEL_SCRAPE_INTERVAL"]
+			IstioCniScrapeInterval = intervalHash["ISTIOCNI_SCRAPE_INTERVAL"]
 			NetworkObservabilityCiliumScrapeInterval = intervalHash["NETWORKOBSERVABILITYCILIUM_SCRAPE_INTERVAL"]
 			NetworkObservabilityHubbleScrapeInterval = intervalHash["NETWORKOBSERVABILITYHUBBLE_SCRAPE_INTERVAL"]
 			NetworkObservabilityRetinaScrapeInterval = intervalHash["NETWORKOBSERVABILITYRETINA_SCRAPE_INTERVAL"]
@@ -922,6 +934,12 @@ func PushMEProcessedAndReceivedCountToAppInsightsMetrics() {
 				if LocalCSIDriverKeepListRegex != "" {
 					metric.Properties["LocalCSIDriverExporterRegex"] = LocalCSIDriverKeepListRegex
 				}
+				if ZtunnelKeepListRegex != "" {
+					metric.Properties["ZtunnelKeepListRegex"] = ZtunnelKeepListRegex
+				}
+				if IstioCniKeepListRegex != "" {
+					metric.Properties["IstioCniKeepListRegex"] = IstioCniKeepListRegex
+				}
 				if NetworkObservabilityCiliumKeepListRegex != "" {
 					metric.Properties["NetworkObservabilityCiliumRegex"] = NetworkObservabilityCiliumKeepListRegex
 				}
@@ -973,6 +991,12 @@ func PushMEProcessedAndReceivedCountToAppInsightsMetrics() {
 				}
 				if AcstorMetricsExporterScrapeInterval != "" {
 					metric.Properties["AcstorMetricsExporterScrapeInterval"] = AcstorMetricsExporterScrapeInterval
+				}
+				if ZtunnelScrapeInterval != "" {
+					metric.Properties["ZtunnelScrapeInterval"] = ZtunnelScrapeInterval
+				}
+				if IstioCniScrapeInterval != "" {
+					metric.Properties["IstioCniScrapeInterval"] = IstioCniScrapeInterval
 				}
 				if NetworkObservabilityCiliumScrapeInterval != "" {
 					metric.Properties["NetworkObservabilityCiliumScrapeInterval"] = NetworkObservabilityCiliumScrapeInterval

--- a/otelcollector/shared/configmap/mp/definitions.go
+++ b/otelcollector/shared/configmap/mp/definitions.go
@@ -52,6 +52,8 @@ var (
 	acstorCapacityProvisionerDefaultFile         = "acstorCapacityProvisionerDefaultFile.yml"
 	acstorMetricsExporterDefaultFile             = "acstorMetricsExporterDefaultFile.yml"
 	LocalCSIDriverDefaultFile                    = "localCSIDriverDefaultFile.yml"
+	ztunnelDefaultFile                           = "ztunnelDefault.yml"
+	istioCniDefaultFile                          = "istioCniDefault.yml"
 )
 
 type RegexValues struct {
@@ -73,6 +75,8 @@ type RegexValues struct {
 	acstorcapacityprovisioner  string
 	acstormetricsexporter      string
 	localcsidriver             string
+	ztunnel                    string
+	istiocni                   string
 }
 
 // FilesystemConfigLoader implements ConfigLoader for file-based configuration loading.
@@ -115,6 +119,8 @@ type ConfigProcessor struct {
 	AcstorCapacityProvisioner  string
 	AcstorMetricsExporter      string
 	LocalCSIDriver             string
+	Ztunnel                    string
+	IstioCni                   string
 }
 
 // ConfigParser is an interface for parsing configurations.

--- a/otelcollector/shared/configmap/mp/prometheus-config-merger.go
+++ b/otelcollector/shared/configmap/mp/prometheus-config-merger.go
@@ -563,6 +563,54 @@ func populateDefaultPrometheusConfig() {
 		}
 	}
 
+	// Add ztunnel support
+	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_ZTUNNEL_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
+		ztunnelMetricsKeepListRegex, exists := regexHash["ZTUNNEL_METRICS_KEEP_LIST_REGEX"]
+		ztunnelScrapeInterval, intervalExists := intervalHash["ZTUNNEL_SCRAPE_INTERVAL"]
+		if currentControllerType == replicasetControllerType && strings.ToLower(os.Getenv("OS_TYPE")) == "linux" {
+			fullZtunnelPath := fmt.Sprintf("%s%s", defaultPromConfigPathPrefix, ztunnelDefaultFile)
+			if intervalExists {
+				UpdateScrapeIntervalConfig(fullZtunnelPath, ztunnelScrapeInterval)
+			}
+			if exists && ztunnelMetricsKeepListRegex != "" {
+				AppendMetricRelabelConfig(fullZtunnelPath, ztunnelMetricsKeepListRegex)
+			}
+			contents, err := os.ReadFile(fullZtunnelPath)
+			if err == nil {
+				contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_IP$$", os.Getenv("NODE_IP")))
+				contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_NAME$$", os.Getenv("NODE_NAME")))
+				err = os.WriteFile(fullZtunnelPath, contents, 0644)
+				if err == nil {
+					defaultConfigs = append(defaultConfigs, fullZtunnelPath)
+				}
+			}
+		}
+	}
+
+	// Add istio-cni support
+	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_ISTIOCNI_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
+		istiocniMetricsKeepListRegex, exists := regexHash["ISTIOCNI_METRICS_KEEP_LIST_REGEX"]
+		istiocniScrapeInterval, intervalExists := intervalHash["ISTIOCNI_SCRAPE_INTERVAL"]
+		if currentControllerType == replicasetControllerType && strings.ToLower(os.Getenv("OS_TYPE")) == "linux" {
+			fullIstioCniPath := fmt.Sprintf("%s%s", defaultPromConfigPathPrefix, istioCniDefaultFile)
+			if intervalExists {
+				UpdateScrapeIntervalConfig(fullIstioCniPath, istiocniScrapeInterval)
+			}
+			if exists && istiocniMetricsKeepListRegex != "" {
+				AppendMetricRelabelConfig(fullIstioCniPath, istiocniMetricsKeepListRegex)
+			}
+			contents, err := os.ReadFile(fullIstioCniPath)
+			if err == nil {
+				contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_IP$$", os.Getenv("NODE_IP")))
+				contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_NAME$$", os.Getenv("NODE_NAME")))
+				err = os.WriteFile(fullIstioCniPath, contents, 0644)
+				if err == nil {
+					defaultConfigs = append(defaultConfigs, fullIstioCniPath)
+				}
+			}
+		}
+	}
+
 	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_COLLECTOR_HEALTH_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
 		prometheusCollectorHealthInterval, intervalExists := intervalHash["PROMETHEUS_COLLECTOR_HEALTH_SCRAPE_INTERVAL"]
 		if intervalExists {
@@ -1034,6 +1082,54 @@ func populateDefaultPrometheusConfigWithOperator() {
 		}
 	}
 
+	// Add ztunnel support
+	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_ZTUNNEL_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
+		ztunnelMetricsKeepListRegex, exists := regexHash["ZTUNNEL_METRICS_KEEP_LIST_REGEX"]
+		ztunnelScrapeInterval, intervalExists := intervalHash["ZTUNNEL_SCRAPE_INTERVAL"]
+		if isConfigReaderSidecar() || (currentControllerType == replicasetControllerType && strings.ToLower(os.Getenv("OS_TYPE")) == "linux") {
+			fullZtunnelPath := fmt.Sprintf("%s%s", defaultPromConfigPathPrefix, ztunnelDefaultFile)
+			if intervalExists {
+				UpdateScrapeIntervalConfig(fullZtunnelPath, ztunnelScrapeInterval)
+			}
+			if exists && ztunnelMetricsKeepListRegex != "" {
+				AppendMetricRelabelConfig(fullZtunnelPath, ztunnelMetricsKeepListRegex)
+			}
+			contents, err := os.ReadFile(fullZtunnelPath)
+			if err == nil {
+				contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_IP$$", os.Getenv("NODE_IP")))
+				contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_NAME$$", os.Getenv("NODE_NAME")))
+				err = os.WriteFile(fullZtunnelPath, contents, 0644)
+				if err == nil {
+					defaultConfigs = append(defaultConfigs, fullZtunnelPath)
+				}
+			}
+		}
+	}
+
+	// Add istio-cni support
+	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_ISTIOCNI_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
+		istiocniMetricsKeepListRegex, exists := regexHash["ISTIOCNI_METRICS_KEEP_LIST_REGEX"]
+		istiocniScrapeInterval, intervalExists := intervalHash["ISTIOCNI_SCRAPE_INTERVAL"]
+		if isConfigReaderSidecar() || (currentControllerType == replicasetControllerType && strings.ToLower(os.Getenv("OS_TYPE")) == "linux") {
+			fullIstioCniPath := fmt.Sprintf("%s%s", defaultPromConfigPathPrefix, istioCniDefaultFile)
+			if intervalExists {
+				UpdateScrapeIntervalConfig(fullIstioCniPath, istiocniScrapeInterval)
+			}
+			if exists && istiocniMetricsKeepListRegex != "" {
+				AppendMetricRelabelConfig(fullIstioCniPath, istiocniMetricsKeepListRegex)
+			}
+			contents, err := os.ReadFile(fullIstioCniPath)
+			if err == nil {
+				contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_IP$$", os.Getenv("NODE_IP")))
+				contents = []byte(strings.ReplaceAll(string(contents), "$$NODE_NAME$$", os.Getenv("NODE_NAME")))
+				err = os.WriteFile(fullIstioCniPath, contents, 0644)
+				if err == nil {
+					defaultConfigs = append(defaultConfigs, fullIstioCniPath)
+				}
+			}
+		}
+	}
+
 	if enabled, exists := os.LookupEnv("AZMON_PROMETHEUS_COLLECTOR_HEALTH_SCRAPING_ENABLED"); exists && strings.ToLower(enabled) == "true" {
 		prometheusCollectorHealthInterval, intervalExists := intervalHash["PROMETHEUS_COLLECTOR_HEALTH_SCRAPE_INTERVAL"]
 		if intervalExists {
@@ -1454,5 +1550,4 @@ func prometheusConfigMerger(operatorEnabled bool) {
 		writeDefaultScrapeTargetsFile(operatorEnabled)
 		shared.EchoSectionDivider("End Processing - prometheusConfigMerger, Done Writing Default Prometheus Config")
 	}
-
 }

--- a/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
@@ -28,8 +28,8 @@ func (fcl *FilesystemConfigLoader) SetDefaultScrapeSettings() (map[string]string
 	config["acstor-capacity-provisioner"] = "true"
 	config["acstor-metrics-exporter"] = "true"
 	config["local-csi-driver"] = "true"
-	config["ztunnel"] = "true"
-	config["istiocni"] = "true"
+	config["ztunnel"] = "false"
+	config["istio-cni"] = "false"
 
 	return config, nil
 }
@@ -55,8 +55,8 @@ func (fcl *FilesystemConfigLoader) ParseConfigMapForDefaultScrapeSettings(metric
 	config["acstor-capacity-provisioner"] = "true"
 	config["acstor-metrics-exporter"] = "true"
 	config["local-csi-driver"] = "true"
-	config["ztunnel"] = "true"
-	config["istiocni"] = "true"
+	config["ztunnel"] = "false"
+	config["istio-cni"] = "false"
 
 	configSectionName := "default-scrape-settings-enabled"
 	if schemaVersion == "v2" {
@@ -166,9 +166,9 @@ func (cp *ConfigProcessor) PopulateSettingValues(parsedConfig map[string]string)
 		fmt.Printf("config:: Using scrape settings for ztunnel: %v\n", cp.Ztunnel)
 	}
 
-	if val, ok := parsedConfig["istiocni"]; ok && val != "" {
+	if val, ok := parsedConfig["istio-cni"]; ok && val != "" {
 		cp.IstioCni = val
-		fmt.Printf("config:: Using scrape settings for istiocni: %v\n", cp.IstioCni)
+		fmt.Printf("config:: Using scrape settings for istio-cni: %v\n", cp.IstioCni)
 	}
 
 	if os.Getenv("MODE") == "" && strings.ToLower(strings.TrimSpace(os.Getenv("MODE"))) == "advanced" {

--- a/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
@@ -28,6 +28,8 @@ func (fcl *FilesystemConfigLoader) SetDefaultScrapeSettings() (map[string]string
 	config["acstor-capacity-provisioner"] = "true"
 	config["acstor-metrics-exporter"] = "true"
 	config["local-csi-driver"] = "true"
+	config["ztunnel"] = "true"
+	config["istiocni"] = "true"
 
 	return config, nil
 }
@@ -53,6 +55,8 @@ func (fcl *FilesystemConfigLoader) ParseConfigMapForDefaultScrapeSettings(metric
 	config["acstor-capacity-provisioner"] = "true"
 	config["acstor-metrics-exporter"] = "true"
 	config["local-csi-driver"] = "true"
+	config["ztunnel"] = "true"
+	config["istiocni"] = "true"
 
 	configSectionName := "default-scrape-settings-enabled"
 	if schemaVersion == "v2" {
@@ -157,6 +161,16 @@ func (cp *ConfigProcessor) PopulateSettingValues(parsedConfig map[string]string)
 		fmt.Printf("config:: Using scrape settings for local-csi-driver: %v\n", cp.LocalCSIDriver)
 	}
 
+	if val, ok := parsedConfig["ztunnel"]; ok && val != "" {
+		cp.Ztunnel = val
+		fmt.Printf("config:: Using scrape settings for ztunnel: %v\n", cp.Ztunnel)
+	}
+
+	if val, ok := parsedConfig["istiocni"]; ok && val != "" {
+		cp.IstioCni = val
+		fmt.Printf("config:: Using scrape settings for istiocni: %v\n", cp.IstioCni)
+	}
+
 	if os.Getenv("MODE") == "" && strings.ToLower(strings.TrimSpace(os.Getenv("MODE"))) == "advanced" {
 		controllerType := os.Getenv("CONTROLLER_TYPE")
 		if controllerType == "ReplicaSet" && strings.ToLower(os.Getenv("OS_TYPE")) == "linux" &&
@@ -199,6 +213,8 @@ func (fcw *FileConfigWriter) WriteDefaultScrapeSettingsToFile(filename string, c
 	file.WriteString(fmt.Sprintf("AZMON_PROMETHEUS_ACSTORCAPACITYPROVISIONER_SCRAPING_ENABLED=%v\n", cp.AcstorCapacityProvisioner))
 	file.WriteString(fmt.Sprintf("AZMON_PROMETHEUS_ACSTORMETRICSEXPORTER_SCRAPING_ENABLED=%v\n", cp.AcstorMetricsExporter))
 	file.WriteString(fmt.Sprintf("AZMON_PROMETHEUS_LOCALCSIDRIVER_SCRAPING_ENABLED=%v\n", cp.LocalCSIDriver))
+	file.WriteString(fmt.Sprintf("AZMON_PROMETHEUS_ZTUNNEL_SCRAPING_ENABLED=%v\n", cp.Ztunnel))
+	file.WriteString(fmt.Sprintf("AZMON_PROMETHEUS_ISTIOCNI_SCRAPING_ENABLED=%v\n", cp.IstioCni))
 
 	return nil
 }

--- a/otelcollector/shared/configmap/mp/tomlparser-default-targets-metrics-keep-list.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-default-targets-metrics-keep-list.go
@@ -19,6 +19,7 @@ var (
 	networkobservabilityCiliumRegex, podAnnotationsRegex                string
 	acstorCapacityProvisionerRegex, acstorMetricsExporterRegex          string
 	localCSIDriverRegex                                                 string
+	ztunnelRegex, istioCniRegex                                         string
 	kubeletRegex_minimal_mac                                            = "kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_node_name|kubelet_running_pods|kubelet_running_pod_count|kubelet_running_sum_containers|kubelet_running_containers|kubelet_running_container_count|volume_manager_total_volumes|kubelet_node_config_error|kubelet_runtime_operations_total|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_duration_seconds_bucket|kubelet_runtime_operations_duration_seconds_sum|kubelet_runtime_operations_duration_seconds_count|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_sum|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_sum|kubelet_pod_worker_duration_seconds_count|storage_operation_duration_seconds_bucket|storage_operation_duration_seconds_sum|storage_operation_duration_seconds_count|storage_operation_errors_total|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_sum|kubelet_cgroup_manager_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pleg_relist_interval_seconds_count|kubelet_pleg_relist_interval_seconds_sum|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_duration_seconds_sum|rest_client_requests_total|rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count|process_resident_memory_bytes|process_cpu_seconds_total|go_goroutines|kubernetes_build_info|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_server_expiration_renew_errors|kubelet_certificate_manager_server_ttl_seconds|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_inodes|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_labels|kube_persistentvolume_status_phase"
 	coreDNSRegex_minimal_mac                                            = "coredns_build_info|coredns_panics_total|coredns_dns_responses_total|coredns_forward_responses_total|coredns_dns_request_duration_seconds|coredns_dns_request_duration_seconds_bucket|coredns_dns_request_duration_seconds_sum|coredns_dns_request_duration_seconds_count|coredns_forward_request_duration_seconds|coredns_forward_request_duration_seconds_bucket|coredns_forward_request_duration_seconds_sum|coredns_forward_request_duration_seconds_count|coredns_dns_requests_total|coredns_forward_requests_total|coredns_cache_hits_total|coredns_cache_misses_total|coredns_cache_entries|coredns_plugin_enabled|coredns_dns_request_size_bytes|coredns_dns_request_size_bytes_bucket|coredns_dns_request_size_bytes_sum|coredns_dns_request_size_bytes_count|coredns_dns_response_size_bytes|coredns_dns_response_size_bytes_bucket|coredns_dns_response_size_bytes_sum|coredns_dns_response_size_bytes_count|coredns_dns_response_size_bytes_bucket|coredns_dns_response_size_bytes_sum|coredns_dns_response_size_bytes_count|process_resident_memory_bytes|process_cpu_seconds_total|go_goroutines|kubernetes_build_info"
 	cadvisorRegex_minimal_mac                                           = "container_spec_cpu_quota|container_spec_cpu_period|container_memory_rss|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_network_receive_packets_total|container_network_transmit_packets_total|container_network_receive_packets_dropped_total|container_network_transmit_packets_dropped_total|container_fs_reads_total|container_fs_writes_total|container_fs_reads_bytes_total|container_fs_writes_bytes_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_memory_cache|container_memory_swap|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_periods_total|container_memory_rss|kubernetes_build_info|container_start_time_seconds"
@@ -37,6 +38,8 @@ var (
 	//These metrics are somewhere getting transformed from rpc_server.duration_milliseconds_bucket to rpc.server.duration_milliseconds_bucket.
 	// It's not clear where this is happening, so we are keeping both regexes for now. Once we find the root cause, we can remove one of them.
 	localCsiDriver_minimal_mac = "rpc.server.duration_milliseconds_bucket|rpc.server.duration_milliseconds_sum|rpc.server.duration_milliseconds_count|rpc_server_duration_milliseconds_bucket|rpc_server_duration_milliseconds_sum|rpc_server_duration_milliseconds_count"
+	ztunnel_minimal_mac        = "istio_build|istio_xds_.*|istio_tcp_.*|istio_on_demand_dns|istio_dns_.*|workload_manager_.*"
+	istioCni_minimal_mac       = "istio_cni_install_ready|istio_cni_installs_total|nodeagent_reconcile_events_total|ztunnel_connected"
 )
 
 // getStringValue checks the type of the value and returns it as a string if possible.
@@ -119,6 +122,8 @@ func populateKeepList(metricsConfigBySection map[string]map[string]string) (Rege
 		acstorcapacityprovisioner:  getStringValue(keeplist["acstor-capacity-provisioner"]),
 		acstormetricsexporter:      getStringValue(keeplist["acstor-metrics-exporter"]),
 		localcsidriver:             getStringValue(keeplist["local-csi-driver"]),
+		ztunnel:                    getStringValue(keeplist["ztunnel"]),
+		istiocni:                   getStringValue(keeplist["istiocni"]),
 		minimalingestionprofile:    minimalingestionprofile_value,
 	}
 
@@ -151,6 +156,8 @@ func validateRegexValues(regexValues RegexValues) error {
 		"acstor-capacity-provisioner": regexValues.acstorcapacityprovisioner,
 		"acstor-metrics-exporter":     regexValues.acstormetricsexporter,
 		"local-csi-driver":            regexValues.localcsidriver,
+		"ztunnel":                     regexValues.ztunnel,
+		"istiocni":                    regexValues.istiocni,
 	}
 
 	// Iterate over the fields and validate each regex
@@ -182,6 +189,8 @@ func populateRegexValuesWithMinimalIngestionProfile(regexValues RegexValues) {
 		acstorCapacityProvisionerRegex = fmt.Sprintf("%s|%s", regexValues.acstorcapacityprovisioner, acstorCapacityProvisionerRegex_minimal_mac)
 		acstorMetricsExporterRegex = fmt.Sprintf("%s|%s", regexValues.acstormetricsexporter, acstorMetricsExporter_minimal_mac)
 		localCSIDriverRegex = fmt.Sprintf("%s|%s", regexValues.localcsidriver, localCsiDriver_minimal_mac)
+		ztunnelRegex = fmt.Sprintf("%s|%s", regexValues.ztunnel, ztunnel_minimal_mac)
+		istioCniRegex = fmt.Sprintf("%s|%s", regexValues.istiocni, istioCni_minimal_mac)
 
 	} else {
 		fmt.Println("minimalIngestionProfile:", regexValues.minimalingestionprofile)
@@ -203,6 +212,8 @@ func populateRegexValuesWithMinimalIngestionProfile(regexValues RegexValues) {
 		acstorCapacityProvisionerRegex = regexValues.acstorcapacityprovisioner
 		acstorMetricsExporterRegex = regexValues.acstormetricsexporter
 		localCSIDriverRegex = regexValues.localcsidriver
+		ztunnelRegex = regexValues.ztunnel
+		istioCniRegex = regexValues.istiocni
 	}
 }
 
@@ -238,6 +249,8 @@ func tomlparserTargetsMetricsKeepList(metricsConfigBySection map[string]map[stri
 		"ACSTORCAPACITYPROVISONER_KEEP_LIST_REGEX":           acstorCapacityProvisionerRegex,
 		"ACSTORMETRICSEXPORTER_KEEP_LIST_REGEX":              acstorMetricsExporterRegex,
 		"LOCALCSIDRIVER_KEEP_LIST_REGEX":                     localCSIDriverRegex,
+		"ZTUNNEL_METRICS_KEEP_LIST_REGEX":                    ztunnelRegex,
+		"ISTIOCNI_METRICS_KEEP_LIST_REGEX":                   istioCniRegex,
 	}
 
 	out, err := yaml.Marshal(data)

--- a/otelcollector/shared/configmap/mp/tomlparser-default-targets-metrics-keep-list.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-default-targets-metrics-keep-list.go
@@ -123,7 +123,7 @@ func populateKeepList(metricsConfigBySection map[string]map[string]string) (Rege
 		acstormetricsexporter:      getStringValue(keeplist["acstor-metrics-exporter"]),
 		localcsidriver:             getStringValue(keeplist["local-csi-driver"]),
 		ztunnel:                    getStringValue(keeplist["ztunnel"]),
-		istiocni:                   getStringValue(keeplist["istiocni"]),
+		istiocni:                   getStringValue(keeplist["istio-cni"]),
 		minimalingestionprofile:    minimalingestionprofile_value,
 	}
 
@@ -157,7 +157,7 @@ func validateRegexValues(regexValues RegexValues) error {
 		"acstor-metrics-exporter":     regexValues.acstormetricsexporter,
 		"local-csi-driver":            regexValues.localcsidriver,
 		"ztunnel":                     regexValues.ztunnel,
-		"istiocni":                    regexValues.istiocni,
+		"istio-cni":                   regexValues.istiocni,
 	}
 
 	// Iterate over the fields and validate each regex

--- a/otelcollector/shared/configmap/mp/tomlparser-scrape-interval.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-scrape-interval.go
@@ -60,7 +60,7 @@ func processConfigMap(metricsConfigBySection map[string]map[string]string) map[s
 		intervalHash["ACSTORMETRICSEXPORTER_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "acstor-metrics-exporter")
 		intervalHash["LOCALCSIDRIVER_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "local-csi-driver")
 		intervalHash["ZTUNNEL_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "ztunnel")
-		intervalHash["ISTIOCNI_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "istiocni")
+		intervalHash["ISTIOCNI_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "istio-cni")
 
 		return intervalHash
 	}

--- a/otelcollector/shared/configmap/mp/tomlparser-scrape-interval.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-scrape-interval.go
@@ -59,6 +59,8 @@ func processConfigMap(metricsConfigBySection map[string]map[string]string) map[s
 		intervalHash["ACSTORCAPACITYPROVISIONER_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "acstor-capacity-provisioner")
 		intervalHash["ACSTORMETRICSEXPORTER_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "acstor-metrics-exporter")
 		intervalHash["LOCALCSIDRIVER_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "local-csi-driver")
+		intervalHash["ZTUNNEL_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "ztunnel")
+		intervalHash["ISTIOCNI_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "istiocni")
 
 		return intervalHash
 	}
@@ -74,6 +76,7 @@ func processConfigMap(metricsConfigBySection map[string]map[string]string) map[s
 		"NETWORKOBSERVABILITYRETINA_SCRAPE_INTERVAL", "NETWORKOBSERVABILITYHUBBLE_SCRAPE_INTERVAL",
 		"NETWORKOBSERVABILITYCILIUM_SCRAPE_INTERVAL", "ACSTORCAPACITYPROVISIONER_SCRAPE_INTERVAL",
 		"ACSTORMETRICSEXPORTER_SCRAPE_INTERVAL", "LOCALCSIDRIVER_SCRAPE_INTERVAL",
+		"ZTUNNEL_SCRAPE_INTERVAL", "ISTIOCNI_SCRAPE_INTERVAL",
 	}
 
 	for _, key := range keys {

--- a/otelcollector/test/test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-all-targets-disabled.yaml
+++ b/otelcollector/test/test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-all-targets-disabled.yaml
@@ -23,6 +23,8 @@ data:
     networkobservabilityRetina = false
     networkobservabilityHubble = false
     networkobservabilityCilium = false
+    ztunnel = false
+    istio-cni = false
     prometheuscollectorhealth = false
     controlplane-apiserver = false
     controlplane-cluster-autoscaler = false
@@ -52,6 +54,8 @@ data:
     networkobservabilityRetina = ""
     networkobservabilityHubble = ""
     networkobservabilityCilium = ""
+    ztunnel = ""
+    istio-cni = ""
     controlplane-apiserver = ""
     controlplane-cluster-autoscaler = ""
     controlplane-node-auto-provisioning = ""
@@ -75,6 +79,8 @@ data:
     networkobservabilityRetina = "30s"
     networkobservabilityHubble = "30s"
     networkobservabilityCilium = "30s"
+    ztunnel = "30s"
+    istio-cni = "30s"
     prometheuscollectorhealth = "30s"
     acstor-capacity-provisioner = "30s"
     acstor-metrics-exporter = "30s"

--- a/otelcollector/test/test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-all-targets-enabled.yaml
+++ b/otelcollector/test/test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-all-targets-enabled.yaml
@@ -32,6 +32,8 @@ data:
     controlplane-etcd = true
     acstor-capacity-provisioner = true
     acstor-metrics-exporter = true
+    ztunnel = true
+    istio-cni = true
   # Regex for which namespaces to scrape through pod annotation based scraping.
   # This is none by default.
   # Ex: Use 'namespace1|namespace2' to scrape the pods in the namespaces 'namespace1' and 'namespace2'.
@@ -52,6 +54,8 @@ data:
     networkobservabilityRetina = ""
     networkobservabilityHubble = ""
     networkobservabilityCilium = ""
+    ztunnel = ""
+    istio-cni = ""
     controlplane-apiserver = ""
     controlplane-cluster-autoscaler = ""
     controlplane-node-auto-provisioning = ""
@@ -75,6 +79,8 @@ data:
     networkobservabilityRetina = "30s"
     networkobservabilityHubble = "30s"
     networkobservabilityCilium = "30s"
+    ztunnel = "30s"
+    istio-cni = "30s"
     prometheuscollectorhealth = "30s"
     acstor-capacity-provisioner = "30s"
     acstor-metrics-exporter = "30s"

--- a/otelcollector/test/test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-defaults-targets-turned-on.yaml
+++ b/otelcollector/test/test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-defaults-targets-turned-on.yaml
@@ -23,6 +23,8 @@ data:
     networkobservabilityRetina = true
     networkobservabilityHubble = true
     networkobservabilityCilium = true
+    ztunnel = false
+    istio-cni = false
     prometheuscollectorhealth = false
     controlplane-apiserver = true
     controlplane-cluster-autoscaler = false
@@ -52,6 +54,8 @@ data:
     networkobservabilityRetina = ""
     networkobservabilityHubble = ""
     networkobservabilityCilium = ""
+    ztunnel = ""
+    istio-cni = ""
     controlplane-apiserver = ""
     controlplane-cluster-autoscaler = ""
     controlplane-node-auto-provisioning = ""
@@ -75,6 +79,8 @@ data:
     networkobservabilityRetina = "30s"
     networkobservabilityHubble = "30s"
     networkobservabilityCilium = "30s"
+    ztunnel = "30s"
+    istio-cni = "30s"
     prometheuscollectorhealth = "30s"
     acstor-capacity-provisioner = "30s"
     acstor-metrics-exporter = "30s"


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

onboard applink scrape targets to prometheus-collector.

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
