### PR TITLE
Update to 1.37 for secret access check instead of 1.36

### DIFF
--- a/.pipelines/azure-pipeline-config-tests.yml
+++ b/.pipelines/azure-pipeline-config-tests.yml
@@ -411,7 +411,7 @@ stages:
               # Detect K8s version and conditionally apply >= 1.37 resources
               KUBE_MINOR=$(kubectl version -o json | jq -r '.serverVersion.minor' | tr -d '+')
               echo "Kubernetes minor version: $KUBE_MINOR"
-              if [ "$KUBE_MINOR" -ge 36 ] 2>/dev/null; then
+              if [ "$KUBE_MINOR" -ge 37 ] 2>/dev/null; then
                 echo "K8s >= 1.37: applying RBAC and settings configmap with secrets_access_namespaces"
                 kubectl apply -f ./test-cluster-yamls/basic-auth/rbac.yaml
                 kubectl apply -f ./test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-basic-auth.yaml
@@ -490,7 +490,7 @@ stages:
 
               # Restore original settings configmap if it was changed (>= 1.37)
               KUBE_MINOR=$(kubectl version -o json | jq -r '.serverVersion.minor' | tr -d '+')
-              if [ "$KUBE_MINOR" -ge 36 ] 2>/dev/null; then
+              if [ "$KUBE_MINOR" -ge 37 ] 2>/dev/null; then
                 kubectl apply -f $(Build.SourcesDirectory)/otelcollector/test/test-cluster-yamls/configmaps/ama-metrics-settings-configmap.yaml
               fi
             displayName: "Create TestKube Results Summary and cleanup basic-auth resources"
@@ -507,7 +507,7 @@ stages:
               # Apply v2 configmap (contains secrets_access_namespaces for >= 1.37)
               KUBE_MINOR=$(kubectl version -o json | jq -r '.serverVersion.minor' | tr -d '+')
               echo "Kubernetes minor version: $KUBE_MINOR"
-              if [ "$KUBE_MINOR" -ge 36 ] 2>/dev/null; then
+              if [ "$KUBE_MINOR" -ge 37 ] 2>/dev/null; then
                 echo "K8s >= 1.37: applying RBAC and v2 settings configmap with secrets_access_namespaces"
                 kubectl apply -f ./test-cluster-yamls/basic-auth/rbac.yaml
                 kubectl apply -f ./test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-basic-auth-v2.yaml

--- a/.pipelines/azure-pipeline-config-tests.yml
+++ b/.pipelines/azure-pipeline-config-tests.yml
@@ -398,9 +398,9 @@ stages:
             condition: always()
 
           # --- Basic Auth ServiceMonitor Tests ---
-          # TODO: When AKS 1.36 becomes available, create a 1.36+ test cluster to validate
+          # TODO: When AKS 1.37 becomes available, create a 1.37+ test cluster to validate
           # the namespaced RBAC path (Role/RoleBinding + secrets_access_namespaces configmap setting)
-          # instead of the cluster-wide secrets access that is used on < 1.36.
+          # instead of the cluster-wide secrets access that is used on < 1.37.
           - bash: |
               # Deploy basic-auth test resources
               kubectl apply -f ./test-cluster-yamls/basic-auth/namespace.yaml
@@ -408,15 +408,15 @@ stages:
               kubectl apply -f ./test-cluster-yamls/basic-auth/deployment.yaml
               kubectl apply -f ./test-cluster-yamls/basic-auth/servicemonitor.yaml
 
-              # Detect K8s version and conditionally apply >= 1.36 resources
+              # Detect K8s version and conditionally apply >= 1.37 resources
               KUBE_MINOR=$(kubectl version -o json | jq -r '.serverVersion.minor' | tr -d '+')
               echo "Kubernetes minor version: $KUBE_MINOR"
               if [ "$KUBE_MINOR" -ge 36 ] 2>/dev/null; then
