### PR TITLE
TIdy and remove duplicate health metrics

### DIFF
--- a/otelcollector/shared/health_metrics.go
+++ b/otelcollector/shared/health_metrics.go
@@ -41,22 +41,11 @@ var (
 	// (ProcessedCount - SentToPublicationCount from ME log lines)
 	MEDroppedCount float64 = 0
 
-	// --- Overall (component-level) metrics ---
-
 	// meBytesSentMetric is the byte rate published by ME to Azure Monitor
 	meBytesSentMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "me_bytes_sent_per_minute",
 			Help: "Bytes of metric data published by ME to Azure Monitor (per minute)",
-		},
-		[]string{"computer", "release", "controller_type"},
-	)
-
-	// overallDroppedMetric is the sum of all stage drops (otelcol + ME)
-	overallDroppedMetric = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "overall_metrics_dropped_total",
-			Help: "Total metric points dropped across all pipeline stages",
 		},
 		[]string{"computer", "release", "controller_type"},
 	)
@@ -153,9 +142,7 @@ func ExposePrometheusCollectorHealthMetrics() {
 
 	// A new registry excludes go_* and promhttp_* metrics for the endpoint
 	r := prometheus.NewRegistry()
-	// Overall (component-level) metrics
 	r.MustRegister(meBytesSentMetric)
-	r.MustRegister(overallDroppedMetric)
 	// ME (sub-component) metrics
 	r.MustRegister(meReceivedMetric)
 	r.MustRegister(meSentMetric)
@@ -204,7 +191,6 @@ func ExposePrometheusCollectorHealthMetrics() {
 
 			MEDroppedMutex.Lock()
 			meDroppedMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Add(MEDroppedCount)
-			overallDroppedMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Add(MEDroppedCount)
 			MEDroppedCount = 0
 			MEDroppedMutex.Unlock()
 
@@ -218,7 +204,6 @@ func ExposePrometheusCollectorHealthMetrics() {
 			otelcolReceivedRateMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(OtelColReceivedRate)
 			otelcolSentRateMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(OtelColSentRate)
 			otelcolDroppedMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Add(OtelColDroppedCount)
-			overallDroppedMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Add(OtelColDroppedCount)
 			OtelColDroppedCount = 0
 			OtelColDiagMutex.Unlock()
 

--- a/otelcollector/shared/health_metrics.go
+++ b/otelcollector/shared/health_metrics.go
@@ -44,15 +44,6 @@ var (
 	// --- Overall (component-level) metrics ---
 	// These represent the full pipeline: input = otelcol receiver, output = ME publication
 
-	// overallReceivedMetric is the pipeline input rate (what otelcol's receiver accepted per minute)
-	overallReceivedMetric = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "overall_metrics_received_per_minute",
-			Help: "Rate of metric points entering the collection pipeline (per minute)",
-		},
-		[]string{"computer", "release", "controller_type"},
-	)
-
 	// overallSentMetric is the pipeline output rate (what ME published to Azure Monitor per minute)
 	overallSentMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -173,7 +164,6 @@ func ExposePrometheusCollectorHealthMetrics() {
 	// A new registry excludes go_* and promhttp_* metrics for the endpoint
 	r := prometheus.NewRegistry()
 	// Overall (component-level) metrics
-	r.MustRegister(overallReceivedMetric)
 	r.MustRegister(overallSentMetric)
 	r.MustRegister(meBytesSentMetric)
 	r.MustRegister(overallDroppedMetric)
@@ -243,8 +233,6 @@ func ExposePrometheusCollectorHealthMetrics() {
 			otelcolSentRateMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(OtelColSentRate)
 			otelcolDroppedMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Add(OtelColDroppedCount)
 			overallDroppedMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Add(OtelColDroppedCount)
-			// Overall input = otelcol receiver rate
-			overallReceivedMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(OtelColReceivedRate)
 			OtelColDroppedCount = 0
 			OtelColDiagMutex.Unlock()
 

--- a/otelcollector/shared/health_metrics.go
+++ b/otelcollector/shared/health_metrics.go
@@ -42,16 +42,6 @@ var (
 	MEDroppedCount float64 = 0
 
 	// --- Overall (component-level) metrics ---
-	// These represent the full pipeline: input = otelcol receiver, output = ME publication
-
-	// overallSentMetric is the pipeline output rate (what ME published to Azure Monitor per minute)
-	overallSentMetric = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "overall_metrics_sent_per_minute",
-			Help: "Rate of metric points delivered to Azure Monitor (per minute)",
-		},
-		[]string{"computer", "release", "controller_type"},
-	)
 
 	// meBytesSentMetric is the byte rate published by ME to Azure Monitor
 	meBytesSentMetric = prometheus.NewGaugeVec(
@@ -164,7 +154,6 @@ func ExposePrometheusCollectorHealthMetrics() {
 	// A new registry excludes go_* and promhttp_* metrics for the endpoint
 	r := prometheus.NewRegistry()
 	// Overall (component-level) metrics
-	r.MustRegister(overallSentMetric)
 	r.MustRegister(meBytesSentMetric)
 	r.MustRegister(overallDroppedMetric)
 	// ME (sub-component) metrics
@@ -198,9 +187,6 @@ func ExposePrometheusCollectorHealthMetrics() {
 			// ME sub-component metrics (ME receives from otelcol, sends to Azure Monitor)
 			meReceivedMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(timeseriesReceivedRate)
 			meSentMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(timeseriesSentRate)
-
-			// Overall metrics: input = otelcol receiver, output = ME publication
-			overallSentMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(timeseriesSentRate)
 			meBytesSentMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(bytesSentRate)
 
 			TimeseriesReceivedTotal = 0.0

--- a/otelcollector/shared/health_metrics.go
+++ b/otelcollector/shared/health_metrics.go
@@ -62,11 +62,11 @@ var (
 		[]string{"computer", "release", "controller_type"},
 	)
 
-	// overallBytesSentMetric is the pipeline output byte rate
-	overallBytesSentMetric = prometheus.NewGaugeVec(
+	// meBytesSentMetric is the byte rate published by ME to Azure Monitor
+	meBytesSentMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "overall_bytes_sent_per_minute",
-			Help: "Bytes of metric data delivered to Azure Monitor (per minute)",
+			Name: "me_bytes_sent_per_minute",
+			Help: "Bytes of metric data published by ME to Azure Monitor (per minute)",
 		},
 		[]string{"computer", "release", "controller_type"},
 	)
@@ -175,7 +175,7 @@ func ExposePrometheusCollectorHealthMetrics() {
 	// Overall (component-level) metrics
 	r.MustRegister(overallReceivedMetric)
 	r.MustRegister(overallSentMetric)
-	r.MustRegister(overallBytesSentMetric)
+	r.MustRegister(meBytesSentMetric)
 	r.MustRegister(overallDroppedMetric)
 	// ME (sub-component) metrics
 	r.MustRegister(meReceivedMetric)
@@ -211,7 +211,7 @@ func ExposePrometheusCollectorHealthMetrics() {
 
 			// Overall metrics: input = otelcol receiver, output = ME publication
 			overallSentMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(timeseriesSentRate)
-			overallBytesSentMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(bytesSentRate)
+			meBytesSentMetric.With(prometheus.Labels{"computer": computer, "release": helmReleaseName, "controller_type": controllerType}).Set(bytesSentRate)
 
 			TimeseriesReceivedTotal = 0.0
 			TimeseriesSentTotal = 0.0

--- a/otelcollector/shared/health_metrics_test.go
+++ b/otelcollector/shared/health_metrics_test.go
@@ -23,7 +23,6 @@ func TestHealthMetricsRegistration(t *testing.T) {
 	registry := prometheus.NewRegistry()
 
 	// Register all health metrics
-	registry.MustRegister(overallReceivedMetric)
 	registry.MustRegister(overallSentMetric)
 	registry.MustRegister(meBytesSentMetric)
 	registry.MustRegister(overallDroppedMetric)
@@ -45,13 +44,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 	registry := prometheus.NewRegistry()
 
 	// Create new instances of the metrics for testing
-	testOverallReceived := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "overall_metrics_received_per_minute",
-			Help: "Rate of metric points entering the collection pipeline",
-		},
-		[]string{"computer", "release", "controller_type"},
-	)
 	testOverallSent := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "overall_metrics_sent_per_minute",
@@ -109,7 +101,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 		[]string{"computer", "release", "controller_type"},
 	)
 
-	registry.MustRegister(testOverallReceived)
 	registry.MustRegister(testOverallSent)
 	registry.MustRegister(testMEBytesSent)
 	registry.MustRegister(testOverallDropped)
@@ -120,7 +111,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 	registry.MustRegister(testOtelColExportFailures)
 
 	// Set some test values
-	testOverallReceived.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
 	testOverallSent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
 	testMEBytesSent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(1000)
 	testOverallDropped.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Add(0)
@@ -149,7 +139,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 
 	// Verify all metrics are in the response
 	expectedMetrics := []string{
-		"overall_metrics_received_per_minute",
 		"overall_metrics_sent_per_minute",
 		"me_bytes_sent_per_minute",
 		"overall_metrics_dropped_total",

--- a/otelcollector/shared/health_metrics_test.go
+++ b/otelcollector/shared/health_metrics_test.go
@@ -24,7 +24,6 @@ func TestHealthMetricsRegistration(t *testing.T) {
 
 	// Register all health metrics
 	registry.MustRegister(meBytesSentMetric)
-	registry.MustRegister(overallDroppedMetric)
 	registry.MustRegister(meReceivedMetric)
 	registry.MustRegister(meSentMetric)
 	registry.MustRegister(meDroppedMetric)
@@ -47,13 +46,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 		prometheus.GaugeOpts{
 			Name: "me_bytes_sent_per_minute",
 			Help: "Rate of bytes published by ME to Azure Monitor",
-		},
-		[]string{"computer", "release", "controller_type"},
-	)
-	testOverallDropped := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "overall_metrics_dropped_total",
-			Help: "Total metric points dropped across all pipeline stages",
 		},
 		[]string{"computer", "release", "controller_type"},
 	)
@@ -94,7 +86,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 	)
 
 	registry.MustRegister(testMEBytesSent)
-	registry.MustRegister(testOverallDropped)
 	registry.MustRegister(testMEReceived)
 	registry.MustRegister(testMESent)
 	registry.MustRegister(testMEDropped)
@@ -103,7 +94,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 
 	// Set some test values
 	testMEBytesSent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(1000)
-	testOverallDropped.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Add(0)
 	testMEReceived.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
 	testMESent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
 	testMEDropped.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Add(0)
@@ -130,7 +120,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 	// Verify all metrics are in the response
 	expectedMetrics := []string{
 		"me_bytes_sent_per_minute",
-		"overall_metrics_dropped_total",
 		"me_metrics_received_per_minute",
 		"me_metrics_sent_per_minute",
 		"me_metrics_dropped_total",

--- a/otelcollector/shared/health_metrics_test.go
+++ b/otelcollector/shared/health_metrics_test.go
@@ -25,7 +25,7 @@ func TestHealthMetricsRegistration(t *testing.T) {
 	// Register all health metrics
 	registry.MustRegister(overallReceivedMetric)
 	registry.MustRegister(overallSentMetric)
-	registry.MustRegister(overallBytesSentMetric)
+	registry.MustRegister(meBytesSentMetric)
 	registry.MustRegister(overallDroppedMetric)
 	registry.MustRegister(meReceivedMetric)
 	registry.MustRegister(meSentMetric)
@@ -59,10 +59,10 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 		},
 		[]string{"computer", "release", "controller_type"},
 	)
-	testOverallBytesSent := prometheus.NewGaugeVec(
+	testMEBytesSent := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "overall_bytes_sent_per_minute",
-			Help: "Rate of bytes delivered to Azure Monitor",
+			Name: "me_bytes_sent_per_minute",
+			Help: "Rate of bytes published by ME to Azure Monitor",
 		},
 		[]string{"computer", "release", "controller_type"},
 	)
@@ -111,7 +111,7 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 
 	registry.MustRegister(testOverallReceived)
 	registry.MustRegister(testOverallSent)
-	registry.MustRegister(testOverallBytesSent)
+	registry.MustRegister(testMEBytesSent)
 	registry.MustRegister(testOverallDropped)
 	registry.MustRegister(testMEReceived)
 	registry.MustRegister(testMESent)
@@ -122,7 +122,7 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 	// Set some test values
 	testOverallReceived.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
 	testOverallSent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
-	testOverallBytesSent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(1000)
+	testMEBytesSent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(1000)
 	testOverallDropped.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Add(0)
 	testMEReceived.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
 	testMESent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
@@ -151,7 +151,7 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 	expectedMetrics := []string{
 		"overall_metrics_received_per_minute",
 		"overall_metrics_sent_per_minute",
-		"overall_bytes_sent_per_minute",
+		"me_bytes_sent_per_minute",
 		"overall_metrics_dropped_total",
 		"me_metrics_received_per_minute",
 		"me_metrics_sent_per_minute",

--- a/otelcollector/shared/health_metrics_test.go
+++ b/otelcollector/shared/health_metrics_test.go
@@ -23,7 +23,6 @@ func TestHealthMetricsRegistration(t *testing.T) {
 	registry := prometheus.NewRegistry()
 
 	// Register all health metrics
-	registry.MustRegister(overallSentMetric)
 	registry.MustRegister(meBytesSentMetric)
 	registry.MustRegister(overallDroppedMetric)
 	registry.MustRegister(meReceivedMetric)
@@ -44,13 +43,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 	registry := prometheus.NewRegistry()
 
 	// Create new instances of the metrics for testing
-	testOverallSent := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "overall_metrics_sent_per_minute",
-			Help: "Rate of metric points delivered to Azure Monitor",
-		},
-		[]string{"computer", "release", "controller_type"},
-	)
 	testMEBytesSent := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "me_bytes_sent_per_minute",
@@ -101,7 +93,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 		[]string{"computer", "release", "controller_type"},
 	)
 
-	registry.MustRegister(testOverallSent)
 	registry.MustRegister(testMEBytesSent)
 	registry.MustRegister(testOverallDropped)
 	registry.MustRegister(testMEReceived)
@@ -111,7 +102,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 	registry.MustRegister(testOtelColExportFailures)
 
 	// Set some test values
-	testOverallSent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
 	testMEBytesSent.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(1000)
 	testOverallDropped.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Add(0)
 	testMEReceived.With(prometheus.Labels{"computer": "test", "release": "test", "controller_type": "test"}).Set(100)
@@ -139,7 +129,6 @@ func TestHealthMetricsEndpoint(t *testing.T) {
 
 	// Verify all metrics are in the response
 	expectedMetrics := []string{
-		"overall_metrics_sent_per_minute",
 		"me_bytes_sent_per_minute",
 		"overall_metrics_dropped_total",
 		"me_metrics_received_per_minute",

--- a/otelcollector/test/README.md
+++ b/otelcollector/test/README.md
@@ -54,7 +54,7 @@
 - Health Metrics (CCP)
   - **These tests cannot run in the standard CI pipeline.** CCP pods live on standalone underlay clusters, not CI clusters.
   - Run interactively via the [CCP Health Metrics Workflow](ccp/ccp-health-metrics-workflow.md) in a VS Code chat session.
-  - Validates all 8 health metrics: `timeseries_received_per_minute`, `timeseries_sent_per_minute`, `bytes_sent_per_minute`, `invalid_metrics_settings_config`, `exporting_metrics_failed`, `otelcol_receiver_accepted_metric_points`, `otelcol_exporter_sent_metric_points`, `otelcol_exporter_send_failed_metric_points`.
+  - Validates all 12 health metrics: `overall_metrics_received_per_minute`, `overall_metrics_sent_per_minute`, `overall_bytes_sent_per_minute`, `overall_metrics_dropped_total`, `me_metrics_received_per_minute`, `me_metrics_sent_per_minute`, `me_metrics_dropped_total`, `otelcol_metrics_received_per_minute`, `otelcol_metrics_sent_per_minute`, `otelcol_metrics_dropped_total`, `otelcol_export_failures_total`, `invalid_metrics_settings_config`.
   - Validates correct labels (computer, release, controller_type).
   - Validates CCP mode active in logs and fluent-bit NOT running.
 

--- a/otelcollector/test/README.md
+++ b/otelcollector/test/README.md
@@ -54,7 +54,7 @@
 - Health Metrics (CCP)
   - **These tests cannot run in the standard CI pipeline.** CCP pods live on standalone underlay clusters, not CI clusters.
   - Run interactively via the [CCP Health Metrics Workflow](ccp/ccp-health-metrics-workflow.md) in a VS Code chat session.
-  - Validates all 12 health metrics: `overall_metrics_received_per_minute`, `overall_metrics_sent_per_minute`, `overall_bytes_sent_per_minute`, `overall_metrics_dropped_total`, `me_metrics_received_per_minute`, `me_metrics_sent_per_minute`, `me_metrics_dropped_total`, `otelcol_metrics_received_per_minute`, `otelcol_metrics_sent_per_minute`, `otelcol_metrics_dropped_total`, `otelcol_export_failures_total`, `invalid_metrics_settings_config`.
+  - Validates all 9 key health metrics: `me_metrics_received_per_minute`, `me_metrics_sent_per_minute`, `me_metrics_dropped_total`, `otelcol_metrics_received_per_minute`, `otelcol_metrics_sent_per_minute`, `otelcol_metrics_dropped_total`, `otelcol_export_failures_total`, `overall_metrics_dropped_total`, `invalid_metrics_settings_config`.
   - Validates correct labels (computer, release, controller_type).
   - Validates CCP mode active in logs and fluent-bit NOT running.
 

--- a/otelcollector/test/README.md
+++ b/otelcollector/test/README.md
@@ -54,7 +54,7 @@
 - Health Metrics (CCP)
   - **These tests cannot run in the standard CI pipeline.** CCP pods live on standalone underlay clusters, not CI clusters.
   - Run interactively via the [CCP Health Metrics Workflow](ccp/ccp-health-metrics-workflow.md) in a VS Code chat session.
-  - Validates all 10 key health metrics: `me_metrics_received_per_minute`, `me_metrics_sent_per_minute`, `me_bytes_sent_per_minute`, `me_metrics_dropped_total`, `otelcol_metrics_received_per_minute`, `otelcol_metrics_sent_per_minute`, `otelcol_metrics_dropped_total`, `otelcol_export_failures_total`, `overall_metrics_dropped_total`, `invalid_metrics_settings_config`.
+  - Validates all 9 key health metrics: `me_metrics_received_per_minute`, `me_metrics_sent_per_minute`, `me_bytes_sent_per_minute`, `me_metrics_dropped_total`, `otelcol_metrics_received_per_minute`, `otelcol_metrics_sent_per_minute`, `otelcol_metrics_dropped_total`, `otelcol_export_failures_total`, `invalid_metrics_settings_config`.
   - Validates correct labels (computer, release, controller_type).
   - Validates CCP mode active in logs and fluent-bit NOT running.
 

--- a/otelcollector/test/README.md
+++ b/otelcollector/test/README.md
@@ -54,7 +54,7 @@
 - Health Metrics (CCP)
   - **These tests cannot run in the standard CI pipeline.** CCP pods live on standalone underlay clusters, not CI clusters.
   - Run interactively via the [CCP Health Metrics Workflow](ccp/ccp-health-metrics-workflow.md) in a VS Code chat session.
-  - Validates all 9 key health metrics: `me_metrics_received_per_minute`, `me_metrics_sent_per_minute`, `me_metrics_dropped_total`, `otelcol_metrics_received_per_minute`, `otelcol_metrics_sent_per_minute`, `otelcol_metrics_dropped_total`, `otelcol_export_failures_total`, `overall_metrics_dropped_total`, `invalid_metrics_settings_config`.
+  - Validates all 10 key health metrics: `me_metrics_received_per_minute`, `me_metrics_sent_per_minute`, `me_bytes_sent_per_minute`, `me_metrics_dropped_total`, `otelcol_metrics_received_per_minute`, `otelcol_metrics_sent_per_minute`, `otelcol_metrics_dropped_total`, `otelcol_export_failures_total`, `overall_metrics_dropped_total`, `invalid_metrics_settings_config`.
   - Validates correct labels (computer, release, controller_type).
   - Validates CCP mode active in logs and fluent-bit NOT running.
 

--- a/otelcollector/test/ccp/ccp-configmap-test-workflow.md
+++ b/otelcollector/test/ccp/ccp-configmap-test-workflow.md
@@ -123,7 +123,6 @@ $response.Content
 | `me_metrics_sent_per_minute` | > 0 |
 | `me_metrics_received_per_minute` | > 0 |
 | `me_bytes_sent_per_minute` | > 0 |
-| `overall_metrics_dropped_total` | = 0 |
 | `invalid_metrics_settings_config` | = 0 |
 
 ---

--- a/otelcollector/test/ccp/ccp-health-metrics-workflow.md
+++ b/otelcollector/test/ccp/ccp-health-metrics-workflow.md
@@ -320,6 +320,7 @@ The following metrics should all be present. They are organized by sub-component
 |--------|------|--------|----------------|
 | `me_metrics_received_per_minute` | Gauge | ME logs | > 0 |
 | `me_metrics_sent_per_minute` | Gauge | ME logs | > 0 |
+| `me_bytes_sent_per_minute` | Gauge | ME logs | > 0 |
 | `me_metrics_dropped_total` | Counter | ME logs | >= 0 |
 
 **OtelCol (sub-component) metrics** — what the otelcollector receiver/exporter handles:
@@ -345,13 +346,13 @@ The following metrics should all be present. They are organized by sub-component
 
 All metrics carry labels: `computer`, `release`, `controller_type`. The `invalid_metrics_settings_config` metric has an additional `error` label.
 
-> **Note:** The code also exposes `overall_metrics_received_per_minute`, `overall_metrics_sent_per_minute`, and `overall_bytes_sent_per_minute`. These duplicate values already available in the sub-component metrics (`otelcol_metrics_received_per_minute` and `me_metrics_sent_per_minute` respectively) and should not be relied on for monitoring.
+> **Note:** The code also exposes `overall_metrics_received_per_minute` and `overall_metrics_sent_per_minute`. These duplicate values already available in the sub-component metrics (`otelcol_metrics_received_per_minute` and `me_metrics_sent_per_minute` respectively) and should not be relied on for monitoring.
 
 **Validation commands:**
 
 ```bash
 # Check key metrics are present
-grep -cE "me_metrics_received_per_minute|me_metrics_sent_per_minute|me_metrics_dropped_total|otelcol_metrics_received_per_minute|otelcol_metrics_sent_per_minute|otelcol_metrics_dropped_total|otelcol_export_failures_total|overall_metrics_dropped_total|invalid_metrics_settings_config" /tmp/ccp_health_metrics.txt
+grep -cE "me_metrics_received_per_minute|me_metrics_sent_per_minute|me_bytes_sent_per_minute|me_metrics_dropped_total|otelcol_metrics_received_per_minute|otelcol_metrics_sent_per_minute|otelcol_metrics_dropped_total|otelcol_export_failures_total|overall_metrics_dropped_total|invalid_metrics_settings_config" /tmp/ccp_health_metrics.txt
 
 # Check ME-based metrics are > 0 (primary ingestion indicators)
 grep -E "^me_metrics_(received|sent)_per_minute" /tmp/ccp_health_metrics.txt

--- a/otelcollector/test/ccp/ccp-health-metrics-workflow.md
+++ b/otelcollector/test/ccp/ccp-health-metrics-workflow.md
@@ -310,18 +310,9 @@ curl -s http://127.0.0.1:12234/metrics > /tmp/ccp_health_metrics.txt
 kill $PF_PID 2>/dev/null
 ```
 
-### Step 5.3: Validate All 12 Health Metrics
+### Step 5.3: Validate Health Metrics
 
-The following metrics should all be present. They are organized into three tiers: overall (full pipeline), ME sub-component, and otelcol sub-component.
-
-**Overall (pipeline-level) metrics** — input = otelcol receiver, output = ME publication:
-
-| Metric | Type | Source | Expected Value |
-|--------|------|--------|----------------|
-| `overall_metrics_received_per_minute` | Gauge | Otelcol `:8888/metrics` | > 0 |
-| `overall_metrics_sent_per_minute` | Gauge | ME logs | > 0 |
-| `overall_bytes_sent_per_minute` | Gauge | ME logs | > 0 |
-| `overall_metrics_dropped_total` | Counter | ME logs + Otelcol | >= 0 |
+The following metrics should all be present. They are organized by sub-component, plus one cross-pipeline counter and a config validation gauge.
 
 **ME (sub-component) metrics** — what ME receives from otelcol and publishes to Azure Monitor:
 
@@ -340,6 +331,12 @@ The following metrics should all be present. They are organized into three tiers
 | `otelcol_metrics_dropped_total` | Counter | Otelcol `:8888/metrics` | >= 0 |
 | `otelcol_export_failures_total` | Counter | Otelcol logs | >= 0 |
 
+**Cross-pipeline:**
+
+| Metric | Type | Source | Expected Value |
+|--------|------|--------|----------------|
+| `overall_metrics_dropped_total` | Counter | ME logs + Otelcol | >= 0 |
+
 **Configuration validation:**
 
 | Metric | Type | Source | Expected Value |
@@ -348,20 +345,22 @@ The following metrics should all be present. They are organized into three tiers
 
 All metrics carry labels: `computer`, `release`, `controller_type`. The `invalid_metrics_settings_config` metric has an additional `error` label.
 
+> **Note:** The code also exposes `overall_metrics_received_per_minute`, `overall_metrics_sent_per_minute`, and `overall_bytes_sent_per_minute`. These duplicate values already available in the sub-component metrics (`otelcol_metrics_received_per_minute` and `me_metrics_sent_per_minute` respectively) and should not be relied on for monitoring.
+
 **Validation commands:**
 
 ```bash
-# Check all 12 metrics are present
-grep -cE "overall_metrics_received_per_minute|overall_metrics_sent_per_minute|overall_bytes_sent_per_minute|overall_metrics_dropped_total|me_metrics_received_per_minute|me_metrics_sent_per_minute|me_metrics_dropped_total|otelcol_metrics_received_per_minute|otelcol_metrics_sent_per_minute|otelcol_metrics_dropped_total|otelcol_export_failures_total|invalid_metrics_settings_config" /tmp/ccp_health_metrics.txt
+# Check key metrics are present
+grep -cE "me_metrics_received_per_minute|me_metrics_sent_per_minute|me_metrics_dropped_total|otelcol_metrics_received_per_minute|otelcol_metrics_sent_per_minute|otelcol_metrics_dropped_total|otelcol_export_failures_total|overall_metrics_dropped_total|invalid_metrics_settings_config" /tmp/ccp_health_metrics.txt
 
-# Check overall pipeline metrics are > 0 (primary ingestion indicators)
-grep -E "^overall_(metrics_received|metrics_sent|bytes_sent)" /tmp/ccp_health_metrics.txt
+# Check ME-based metrics are > 0 (primary ingestion indicators)
+grep -E "^me_metrics_(received|sent)_per_minute" /tmp/ccp_health_metrics.txt
 
 # Check status metric is 0 (healthy state)
 grep -E "^invalid_metrics_settings_config" /tmp/ccp_health_metrics.txt
 
 # Check labels include computer, release, controller_type
-grep "overall_metrics_received_per_minute" /tmp/ccp_health_metrics.txt | head -1
+grep "me_metrics_received_per_minute" /tmp/ccp_health_metrics.txt | head -1
 ```
 
 ### Step 5.4: Verify CCP Mode in Logs

--- a/otelcollector/test/ccp/ccp-health-metrics-workflow.md
+++ b/otelcollector/test/ccp/ccp-health-metrics-workflow.md
@@ -310,35 +310,58 @@ curl -s http://127.0.0.1:12234/metrics > /tmp/ccp_health_metrics.txt
 kill $PF_PID 2>/dev/null
 ```
 
-### Step 5.3: Validate All 8 Health Metrics
+### Step 5.3: Validate All 12 Health Metrics
 
-The following metrics should all be present:
+The following metrics should all be present. They are organized into three tiers: overall (full pipeline), ME sub-component, and otelcol sub-component.
 
-| Metric | Source | Expected Value |
-|--------|--------|----------------|
-| `timeseries_received_per_minute` | ME logs | > 0 |
-| `timeseries_sent_per_minute` | ME logs | > 0 |
-| `bytes_sent_per_minute` | ME logs | > 0 |
-| `invalid_custom_prometheus_config` | Status | 0 |
-| `exporting_metrics_failed` | Status | 0 |
-| `otelcol_receiver_accepted_metric_points` | Otelcol diagnostic | >= 0 |
-| `otelcol_exporter_sent_metric_points` | Otelcol diagnostic | >= 0 |
-| `otelcol_exporter_send_failed_metric_points` | Otelcol diagnostic | >= 0 |
+**Overall (pipeline-level) metrics** — input = otelcol receiver, output = ME publication:
+
+| Metric | Type | Source | Expected Value |
+|--------|------|--------|----------------|
+| `overall_metrics_received_per_minute` | Gauge | Otelcol `:8888/metrics` | > 0 |
+| `overall_metrics_sent_per_minute` | Gauge | ME logs | > 0 |
+| `overall_bytes_sent_per_minute` | Gauge | ME logs | > 0 |
+| `overall_metrics_dropped_total` | Counter | ME logs + Otelcol | >= 0 |
+
+**ME (sub-component) metrics** — what ME receives from otelcol and publishes to Azure Monitor:
+
+| Metric | Type | Source | Expected Value |
+|--------|------|--------|----------------|
+| `me_metrics_received_per_minute` | Gauge | ME logs | > 0 |
+| `me_metrics_sent_per_minute` | Gauge | ME logs | > 0 |
+| `me_metrics_dropped_total` | Counter | ME logs | >= 0 |
+
+**OtelCol (sub-component) metrics** — what the otelcollector receiver/exporter handles:
+
+| Metric | Type | Source | Expected Value |
+|--------|------|--------|----------------|
+| `otelcol_metrics_received_per_minute` | Gauge | Otelcol `:8888/metrics` | > 0 |
+| `otelcol_metrics_sent_per_minute` | Gauge | Otelcol `:8888/metrics` | > 0 |
+| `otelcol_metrics_dropped_total` | Counter | Otelcol `:8888/metrics` | >= 0 |
+| `otelcol_export_failures_total` | Counter | Otelcol logs | >= 0 |
+
+**Configuration validation:**
+
+| Metric | Type | Source | Expected Value |
+|--------|------|--------|----------------|
+| `invalid_metrics_settings_config` | Gauge | Configmap parser | 0 |
+
+All metrics carry labels: `computer`, `release`, `controller_type`. The `invalid_metrics_settings_config` metric has an additional `error` label.
 
 **Validation commands:**
 
 ```bash
-# Check all 8 metrics are present
-grep -cE "timeseries_received_per_minute|timeseries_sent_per_minute|bytes_sent_per_minute|invalid_custom_prometheus_config|exporting_metrics_failed|otelcol_receiver_accepted_metric_points|otelcol_exporter_sent_metric_points|otelcol_exporter_send_failed_metric_points" /tmp/ccp_health_metrics.txt
+# Check all 12 metrics are present
+grep -cE "overall_metrics_received_per_minute|overall_metrics_sent_per_minute|overall_bytes_sent_per_minute|overall_metrics_dropped_total|me_metrics_received_per_minute|me_metrics_sent_per_minute|me_metrics_dropped_total|otelcol_metrics_received_per_minute|otelcol_metrics_sent_per_minute|otelcol_metrics_dropped_total|otelcol_export_failures_total|invalid_metrics_settings_config" /tmp/ccp_health_metrics.txt
 
-# Check ME-based metrics are > 0 (primary ingestion indicators)
-grep -E "^(timeseries_received|timeseries_sent|bytes_sent)" /tmp/ccp_health_metrics.txt
+# Check overall pipeline metrics are > 0 (primary ingestion indicators)
+grep -E "^overall_(metrics_received|metrics_sent|bytes_sent)" /tmp/ccp_health_metrics.txt
 
-# Check status metrics are 0 (healthy state)
-grep -E "^(invalid_custom_prometheus_config|exporting_metrics_failed)" /tmp/ccp_health_metrics.txt
+# Check status metric is 0 (healthy state)
+grep -E "^invalid_metrics_settings_config" /tmp/ccp_health_metrics.txt
 
 # Check labels include computer, release, controller_type
-grep "timeseries_received_per_minute" /tmp/ccp_health_metrics.txt | head -1
+grep "overall_metrics_received_per_minute" /tmp/ccp_health_metrics.txt | head -1
 ```
 
 ### Step 5.4: Verify CCP Mode in Logs

--- a/otelcollector/test/ccp/ccp-health-metrics-workflow.md
+++ b/otelcollector/test/ccp/ccp-health-metrics-workflow.md
@@ -346,8 +346,6 @@ The following metrics should all be present. They are organized by sub-component
 
 All metrics carry labels: `computer`, `release`, `controller_type`. The `invalid_metrics_settings_config` metric has an additional `error` label.
 
-> **Note:** The code also exposes `overall_metrics_sent_per_minute` which duplicates `me_metrics_sent_per_minute` and should not be relied on for monitoring.
-
 **Validation commands:**
 
 ```bash

--- a/otelcollector/test/ccp/ccp-health-metrics-workflow.md
+++ b/otelcollector/test/ccp/ccp-health-metrics-workflow.md
@@ -332,12 +332,6 @@ The following metrics should all be present. They are organized by sub-component
 | `otelcol_metrics_dropped_total` | Counter | Otelcol `:8888/metrics` | >= 0 |
 | `otelcol_export_failures_total` | Counter | Otelcol logs | >= 0 |
 
-**Cross-pipeline:**
-
-| Metric | Type | Source | Expected Value |
-|--------|------|--------|----------------|
-| `overall_metrics_dropped_total` | Counter | ME logs + Otelcol | >= 0 |
-
 **Configuration validation:**
 
 | Metric | Type | Source | Expected Value |
@@ -350,7 +344,7 @@ All metrics carry labels: `computer`, `release`, `controller_type`. The `invalid
 
 ```bash
 # Check key metrics are present
-grep -cE "me_metrics_received_per_minute|me_metrics_sent_per_minute|me_bytes_sent_per_minute|me_metrics_dropped_total|otelcol_metrics_received_per_minute|otelcol_metrics_sent_per_minute|otelcol_metrics_dropped_total|otelcol_export_failures_total|overall_metrics_dropped_total|invalid_metrics_settings_config" /tmp/ccp_health_metrics.txt
+grep -cE "me_metrics_received_per_minute|me_metrics_sent_per_minute|me_bytes_sent_per_minute|me_metrics_dropped_total|otelcol_metrics_received_per_minute|otelcol_metrics_sent_per_minute|otelcol_metrics_dropped_total|otelcol_export_failures_total|invalid_metrics_settings_config" /tmp/ccp_health_metrics.txt
 
 # Check ME-based metrics are > 0 (primary ingestion indicators)
 grep -E "^me_metrics_(received|sent)_per_minute" /tmp/ccp_health_metrics.txt

--- a/otelcollector/test/ccp/ccp-health-metrics-workflow.md
+++ b/otelcollector/test/ccp/ccp-health-metrics-workflow.md
@@ -346,7 +346,7 @@ The following metrics should all be present. They are organized by sub-component
 
 All metrics carry labels: `computer`, `release`, `controller_type`. The `invalid_metrics_settings_config` metric has an additional `error` label.
 
-> **Note:** The code also exposes `overall_metrics_received_per_minute` and `overall_metrics_sent_per_minute`. These duplicate values already available in the sub-component metrics (`otelcol_metrics_received_per_minute` and `me_metrics_sent_per_minute` respectively) and should not be relied on for monitoring.
+> **Note:** The code also exposes `overall_metrics_sent_per_minute` which duplicates `me_metrics_sent_per_minute` and should not be relied on for monitoring.
 
 **Validation commands:**
 


### PR DESCRIPTION
The CCP health metrics were restructured into a 3-tier model (overall/ME/otelcol) but some old metrics were left in as duplicates. 

Update to leave just the core 10 health metrics: `me_metrics_received_per_minute`, `me_metrics_sent_per_minute`, `me_bytes_sent_per_minute`, `me_metrics_dropped_total`, `otelcol_metrics_received_per_minute`, `otelcol_metrics_sent_per_minute`, `otelcol_metrics_dropped_total`, `otelcol_export_failures_total`, `overall_metrics_dropped_total`, `invalid_metrics_settings_config`.

[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
