### PR TITLE
feat: Add DCGM exporter support for GPU metrics collection

### DIFF
--- a/otelcollector/configmapparser/default-prom-configs/dcgmExporterDefaultDs.yml
+++ b/otelcollector/configmapparser/default-prom-configs/dcgmExporterDefaultDs.yml
@@ -1,0 +1,20 @@
+scrape_configs:
+- job_name: dcgm-exporter
+  scheme: http
+  metrics_path: /metrics
+  scrape_interval: $$SCRAPE_INTERVAL$$
+  label_limit: 63
+  label_name_length_limit: 511
+  label_value_length_limit: 1023
+  kubernetes_sd_configs:
+  - role: node
+  relabel_configs:
+  # Only scrape nodes with label kubernetes.azure.com/dcgm-exporter=enabled
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_azure_com_dcgm_exporter]
+    regex: enabled
+    action: keep
+  - source_labels: [__address__]
+    replacement: '$$NODE_NAME$$'
+    target_label: instance
+  static_configs:
+  - targets: ['$$NODE_IP$$:$$DCGM_EXPORTER_TARGETPORT$$']

--- a/otelcollector/configmaps/ama-metrics-settings-configmap-v1.yaml
+++ b/otelcollector/configmaps/ama-metrics-settings-configmap-v1.yaml
@@ -37,6 +37,7 @@ data:
     ztunnel = false
     istio-cni = false
     waypoint-proxy = false
+    dcgmexporter = false
   # Regex for which namespaces to scrape through pod annotation based scraping.
   # This is none by default.
   # Ex: Use 'namespace1|namespace2' to scrape the pods in the namespaces 'namespace1' and 'namespace2'.
@@ -69,6 +70,7 @@ data:
     ztunnel = ""
     istio-cni = ""
     waypoint-proxy = ""
+    dcgmexporter = ""
     minimalingestionprofile = true
   default-targets-scrape-interval-settings: |-
     kubelet = "30s"
@@ -91,6 +93,7 @@ data:
     ztunnel = "30s"
     istio-cni = "30s"
     waypoint-proxy = "30s"
+    dcgmexporter = "30s"
     podannotations = "30s"
   debug-mode: |-
     enabled = false

--- a/otelcollector/configmaps/ama-metrics-settings-configmap-v2.yaml
+++ b/otelcollector/configmaps/ama-metrics-settings-configmap-v2.yaml
@@ -28,6 +28,7 @@ data:
       ztunnel = false
       istio-cni = false
       waypoint-proxy = false
+      dcgmexporter = false
       prometheuscollectorhealth = false
     pod-annotation-based-scraping: |-
       podannotationnamespaceregex = ""
@@ -52,6 +53,7 @@ data:
       ztunnel = ""
       istio-cni = ""
       waypoint-proxy = ""
+      dcgmexporter = ""
     minimal-ingestion-profile: |-
       enabled = true
     default-targets-scrape-interval-settings: |-
@@ -74,6 +76,7 @@ data:
       ztunnel = "30s"
       istio-cni = "30s"
       waypoint-proxy = "30s"
+      dcgmexporter = "30s"
       prometheuscollectorhealth = "30s"
       podannotations = "30s"
   controlplane-metrics: |-

--- a/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
+++ b/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
@@ -37,6 +37,7 @@ data:
     ztunnel = false
     istio-cni = false
     waypoint-proxy = false
+    dcgmexporter = false
   # Regex for which namespaces to scrape through pod annotation based scraping.
   # This is none by default.
   # Ex: Use 'namespace1|namespace2' to scrape the pods in the namespaces 'namespace1' and 'namespace2'.
@@ -69,6 +70,7 @@ data:
     ztunnel = ""
     istio-cni = ""
     waypoint-proxy = ""
+    dcgmexporter = ""
     minimalingestionprofile = true
   default-targets-scrape-interval-settings: |-
     kubelet = "30s"
@@ -91,6 +93,7 @@ data:
     ztunnel = "30s"
     istio-cni = "30s"
     waypoint-proxy = "30s"