-                echo "K8s >= 1.36: applying RBAC and settings configmap with secrets_access_namespaces"
+                echo "K8s >= 1.37: applying RBAC and settings configmap with secrets_access_namespaces"
                 kubectl apply -f ./test-cluster-yamls/basic-auth/rbac.yaml
                 kubectl apply -f ./test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-basic-auth.yaml
               else
-                echo "K8s < 1.36: skipping RBAC and settings configmap (cluster-wide secrets access is available)"
+                echo "K8s < 1.37: skipping RBAC and settings configmap (cluster-wide secrets access is available)"
               fi
 
               # Wait for the basic-auth reference app to be ready
@@ -488,7 +488,7 @@ stages:
               # Clean up basic-auth test resources
               kubectl delete namespace basic-auth-test --ignore-not-found
 
-              # Restore original settings configmap if it was changed (>= 1.36)
+              # Restore original settings configmap if it was changed (>= 1.37)
               KUBE_MINOR=$(kubectl version -o json | jq -r '.serverVersion.minor' | tr -d '+')
               if [ "$KUBE_MINOR" -ge 36 ] 2>/dev/null; then
                 kubectl apply -f $(Build.SourcesDirectory)/otelcollector/test/test-cluster-yamls/configmaps/ama-metrics-settings-configmap.yaml
@@ -504,15 +504,15 @@ stages:
               kubectl apply -f ./test-cluster-yamls/basic-auth/deployment.yaml
               kubectl apply -f ./test-cluster-yamls/basic-auth/servicemonitor.yaml
 
-              # Apply v2 configmap (contains secrets_access_namespaces for >= 1.36)
+              # Apply v2 configmap (contains secrets_access_namespaces for >= 1.37)
               KUBE_MINOR=$(kubectl version -o json | jq -r '.serverVersion.minor' | tr -d '+')
               echo "Kubernetes minor version: $KUBE_MINOR"
               if [ "$KUBE_MINOR" -ge 36 ] 2>/dev/null; then
-                echo "K8s >= 1.36: applying RBAC and v2 settings configmap with secrets_access_namespaces"
+                echo "K8s >= 1.37: applying RBAC and v2 settings configmap with secrets_access_namespaces"
                 kubectl apply -f ./test-cluster-yamls/basic-auth/rbac.yaml
                 kubectl apply -f ./test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-basic-auth-v2.yaml
               else
-                echo "K8s < 1.36: applying v2 settings configmap (cluster-wide secrets access is available)"
+                echo "K8s < 1.37: applying v2 settings configmap (cluster-wide secrets access is available)"
                 kubectl apply -f ./test-cluster-yamls/configmaps/default-config-map/ama-metrics-settings-configmap-basic-auth-v2.yaml
               fi
 

--- a/internal/docs/secret-restriction-changes.md
+++ b/internal/docs/secret-restriction-changes.md
@@ -7,14 +7,14 @@ This change removes **cluster-wide secrets access** from the `ama-metrics` Clust
 
 | Area | Before | After |
 |------|--------|-------|
-| **ClusterRole** | Included `get`, `list`, `watch` on `secrets` cluster-wide | On Kubernetes >= 1.36, cluster-wide secrets verbs **removed**. On < 1.36, kept for backward compatibility. |
+| **ClusterRole** | Included `get`, `list`, `watch` on `secrets` cluster-wide | On Kubernetes >= 1.37, cluster-wide secrets verbs **removed**. On < 1.37, kept for backward compatibility. |
 | **Namespace RBAC** | N/A (cluster-wide) | User creates namespaced `Role` + `RoleBinding` in each namespace where secrets are needed |
 | **Target allocator config** | Metadata informer watched secrets in all namespaces | Metadata informer scoped to configured namespaces only |
 
 ### Default Behavior
 
