### PR TITLE
Fix Fluent-Bit log level from debug to warning

### DIFF
--- a/otelcollector/fluent-bit/fluent-bit-daemonset.yaml
+++ b/otelcollector/fluent-bit/fluent-bit-daemonset.yaml
@@ -2,7 +2,7 @@ service:
     flush: 15
     http_server: Off
     daemon: Off
-    log_level: debug
+    log_level: warning
     parsers_file: /opt/fluent-bit/fluent-bit-parsers.conf
     log_file: /opt/fluent-bit/fluent-bit.log
 

--- a/otelcollector/fluent-bit/fluent-bit-windows.conf
+++ b/otelcollector/fluent-bit/fluent-bit-windows.conf
@@ -2,7 +2,7 @@
     Flush        15
     HTTP_Server   Off
     Daemon       Off
-    Log_Level    debug
+    Log_Level    warning
     Parsers_File  C:\\opt\\fluent-bit\\fluent-bit-parsers.conf
     Log_File      C:\\opt\\fluent-bit\\fluent-bit.log
 

--- a/otelcollector/fluent-bit/fluent-bit.yaml
+++ b/otelcollector/fluent-bit/fluent-bit.yaml
@@ -2,7 +2,7 @@ service:
   flush:        15
   http_server:   Off
   daemon:        Off
-  log_level:     debug
+  log_level:     warning
   parsers_file:  /opt/fluent-bit/fluent-bit-parsers.conf
   log_file:      /opt/fluent-bit/fluent-bit.log
 


### PR DESCRIPTION
## Summary
- Change Fluent-Bit log_level from debug to warning in replica/CCP config (`fluent-bit.yaml`), daemonset config (`fluent-bit-daemonset.yaml`), and Windows config (`fluent-bit-windows.conf`)
- DEBUG level generates excessive internal diagnostics in production, increasing CPU/memory overhead and log volume

## Test plan
- Verify Fluent-Bit starts correctly with warning level
- Confirm error/warning logs still appear
- Verify reduced log volume in prod