+    dcgmexporter = "30s"
     podannotations = "30s"
   debug-mode: |-
     enabled = false

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
@@ -142,6 +142,8 @@ spec:
               {{- else }}
               value: "19100"
               {{- end }}
+            - name: DCGM_EXPORTER_TARGETPORT
+              value: "19400"
               {{- if $.Values.AzureMonitorMetrics }}
               {{- if $.Values.AzureMonitorMetrics.KubeStateMetrics }}
             - name: KUBE_STATE_VERSION

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-deployment.yaml
@@ -147,6 +147,8 @@ spec:
               {{- else }}
               value: "19100"
               {{- end }}
+            - name: DCGM_EXPORTER_TARGETPORT
+              value: "19400"
             {{- if .Values.AzureMonitorMetrics }}
               {{- if .Values.AzureMonitorMetrics.KubeStateMetrics }}
             - name: KUBE_STATE_VERSION

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-targetallocator.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-targetallocator.yaml
@@ -152,6 +152,8 @@ spec:
           {{- else }}
           value: "19100"
           {{- end }}
+        - name: DCGM_EXPORTER_TARGETPORT
+          value: "19400"
         - name: customEnvironment
           {{- if .Values.AzureMonitorMetrics.isArcACluster }}
           value: "arcautonomous"

--- a/otelcollector/deploy/addon-chart/ccp-metrics-plugin/templates/ama-metrics-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/ccp-metrics-plugin/templates/ama-metrics-deployment.yaml
@@ -84,6 +84,8 @@ spec:
               value: "" # Replace this with the node exporter shipped out of box with AKS
             - name: NODE_EXPORTER_TARGETPORT
               value: "19100"
+            - name: DCGM_EXPORTER_TARGETPORT
+              value: "19400"
             - name: NODE_EXPORTER_VERSION
               value: "v1.5.0" # Replace this with the version shipped by default
             - name: AGENT_VERSION

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-daemonset.yaml
@@ -111,6 +111,8 @@ spec:
               value: {{ include "prometheus-collector.nodeexporterfullname" . }}
             - name: NODE_EXPORTER_TARGETPORT
               value: "{{ index .Values "prometheus-node-exporter" "service" "targetPort" }}"
+            - name: DCGM_EXPORTER_TARGETPORT
+              value: "19400"
             - name: KUBE_STATE_VERSION
               value: "{{ index .Values "kube-state-metrics" "image" "repository" }}:{{ index .Values "kube-state-metrics" "image" "tag" }}"
             - name: NODE_EXPORTER_VERSION

--- a/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
+++ b/otelcollector/deploy/chart/prometheus-collector/templates/prometheus-collector-deployment.yaml
@@ -107,6 +107,8 @@ spec:
               value: {{ include "prometheus-collector.nodeexporterfullname" . }}
             - name: NODE_EXPORTER_TARGETPORT
               value: "{{ index .Values "prometheus-node-exporter" "service" "targetPort" }}"
+            - name: DCGM_EXPORTER_TARGETPORT
+              value: "19400"
             - name: KUBE_STATE_VERSION
               value: "{{ index .Values "kube-state-metrics" "image" "repository" }}:{{ index .Values "kube-state-metrics" "image" "tag" }}"
             - name: KUBE_STATE_METRIC_LABELS_ALLOWLIST

