### PR TITLE
Fix for HPA and PDB for kubernetes version less than 1.27

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-collector-hpa.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-collector-hpa.yaml
@@ -17,6 +17,7 @@ spec:
   minReplicas: {{ $amaMetricsHpa.amaMetricsMinReplicasFromHelper }}
   maxReplicas: {{ $amaMetricsHpa.amaMetricsMaxReplicasFromHelper }}
   metrics:
+{{- if semverCompare ">=1.27.0" .Values.global.commonGlobals.Versions.Kubernetes }}
     - type: ContainerResource
       containerResource:
         name: memory
@@ -24,6 +25,17 @@ spec:
         target:
           averageValue: 5Gi
           type: AverageValue
+{{- else }}
+    # ContainerResource metrics require the HPAContainerMetrics feature gate
+    # (alpha in K8s 1.20, beta/default in 1.27, GA in 1.30). For clusters on
+    # K8s < 1.27, fall back to a pod-level Resource metric.
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          averageValue: 5Gi
+          type: AverageValue
+{{- end }}
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 300

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-pod-disruption-budget.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-pod-disruption-budget.yaml
@@ -11,4 +11,8 @@ spec:
   selector:
     matchLabels:
       rsName: ama-metrics
+  # unhealthyPodEvictionPolicy is alpha in K8s 1.26 (feature gate off by default,
+  # rejected as unknown field), beta/default in 1.27, GA in 1.31. Only emit on >= 1.27.
+{{- if semverCompare ">=1.27.0" .Values.global.commonGlobals.Versions.Kubernetes }}
   unhealthyPodEvictionPolicy: AlwaysAllow
+{{- end }}


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description
This PR fixes the HPA and PDB manifests to conditionally use the right fields based on kubernetes version. This is needed because, the extension migration fails since templates dont render correctly for AKS clusters with versions < 1.27. Because of this the ownership cannot be obtained by extension manager and the clusters end up being owned by addon manager.

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