-- **Kubernetes < 1.36:** Cluster-wide secrets access is retained in the ClusterRole for backward compatibility. No additional RBAC is needed.
-- **Kubernetes >= 1.36:** Cluster-wide secrets access is removed from the ClusterRole. By default (no configuration), the target allocator watches **no** namespaces for secrets. Users must configure `secrets_access_namespaces` and create the appropriate Role+RoleBinding in each namespace (see [User Instructions](#user-instructions-basic-auth-with-podservicemonitors) below).
+- **Kubernetes < 1.37:** Cluster-wide secrets access is retained in the ClusterRole for backward compatibility. No additional RBAC is needed.
+- **Kubernetes >= 1.37:** Cluster-wide secrets access is removed from the ClusterRole. By default (no configuration), the target allocator watches **no** namespaces for secrets. Users must configure `secrets_access_namespaces` and create the appropriate Role+RoleBinding in each namespace (see [User Instructions](#user-instructions-basic-auth-with-podservicemonitors) below).
 
 ---
 
@@ -22,7 +22,7 @@ This change removes **cluster-wide secrets access** from the `ama-metrics` Clust
 
 | File | Change |
 |------|--------|
-| `ama-metrics-clusterRole.yaml` | Cluster-wide `secrets` `get`/`list`/`watch` conditionally included only on Kubernetes < 1.36 via `semverCompare` |
+| `ama-metrics-clusterRole.yaml` | Cluster-wide `secrets` `get`/`list`/`watch` conditionally included only on Kubernetes < 1.37 via `semverCompare` |
 | `ama-metrics-settings-configmap*.yaml` (3 files) | Added `secrets_access_namespaces = ""` setting under `prometheus-collector-settings` |
 | `definitions.go` | Added `SecretsAccessNamespaces []string` to `ConfigProcessor` struct |
 | `tomlparser-prometheus-collector-settings.go` | Parses `secrets_access_namespaces` from configmap (comma-separated), writes `AZMON_SECRETS_ACCESS_NAMESPACES` env var |
@@ -142,11 +142,11 @@ data:
 
 > **Note:** Use a comma-separated list for multiple namespaces. Include `kube-system` if you also have secrets there. The setting takes effect after the next pod restart (the configmap is re-read on startup).
 
-### Step 4: Create RBAC in Each Namespace (Kubernetes >= 1.36)
+### Step 4: Create RBAC in Each Namespace (Kubernetes >= 1.37)
 
-On Kubernetes >= 1.36, the ClusterRole no longer grants cluster-wide secrets access. You must create a `Role` and `RoleBinding` in **every** namespace listed in `secrets_access_namespaces` (including `kube-system` if needed).
+On Kubernetes >= 1.37, the ClusterRole no longer grants cluster-wide secrets access. You must create a `Role` and `RoleBinding` in **every** namespace listed in `secrets_access_namespaces` (including `kube-system` if needed).
 
-> **Kubernetes < 1.36:** This step is **not required** — the ClusterRole still includes cluster-wide secrets access for backward compatibility.
+> **Kubernetes < 1.37:** This step is **not required** — the ClusterRole still includes cluster-wide secrets access for backward compatibility.
 
 Apply the following in each namespace. Replace `my-app` with the target namespace:
 
@@ -206,7 +206,7 @@ If you have secrets in `my-app`, `backend`, and `monitoring`:
    secrets_access_namespaces = "kube-system,my-app,backend,monitoring"
    ```
 
-2. **RBAC (>= 1.36 only):** Create the Role + RoleBinding (from Step 4) in each of `my-app`, `backend`, and `monitoring`.
+2. **RBAC (>= 1.37 only):** Create the Role + RoleBinding (from Step 4) in each of `my-app`, `backend`, and `monitoring`.
 
 ---
 

--- a/otelcollector/configuration-reader-builder/main.go
+++ b/otelcollector/configuration-reader-builder/main.go
@@ -131,7 +131,7 @@ func updateTAConfigFile(configFilePath string, httpsEnabled bool) {
 
 	// Determine secrets access namespaces.
 	// Default: watch all namespaces for secrets (backward-compatible behavior).
-	// On Kubernetes >= 1.36: use the explicit configmap setting instead.
+	// On Kubernetes >= 1.37: use the explicit configmap setting instead.
 	secretsAccessNamespaces := []string{""}
 	log.Println("Defaulting to watch all namespaces for secrets")
 
@@ -140,8 +140,8 @@ func updateTAConfigFile(configFilePath string, httpsEnabled bool) {
 	if kubeVersion != "" && kubeVersionErr != nil {
 		log.Printf("Failed to parse Kubernetes version %q: %v, defaulting to watch all namespaces\n", kubeVersion, kubeVersionErr)
 	}
-	if kubeVersion != "" && kubeVersionErr == nil && !parsedKubeVersion.LessThan(utilversion.MustParseSemantic("v1.36.0")) {
-		// On >= 1.36, read the scoped namespace list from the configmap setting.
+	if kubeVersion != "" && kubeVersionErr == nil && !parsedKubeVersion.LessThan(utilversion.MustParseSemantic("v1.37.0")) {
+		// On >= 1.37, read the scoped namespace list from the configmap setting.
 		secretsAccessNamespaces = nil
 		if sns := os.Getenv("AZMON_SECRETS_ACCESS_NAMESPACES"); sns != "" {
 			for _, ns := range strings.Split(sns, ",") {
@@ -150,12 +150,12 @@ func updateTAConfigFile(configFilePath string, httpsEnabled bool) {
 					secretsAccessNamespaces = append(secretsAccessNamespaces, ns)
 				}
 			}
-			log.Printf("Kubernetes version %s >= 1.36: SecretsAccessNamespaces from configmap: %v\n", kubeVersion, secretsAccessNamespaces)
+			log.Printf("Kubernetes version %s >= 1.37: SecretsAccessNamespaces from configmap: %v\n", kubeVersion, secretsAccessNamespaces)
 		} else {
-			log.Printf("Kubernetes version %s >= 1.36: no secrets_access_namespaces configured, no namespaces will be watched for secrets\n", kubeVersion)
+			log.Printf("Kubernetes version %s >= 1.37: no secrets_access_namespaces configured, no namespaces will be watched for secrets\n", kubeVersion)
 		}
 	} else if kubeVersion != "" && kubeVersionErr == nil {
-		log.Printf("Kubernetes version %s < 1.36: watching all namespaces for secrets\n", kubeVersion)
+		log.Printf("Kubernetes version %s < 1.37: watching all namespaces for secrets\n", kubeVersion)
 	}
 
 	if os.Getenv("AZMON_OPERATOR_HTTPS_ENABLED") == "true" && httpsEnabled {

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-clusterRole.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-clusterRole.yaml
@@ -26,9 +26,9 @@ rules:
     resources: ["secrets"]
     resourceNames: ["aad-msi-auth-token", "ama-metrics-mtls-secret"]
     verbs: ["get", "watch"]
-  # For Kubernetes < 1.36, keep cluster-wide secrets access for basic auth in pod/service monitors.
-  # For >= 1.36, secrets access is scoped to specific namespaces via namespaced Role+RoleBinding.
-{{- if semverCompare "<1.36.0" .Values.global.commonGlobals.Versions.Kubernetes }}
+  # For Kubernetes < 1.37, keep cluster-wide secrets access for basic auth in pod/service monitors.
+  # For >= 1.37, secrets access is scoped to specific namespaces via namespaced Role+RoleBinding.
+{{- if semverCompare "<1.37.0" .Values.global.commonGlobals.Versions.Kubernetes }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]

--- a/otelcollector/test/ginkgo-e2e/configprocessing/config_processing_test.go
+++ b/otelcollector/test/ginkgo-e2e/configprocessing/config_processing_test.go
@@ -909,13 +909,13 @@ var _ = Describe("Basic auth ServiceMonitor scraping", Label(utils.ConfigProcess
 			}
 		}
 
-		if parsedVersion.LessThan(utilversion.MustParseSemantic("v1.36.0")) {
-			GinkgoWriter.Printf("[BasicAuth] K8s < 1.36: expecting generic secrets rule in ClusterRole\n")
-			Expect(hasGenericSecretsRule).To(BeTrue(), "On K8s < 1.36, ClusterRole ama-metrics-reader should have a generic secrets get/list/watch rule")
+		if parsedVersion.LessThan(utilversion.MustParseSemantic("v1.37.0")) {
+			GinkgoWriter.Printf("[BasicAuth] K8s < 1.37: expecting generic secrets rule in ClusterRole\n")
+			Expect(hasGenericSecretsRule).To(BeTrue(), "On K8s < 1.37, ClusterRole ama-metrics-reader should have a generic secrets get/list/watch rule")
 			GinkgoWriter.Printf("[BasicAuth] ClusterRole secrets rule check passed\n")
 		} else {
-			GinkgoWriter.Printf("[BasicAuth] K8s >= 1.36: expecting NO generic secrets rule in ClusterRole\n")
-			Expect(hasGenericSecretsRule).To(BeFalse(), "On K8s >= 1.36, ClusterRole ama-metrics-reader should NOT have a generic secrets get/list/watch rule")
+			GinkgoWriter.Printf("[BasicAuth] K8s >= 1.37: expecting NO generic secrets rule in ClusterRole\n")
+			Expect(hasGenericSecretsRule).To(BeFalse(), "On K8s >= 1.37, ClusterRole ama-metrics-reader should NOT have a generic secrets get/list/watch rule")
 
 			// Verify namespaced Role and RoleBinding exist
 			GinkgoWriter.Printf("[BasicAuth] Checking namespaced Role and RoleBinding in basic-auth-test...\n")
@@ -1104,13 +1104,13 @@ var _ = Describe("Basic auth ServiceMonitor scraping (v2)", Label(utils.ConfigPr
 			}
 		}
 
-		if parsedVersion.LessThan(utilversion.MustParseSemantic("v1.36.0")) {
-			GinkgoWriter.Printf("[BasicAuthV2] K8s < 1.36: expecting generic secrets rule in ClusterRole\n")
-			Expect(hasGenericSecretsRule).To(BeTrue(), "On K8s < 1.36, ClusterRole ama-metrics-reader should have a generic secrets get/list/watch rule")
+		if parsedVersion.LessThan(utilversion.MustParseSemantic("v1.37.0")) {
+			GinkgoWriter.Printf("[BasicAuthV2] K8s < 1.37: expecting generic secrets rule in ClusterRole\n")
+			Expect(hasGenericSecretsRule).To(BeTrue(), "On K8s < 1.37, ClusterRole ama-metrics-reader should have a generic secrets get/list/watch rule")
 			GinkgoWriter.Printf("[BasicAuthV2] ClusterRole secrets rule check passed\n")
 		} else {
-			GinkgoWriter.Printf("[BasicAuthV2] K8s >= 1.36: expecting NO generic secrets rule in ClusterRole\n")
-			Expect(hasGenericSecretsRule).To(BeFalse(), "On K8s >= 1.36, ClusterRole ama-metrics-reader should NOT have a generic secrets get/list/watch rule")
+			GinkgoWriter.Printf("[BasicAuthV2] K8s >= 1.37: expecting NO generic secrets rule in ClusterRole\n")
+			Expect(hasGenericSecretsRule).To(BeFalse(), "On K8s >= 1.37, ClusterRole ama-metrics-reader should NOT have a generic secrets get/list/watch rule")
 
 			GinkgoWriter.Printf("[BasicAuthV2] Checking namespaced Role and RoleBinding in basic-auth-test...\n")
 			role, err := utils.GetRole(K8sClient, "basic-auth-test", "ama-metrics-secrets-reader")

--- a/otelcollector/test/test-cluster-yamls/basic-auth/rbac.yaml
+++ b/otelcollector/test/test-cluster-yamls/basic-auth/rbac.yaml
@@ -1,5 +1,5 @@
-# RBAC for namespace-scoped secrets access (required on Kubernetes >= 1.36)
-# On < 1.36 these resources are not applied by the pipeline.
+# RBAC for namespace-scoped secrets access (required on Kubernetes >= 1.37)
+# On < 1.37 these resources are not applied by the pipeline.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description
Update the check to use 1.37 instead of 1.36 since security review board pushed back that we need to provide additional time for the customers to make necessary changes

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