--- a/otelcollector/shared/configmap/mp/definitions.go
+++ b/otelcollector/shared/configmap/mp/definitions.go
@@ -55,6 +55,7 @@ var (
 	ztunnelDefaultFile                           = "ztunnelDefault.yml"
 	istioCniDefaultFile                          = "istioCniDefault.yml"
 	waypointProxyDefaultFile                     = "waypointProxyDefault.yml"
+	dcgmExporterDefaultFileDs                    = "dcgmExporterDefaultDs.yml"
 )
 
 type RegexValues struct {
@@ -79,6 +80,7 @@ type RegexValues struct {
 	ztunnel                    string
 	istiocni                   string
 	waypoint                   string
+	dcgmexporter               string
 }
 
 // FilesystemConfigLoader implements ConfigLoader for file-based configuration loading.
@@ -124,6 +126,7 @@ type ConfigProcessor struct {
 	Ztunnel                    string
 	IstioCni                   string
 	WaypointProxy              string
+	DcgmExporter               string
 }
 
 // ConfigParser is an interface for parsing configurations.

--- a/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-default-scrape-settings.go
@@ -32,6 +32,7 @@ func (fcl *FilesystemConfigLoader) SetDefaultScrapeSettings() (map[string]string
 	config["ztunnel"] = "false"
 	config["istio-cni"] = "false"
 	config["waypoint-proxy"] = "false"
+	config["dcgmexporter"] = "false"
 
 	return config, nil
 }
@@ -60,6 +61,7 @@ func (fcl *FilesystemConfigLoader) ParseConfigMapForDefaultScrapeSettings(metric
 	config["ztunnel"] = "false"
 	config["istio-cni"] = "false"
 	config["waypoint-proxy"] = "false"
+	config["dcgmexporter"] = "false"
 
 	configSectionName := "default-scrape-settings-enabled"
 	if schemaVersion == "v2" {
@@ -179,6 +181,11 @@ func (cp *ConfigProcessor) PopulateSettingValues(parsedConfig map[string]string)
 		fmt.Printf("config:: Using scrape settings for waypoint-proxy: %v\n", cp.WaypointProxy)
 	}
 
+	if val, ok := parsedConfig["dcgmexporter"]; ok && val != "" {
+		cp.DcgmExporter = val
+		fmt.Printf("config:: Using scrape settings for dcgmexporter: %v\n", cp.DcgmExporter)
+	}
+
 	if os.Getenv("MODE") == "" && strings.ToLower(strings.TrimSpace(os.Getenv("MODE"))) == "advanced" {
 		controllerType := os.Getenv("CONTROLLER_TYPE")
 		if controllerType == "ReplicaSet" && strings.ToLower(os.Getenv("OS_TYPE")) == "linux" &&
@@ -224,6 +231,7 @@ func (fcw *FileConfigWriter) WriteDefaultScrapeSettingsToFile(filename string, c
 	file.WriteString(fmt.Sprintf("AZMON_PROMETHEUS_ZTUNNEL_SCRAPING_ENABLED=%v\n", cp.Ztunnel))
 	file.WriteString(fmt.Sprintf("AZMON_PROMETHEUS_ISTIOCNI_SCRAPING_ENABLED=%v\n", cp.IstioCni))
 	file.WriteString(fmt.Sprintf("AZMON_PROMETHEUS_WAYPOINT_PROXY_SCRAPING_ENABLED=%v\n", cp.WaypointProxy))
+	file.WriteString(fmt.Sprintf("AZMON_PROMETHEUS_DCGMEXPORTER_SCRAPING_ENABLED=%v\n", cp.DcgmExporter))
 
 	return nil
 }

--- a/otelcollector/shared/configmap/mp/tomlparser-default-targets-metrics-keep-list.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-default-targets-metrics-keep-list.go
@@ -21,6 +21,7 @@ var (
 	acstorCapacityProvisionerRegex, acstorMetricsExporterRegex          string
 	localCSIDriverRegex                                                 string
 	ztunnelRegex, istioCniRegex, waypointRegex                          string
+	dcgmExporterRegex                                                   string
 	kubeletRegex_minimal_mac                                            = "kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_node_name|kubelet_running_pods|kubelet_running_pod_count|kubelet_running_sum_containers|kubelet_running_containers|kubelet_running_container_count|volume_manager_total_volumes|kubelet_node_config_error|kubelet_runtime_operations_total|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_duration_seconds_bucket|kubelet_runtime_operations_duration_seconds_sum|kubelet_runtime_operations_duration_seconds_count|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_sum|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_sum|kubelet_pod_worker_duration_seconds_count|storage_operation_duration_seconds_bucket|storage_operation_duration_seconds_sum|storage_operation_duration_seconds_count|storage_operation_errors_total|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_sum|kubelet_cgroup_manager_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pleg_relist_interval_seconds_count|kubelet_pleg_relist_interval_seconds_sum|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_duration_seconds_sum|rest_client_requests_total|rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count|process_resident_memory_bytes|process_cpu_seconds_total|go_goroutines|kubernetes_build_info|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_server_expiration_renew_errors|kubelet_certificate_manager_server_ttl_seconds|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_inodes|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_labels|kube_persistentvolume_status_phase"
 	coreDNSRegex_minimal_mac                                            = "coredns_build_info|coredns_panics_total|coredns_dns_responses_total|coredns_forward_responses_total|coredns_dns_request_duration_seconds|coredns_dns_request_duration_seconds_bucket|coredns_dns_request_duration_seconds_sum|coredns_dns_request_duration_seconds_count|coredns_forward_request_duration_seconds|coredns_forward_request_duration_seconds_bucket|coredns_forward_request_duration_seconds_sum|coredns_forward_request_duration_seconds_count|coredns_dns_requests_total|coredns_forward_requests_total|coredns_cache_hits_total|coredns_cache_misses_total|coredns_cache_entries|coredns_plugin_enabled|coredns_dns_request_size_bytes|coredns_dns_request_size_bytes_bucket|coredns_dns_request_size_bytes_sum|coredns_dns_request_size_bytes_count|coredns_dns_response_size_bytes|coredns_dns_response_size_bytes_bucket|coredns_dns_response_size_bytes_sum|coredns_dns_response_size_bytes_count|coredns_dns_response_size_bytes_bucket|coredns_dns_response_size_bytes_sum|coredns_dns_response_size_bytes_count|process_resident_memory_bytes|process_cpu_seconds_total|go_goroutines|kubernetes_build_info"
 	cadvisorRegex_minimal_mac                                           = "container_spec_cpu_quota|container_spec_cpu_period|container_memory_rss|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_network_receive_packets_total|container_network_transmit_packets_total|container_network_receive_packets_dropped_total|container_network_transmit_packets_dropped_total|container_fs_reads_total|container_fs_writes_total|container_fs_reads_bytes_total|container_fs_writes_bytes_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_memory_cache|container_memory_swap|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_periods_total|container_memory_rss|kubernetes_build_info|container_start_time_seconds"
@@ -42,6 +43,7 @@ var (
 	ztunnel_minimal_mac        = "istio_build|istio_xds_connection_terminations_total|istio_xds_message_total|istio_tcp_connections_opened_total|istio_tcp_connections_closed_total|istio_tcp_sent_bytes_total|istio_tcp_received_bytes_total|istio_dns_requests_total|workload_manager_active_proxy_count|workload_manager_pending_proxy_count"
 	istioCni_minimal_mac       = "istio_cni_install_ready|istio_cni_installs_total|nodeagent_reconcile_events_total|ztunnel_connected"
 	waypoint_minimal_mac       = "istio_build|istio_requests_total|istio_request_duration_milliseconds_sum|istio_request_duration_milliseconds_count|envoy_cluster_upstream_cx_active|envoy_cluster_upstream_cx_connect_fail|envoy_server_memory_allocated"
+	dcgmexporter_minimal_mac   = "DCGM_.*"
 )
 
 // getStringValue checks the type of the value and returns it as a string if possible.
@@ -127,6 +129,7 @@ func populateKeepList(metricsConfigBySection map[string]map[string]string) (Rege
 		ztunnel:                    getStringValue(keeplist["ztunnel"]),
 		istiocni:                   getStringValue(keeplist["istio-cni"]),
 		waypoint:                   getStringValue(keeplist["waypoint-proxy"]),
+		dcgmexporter:               getStringValue(keeplist["dcgmexporter"]),
 		minimalingestionprofile:    minimalingestionprofile_value,
 	}
 
@@ -162,6 +165,7 @@ func validateRegexValues(regexValues RegexValues) error {
 		"ztunnel":                     regexValues.ztunnel,
 		"istio-cni":                   regexValues.istiocni,
 		"waypoint-proxy":              regexValues.waypoint,
+		"dcgmexporter":                regexValues.dcgmexporter,
 	}
 
 	// Iterate over the fields and validate each regex
@@ -216,6 +220,7 @@ func populateRegexValuesWithMinimalIngestionProfile(regexValues RegexValues) {
 		ztunnelRegex = fmt.Sprintf("%s|%s", regexValues.ztunnel, ztunnel_minimal_mac)
 		istioCniRegex = fmt.Sprintf("%s|%s", regexValues.istiocni, istioCni_minimal_mac)
 		waypointRegex = fmt.Sprintf("%s|%s", regexValues.waypoint, waypoint_minimal_mac)
+		dcgmExporterRegex = fmt.Sprintf("%s|%s", regexValues.dcgmexporter, dcgmexporter_minimal_mac)
 
 	} else {
 		log.Println("minimalIngestionProfile:", regexValues.minimalingestionprofile)
@@ -240,6 +245,7 @@ func populateRegexValuesWithMinimalIngestionProfile(regexValues RegexValues) {
 		ztunnelRegex = regexValues.ztunnel
 		istioCniRegex = regexValues.istiocni
 		waypointRegex = regexValues.waypoint
+		dcgmExporterRegex = regexValues.dcgmexporter
 	}
 }
 
@@ -278,6 +284,7 @@ func tomlparserTargetsMetricsKeepList(metricsConfigBySection map[string]map[stri
 		"ZTUNNEL_METRICS_KEEP_LIST_REGEX":                    ztunnelRegex,
 		"ISTIOCNI_METRICS_KEEP_LIST_REGEX":                   istioCniRegex,
 		"WAYPOINT_PROXY_METRICS_KEEP_LIST_REGEX":             waypointRegex,
+		"DCGMEXPORTER_METRICS_KEEP_LIST_REGEX":               dcgmExporterRegex,
 	}
 
 	out, err := yaml.Marshal(data)

--- a/otelcollector/shared/configmap/mp/tomlparser-scrape-interval.go
+++ b/otelcollector/shared/configmap/mp/tomlparser-scrape-interval.go
@@ -62,6 +62,7 @@ func processConfigMap(metricsConfigBySection map[string]map[string]string) map[s
 		intervalHash["ZTUNNEL_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "ztunnel")
 		intervalHash["ISTIOCNI_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "istio-cni")
 		intervalHash["WAYPOINT_PROXY_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "waypoint-proxy")
+		intervalHash["DCGMEXPORTER_SCRAPE_INTERVAL"] = getParsedDataValue(metricsConfigBySection, "dcgmexporter")
 
 		return intervalHash
 	}
@@ -78,6 +79,7 @@ func processConfigMap(metricsConfigBySection map[string]map[string]string) map[s
 		"NETWORKOBSERVABILITYCILIUM_SCRAPE_INTERVAL", "ACSTORCAPACITYPROVISIONER_SCRAPE_INTERVAL",
 		"ACSTORMETRICSEXPORTER_SCRAPE_INTERVAL", "LOCALCSIDRIVER_SCRAPE_INTERVAL",
 		"ZTUNNEL_SCRAPE_INTERVAL", "ISTIOCNI_SCRAPE_INTERVAL", "WAYPOINT_PROXY_SCRAPE_INTERVAL",
+		"DCGMEXPORTER_SCRAPE_INTERVAL",
 	}
 
 	for _, key := range keys {


### PR DESCRIPTION
This commit adds comprehensive support for Nvidia DCGM (Data Center GPU Manager) exporter to enable GPU metrics collection.

Key changes:
- Add dcgmExporterDefaultDs.yml configuration for DCGM exporter running as systemd unit on each node.
- Add DCGM_EXPORTER_TARGETPORT environment variable (default: 19400) to deployment templates
- Add scrape interval configuration for DCGM exporter (default: 30s)
- Update config map parsers to handle dcgmexporter settings
- Add validation and processing logic for DCGM exporter regex patterns
- Extend test coverage to include dcgmexporter configuration validation

The DCGM exporter is configured to:
- Only scrape nodes with label `kubernetes.azure.com/dcgm-exporter=enabled`
- Use node-based service discovery for GPU-enabled nodes
- Include default metrics regex pattern `DCGM_.*` for minimal ingestion profile
- Be disabled by default (`dcgmexporter = false`)


[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
