### PR TITLE
Add missing CPU limit for Windows addon-token-adapter

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-daemonset.yaml
@@ -628,6 +628,7 @@ spec:
            periodSeconds: 60
           resources:
            limits:
+             cpu: 500m
              memory: 500Mi
            requests:
              cpu: 100m


### PR DESCRIPTION
## Summary
Add the missing CPU limit (500m) for the addon-token-adapter-win container in the Windows DaemonSet. This aligns it with the Linux addon-token-adapter container which already has a 500m CPU limit defined.

## Changes
- Added cpu: 500m to the resources.limits section for addon-token-adapter-win in ama-metrics-daemonset.yaml