### PR TITLE
doc: Update default configmap to v2 schema

### DIFF
--- a/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
+++ b/otelcollector/configmaps/ama-metrics-settings-configmap.yaml
@@ -3,100 +3,103 @@ apiVersion: v1
 data:
   schema-version:
     #string.used by agent to parse config. supported versions are {v1, v2}. Configs with other schema versions will be rejected by the agent.
-    v1
+    v2
   config-version:
     #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
     ver1
+  cluster-metrics: |-
+    default-targets-scrape-enabled: |-
+      kubelet = true
+      coredns = true
+      cadvisor = true
+      kubeproxy = true
+      apiserver = false
+      kubestate = true
+      nodeexporter = true
+      windowsexporter = true
+      windowskubeproxy = true
+      kappiebasic = true
+      networkobservabilityRetina = true
+      networkobservabilityHubble = true
+      networkobservabilityCilium = true
+      acstor-capacity-provisioner = true
+      acstor-metrics-exporter = true
+      local-csi-driver = true
+      ztunnel = false
+      istio-cni = false
+      dcgmexporter = true
+      prometheuscollectorhealth = false
+    pod-annotation-based-scraping: |-
+      podannotationnamespaceregex = ""
+    default-targets-metrics-keep-list: |-
+      kubelet = ""
+      coredns = ""
+      cadvisor = ""
+      kubeproxy = ""
+      apiserver = ""
+      kubestate = ""
+      nodeexporter = ""
+      windowsexporter = ""
+      windowskubeproxy = ""
+      podannotations = ""
+      kappiebasic = ""
+      networkobservabilityRetina = ""
+      networkobservabilityHubble = ""
+      networkobservabilityCilium = ""
+      acstor-capacity-provisioner = ""
+      acstor-metrics-exporter = ""
+      local-csi-driver = ""
+      ztunnel = ""
+      istio-cni = ""
+      dcgmexporter = ""
+    minimal-ingestion-profile: |-
+      enabled = true
+    default-targets-scrape-interval-settings: |-
+      kubelet = "30s"
+      coredns = "30s"
+      cadvisor = "30s"
+      kubeproxy = "30s"
+      apiserver = "30s"
+      kubestate = "30s"
+      nodeexporter = "30s"
+      windowsexporter = "30s"
+      windowskubeproxy = "30s"
+      kappiebasic = "30s"
+      networkobservabilityRetina = "30s"
+      networkobservabilityHubble = "30s"
+      networkobservabilityCilium = "30s"
+      acstor-capacity-provisioner = "30s"
+      acstor-metrics-exporter = "30s"
+      local-csi-driver = "30s"  
+      ztunnel = "30s"
+      istio-cni = "30s"
+      dcgmexporter = "30s"
+      prometheuscollectorhealth = "30s"
+      podannotations = "30s"
+  controlplane-metrics: |-
+    default-targets-scrape-enabled: |-
+      apiserver = true
+      cluster-autoscaler = false
+      node-auto-provisioning = false
+      kube-scheduler = false
+      kube-controller-manager = false
+      etcd = true
+      istio = false
+    default-targets-metrics-keep-list: |-
+      apiserver = ""
+      cluster-autoscaler = ""
+      node-auto-provisioning = ""
+      kube-scheduler = ""
+      kube-controller-manager = ""
+      etcd = ""
+      istio = ""
+    minimal-ingestion-profile: |-
+      enabled = true
   prometheus-collector-settings: |-
     cluster_alias = ""
+    debug-mode = false
     https_config = true
     secrets_access_namespaces = ""
-  default-scrape-settings-enabled: |-
-    kubelet = true
-    coredns = false
-    cadvisor = true
-    kubeproxy = false
-    apiserver = false
-    kubestate = true
-    nodeexporter = true
-    windowsexporter = false
-    windowskubeproxy = false
-    kappiebasic = true
-    networkobservabilityRetina = true
-    networkobservabilityHubble = true
-    networkobservabilityCilium = true
-    prometheuscollectorhealth = false
-    controlplane-apiserver = true
-    controlplane-cluster-autoscaler = false
-    controlplane-node-auto-provisioning = false
-    controlplane-kube-scheduler = false
-    controlplane-kube-controller-manager = false
-    controlplane-etcd = true
-    controlplane-istio = false
-    acstor-capacity-provisioner = true
-    acstor-metrics-exporter = true
-    local-csi-driver = true
-    ztunnel = false
-    istio-cni = false
-    dcgmexporter = true
-  # Regex for which namespaces to scrape through pod annotation based scraping.
-  # This is none by default.
-  # Ex: Use 'namespace1|namespace2' to scrape the pods in the namespaces 'namespace1' and 'namespace2'.
-  pod-annotation-based-scraping: |-
-    podannotationnamespaceregex = ""
-  default-targets-metrics-keep-list: |-
-    kubelet = ""
-    coredns = ""
-    cadvisor = ""
-    kubeproxy = ""
-    apiserver = ""
-    kubestate = ""
-    nodeexporter = ""
-    windowsexporter = ""
-    windowskubeproxy = ""
-    podannotations = ""
-    kappiebasic = ""
-    networkobservabilityRetina = ""
-    networkobservabilityHubble = ""
-    networkobservabilityCilium = ""
-    controlplane-apiserver = ""
-    controlplane-cluster-autoscaler = ""
-    controlplane-node-auto-provisioning = ""
-    controlplane-kube-scheduler = ""
-    controlplane-kube-controller-manager = ""
-    controlplane-etcd = ""
-    controlplane-istio = ""
-    acstor-capacity-provisioner = ""
-    acstor-metrics-exporter = ""
-    local-csi-driver = ""
-    ztunnel = ""
-    istio-cni = ""
-    dcgmexporter = ""
-    minimalingestionprofile = true
-  default-targets-scrape-interval-settings: |-
-    kubelet = "30s"
-    coredns = "30s"
-    cadvisor = "30s"
-    kubeproxy = "30s"
-    apiserver = "30s"
-    kubestate = "30s"
-    nodeexporter = "30s"
-    windowsexporter = "30s"
-    windowskubeproxy = "30s"
-    kappiebasic = "30s"
-    networkobservabilityRetina = "30s"
-    networkobservabilityHubble = "30s"
-    networkobservabilityCilium = "30s"
-    prometheuscollectorhealth = "30s"
-    acstor-capacity-provisioner = "30s"
-    acstor-metrics-exporter = "30s"
-    local-csi-driver = "30s"
-    ztunnel = "30s"
-    istio-cni = "30s"
-    dcgmexporter = "30s"
-    podannotations = "30s"
-  debug-mode: |-
-    enabled = false
   # Note that below section (ksm-config) is a yaml configuration, the settings override the configuration provided by optional parameters during 
   # onboarding for kube-state-metrics, only uncomment and use them if the collection needs to be customized.
   # Default settings - https://github.com/Azure/prometheus-collector/blob/e40947f3eaee8843021c90bd8645ce7875ad1fcf/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml#L2


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
