### PR TITLE
Fix code bug to remove insecure calls to cadvisor

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -4,6 +4,7 @@ trigger:
     - main
     - bot/otelcollector-upgrade-*
     - dependabot*
+    - rashmi/*
 pr:
   autoCancel: true
   branches:

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -4,7 +4,6 @@ trigger:
     - main
     - bot/otelcollector-upgrade-*
     - dependabot*
-    - rashmi/*
 pr:
   autoCancel: true
   branches:

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -738,8 +738,7 @@ func retrieveKsmData() []byte {
 		Timeout: time.Duration(5) * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs:            caCertPool,
-				InsecureSkipVerify: true,
+				RootCAs: caCertPool,
 			},
 		},
 	}

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -584,6 +584,12 @@ func GetAndSendContainerCPUandMemoryFromCadvisorJSON(container Container, cpuMet
 	cpuUsageNanoCoresLinux := container.Cpu.UsageNanoCores
 	memoryRssBytesLinux := container.Memory.RssBytes
 
+	// Skip sending if both CPU and memory are zero (container just started, no data yet)
+	if cpuUsageNanoCoresLinux == 0 && memoryRssBytesLinux == 0 {
+		Log(fmt.Sprintf("Skipping zero CPU and Mem data for %s (pod: %s)\n", cpuMetricName, podRefName))
+		return
+	}
+
 	// Send metric to app insights for Cpu and Memory Usage for Kube state metrics
 	metricTelemetryItem := appinsights.NewMetricTelemetry(cpuMetricName, cpuUsageNanoCoresLinux)
 
@@ -707,23 +713,24 @@ func getTargetAllocatorResponse(taEndpoint string) []byte {
 	}
 
 	resp, err := client.Get(taEndpoint)
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		Log(fmt.Sprintf("Failed to reach Target Allocator endpoint - %s\n", taEndpoint))
 		SendException(err)
 		return nil
-	} else {
-		Log(fmt.Sprintf("Successfully reached Target Allocator endpoint - %s\n", taEndpoint))
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		Log(fmt.Sprintf("Non-OK status %d from Target Allocator endpoint - %s\n", resp.StatusCode, taEndpoint))
+		return nil
+	}
+	Log(fmt.Sprintf("Successfully reached Target Allocator endpoint - %s\n", taEndpoint))
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		Log(fmt.Sprintf("Error reading response body: %v", err))
 		SendException(err)
 		return nil
-	}
-
-	if resp != nil && resp.Body != nil {
-		defer resp.Body.Close()
 	}
 
 	return body
@@ -736,6 +743,7 @@ func retrieveKsmData() []byte {
 		message := fmt.Sprintf("Error getting certificate - %v\n", err)
 		Log(message)
 		SendException(message)
+		return nil
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -535,16 +535,22 @@ type Container struct {
 
 // Send Cpu and Memory Usage for our containers to Application Insights periodically
 func SendContainersCpuMemoryToAppInsightsMetrics() {
-	var p CadvisorJson
-	err := json.Unmarshal(retrieveKsmData(), &p)
-	if err != nil {
-		message := fmt.Sprintf("Unable to retrieve the unmarshalled Json from Cadvisor- %v\n", err)
-		Log(message)
-		SendException(message)
-	}
-
 	ksmTelemetryTicker := time.NewTicker(time.Second * time.Duration(ksmAttachedTelemetryIntervalSeconds))
 	for ; true; <-ksmTelemetryTicker.C {
+		var p CadvisorJson
+		data := retrieveKsmData()
+		if data == nil {
+			Log("No data returned from cadvisor, skipping this interval\n")
+			continue
+		}
+		err := json.Unmarshal(data, &p)
+		if err != nil {
+			message := fmt.Sprintf("Unable to retrieve the unmarshalled Json from Cadvisor- %v\n", err)
+			Log(message)
+			SendException(message)
+			continue
+		}
+
 		for podId := 0; podId < len(p.Pods); podId++ {
 			podRefName := strings.TrimSpace(p.Pods[podId].PodRef.PodRefName)
 			for containerId := 0; containerId < len(p.Pods[podId].Containers); containerId++ {


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description
Fixing -
1. codeql bug - https://codeql.microsoft.com/issues/84a178da-b2fa-45de-b644-0cd2c4d90fcf?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058
2. bug where cadvisor endpoint was called just once at the beginning instead of every 10 minutes
3. If reading the CA cert fails, the code logs the error but continues to make the request with an empty cert pool, which will always fail with a TLS error.
4. defer resp.Body.Close() was registered after [ioutil.ReadAll]. If ReadAll errors and returns early, the defer was never reached.
5. The kubelet returns usageNanoCores: 0 until it has two cAdvisor samples to compute a rate. These zeros are sent to App Insights as real metric values, which could skew averages.



[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
