### PR TITLE
Update FullAzureMonitorMetricsProfile.bicep

### DIFF
--- a/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
+++ b/AddonBicepTemplate/FullAzureMonitorMetricsProfile.bicep
@@ -617,7 +617,7 @@ resource uxRecordingRulesRuleGroupWinObj 'Microsoft.AlertsManagement/prometheusR
     rules: [
       {
             record: 'ux:pod_cpu_usage_windows:sum_irate'
-            expression: '''sum by (cluster, pod, namespace, node, created_by_kind, created_by_name, microsoft_resourceid) ((max by (instance, container_id, cluster, microsoft_resourceid) (irate(windows_container_cpu_usage_seconds_total{ container_id != \"\", job = \"windows-exporter\"}[5m])) * on (container_id, cluster, microsoft_resourceid) group_left (container, pod, namespace) (max by (container, container_id, pod, namespace, cluster, microsoft_resourceid) (kube_pod_container_info{container != \"\", pod != \"\", container_id != \"\", job = \"kube-state-metrics\"}))) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)(max by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (  kube_pod_info{ pod != \"\", job = \"kube-state-metrics\"})))'''
+            expression: '''sum by (cluster, pod, namespace, node, created_by_kind, created_by_name, microsoft_resourceid) ((max by (instance, container_id, cluster, microsoft_resourceid) (irate(windows_container_cpu_usage_seconds_total{ container_id != "", job = "windows-exporter"}[5m])) * on (container_id, cluster, microsoft_resourceid) group_left (container, pod, namespace) (max by (container, container_id, pod, namespace, cluster, microsoft_resourceid) (kube_pod_container_info{container != "", pod != "", container_id != "", job = "kube-state-metrics"}))) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)(max by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (  kube_pod_info{ pod != "", job = "kube-state-metrics"})))'''
           }
           {
             record: 'ux:controller_cpu_usage_windows:sum_irate'
@@ -625,7 +625,7 @@ resource uxRecordingRulesRuleGroupWinObj 'Microsoft.AlertsManagement/prometheusR
           }
           {
             record: 'ux:pod_workingset_memory_windows:sum'
-            expression: '''sum by (cluster, pod, namespace, node, created_by_kind, created_by_name, microsoft_resourceid) ((max by (instance, container_id, cluster, microsoft_resourceid) (windows_container_memory_usage_private_working_set_bytes{ container_id != \"\", job = \"windows-exporter\"}) * on (container_id, cluster, microsoft_resourceid) group_left (container, pod, namespace) (max by (container, container_id, pod, namespace, cluster, microsoft_resourceid) (kube_pod_container_info{container != \"\", pod != \"\", container_id != \"\", job = \"kube-state-metrics\"}))) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)(max by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (  kube_pod_info{ pod != \"\", job = \"kube-state-metrics\"})))'''
+            expression: '''sum by (cluster, pod, namespace, node, created_by_kind, created_by_name, microsoft_resourceid) ((max by (instance, container_id, cluster, microsoft_resourceid) (windows_container_memory_usage_private_working_set_bytes{ container_id != "", job = "windows-exporter"}) * on (container_id, cluster, microsoft_resourceid) group_left (container, pod, namespace) (max by (container, container_id, pod, namespace, cluster, microsoft_resourceid) (kube_pod_container_info{container != "", pod != "", container_id != "", job = "kube-state-metrics"}))) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)(max by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (  kube_pod_info{ pod != "", job = "kube-state-metrics"})))'''
           }
           {
             record: 'ux:controller_workingset_memory_windows:sum'
@@ -633,19 +633,19 @@ resource uxRecordingRulesRuleGroupWinObj 'Microsoft.AlertsManagement/prometheusR
           }
           {
             record: 'ux:node_cpu_usage_windows:sum_irate'
-            expression: '''sum by (instance, cluster, microsoft_resourceid) ((1 - irate(windows_cpu_time_total{job=\"windows-exporter\", mode=\"idle\"}[5m])))'''
+            expression: '''sum by (instance, cluster, microsoft_resourceid) ((1 - irate(windows_cpu_time_total{job="windows-exporter", mode="idle"}[5m])))'''
           }
           {
             record: 'ux:node_memory_usage_windows:sum'
-            expression: '''sum by (instance, cluster, microsoft_resourceid) ((windows_os_visible_memory_bytes{job = \"windows-exporter\"}- windows_memory_available_bytes{job = \"windows-exporter\"}))'''
+            expression: '''sum by (instance, cluster, microsoft_resourceid) ((windows_os_visible_memory_bytes{job = "windows-exporter"}- windows_memory_available_bytes{job = "windows-exporter"}))'''
           }
           {
             record: 'ux:node_network_packets_received_drop_total_windows:sum_irate'
-            expression: '''sum by (instance, cluster, microsoft_resourceid) (irate(windows_net_packets_received_discarded_total{job=\"windows-exporter\", device!=\"lo\"}[5m]))'''
+            expression: '''sum by (instance, cluster, microsoft_resourceid) (irate(windows_net_packets_received_discarded_total{job="windows-exporter", device!="lo"}[5m]))'''
           }
           {
             record: 'ux:node_network_packets_outbound_drop_total_windows:sum_irate'
-            expression: '''sum by (instance, cluster, microsoft_resourceid) (irate(windows_net_packets_outbound_discarded_total{job=\"windows-exporter\", device!=\"lo\"}[5m]))'''
+            expression: '''sum by (instance, cluster, microsoft_resourceid) (irate(windows_net_packets_outbound_discarded_total{job="windows-exporter", device!="lo"}[5m]))'''
           }
     ]
   }


### PR DESCRIPTION
The file contains syntax errors and invalid bicep.

I have fixed the issues without changing the logic of the file.

[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
