### PR TITLE
Add new Go stdlib CVEs to .trivyignore (CVE-2026-42504, CVE-2026-27145, CVE-2026-42507)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -12,6 +12,7 @@ CVE-2026-33814 #stdlib - net/http HTTP/2 SETTINGS frames cause infinite loop in 
 CVE-2026-39820 #stdlib - net/mail ParseAddress/ParseAddressList input handling vulnerability (v1.25.9 -> 1.25.10, 1.26.3)
 CVE-2026-39836 #stdlib - net panic in Dial and LookupPort when handling NUL byte on Windows (v1.25.9 -> 1.25.10, 1.26.3)
 CVE-2026-42499 #stdlib - net/mail DoS via consumePhrase when parsing pathological inputs (v1.25.9 -> 1.25.10, 1.26.3)
+CVE-2026-42504 #stdlib - net/textproto DoS decoding maliciously-crafted MIME header containing many invalid encoded-words (v1.25.9 -> 1.25.11, 1.26.4)
 
 # MEDIUM
 # gobinary - target-allocator
@@ -24,6 +25,8 @@ CVE-2026-44903 #github.com/prometheus/prometheus - Stored XSS via crafted histog
 CVE-2026-39823 #stdlib - net/url incomplete URL parsing fix (extends CVE-2026-27142) (v1.25.9 -> 1.25.10, 1.26.3)
 CVE-2026-39825 #stdlib - net/http/httputil ReverseProxy forwards hidden query parameters (v1.25.9 -> 1.25.10, 1.26.3)
 CVE-2026-39826 #stdlib - html/template stored XSS via crafted script tag content (v1.25.9 -> 1.25.10, 1.26.3)
+CVE-2026-27145 #stdlib - crypto/x509 (*Certificate).VerifyHostname hostname matching regression in matchHostnames (v1.25.9 -> 1.25.11, 1.26.4)
+CVE-2026-42507 #stdlib - net/textproto misleading error messages via input injection (v1.25.9 -> 1.25.11, 1.26.4)
 # os-pkgs - openssl/openssl-libs (azurelinux 3.0, 3.3.5-4.azl3 -> 3.3.5-5.azl3)
 CVE-2026-28388 #openssl - DoS due to NULL pointer dereference in delta CRL processing
 CVE-2026-28389 #openssl - DoS vulnerability in CMS processing


### PR DESCRIPTION
## What

Adds three Go **stdlib** CVEs to .trivyignore, flagged by the Trivy HIGH/MEDIUM gate against the pinned Go `1.25.9` toolchain:

| CVE | Severity | stdlib area | Fixed in |
|-----|----------|-------------|----------|
| CVE-2026-42504 | HIGH | net/textproto MIME header decode DoS | 1.25.11 / 1.26.4 |
| CVE-2026-27145 | MEDIUM | crypto/x509 VerifyHostname | 1.25.11 / 1.26.4 |
| CVE-2026-42507 | MEDIUM | net/textproto misleading errors | 1.25.11 / 1.26.4 |

## Why

These newly-published advisories are failing the `trivy image --severity HIGH,CRITICAL,MEDIUM --exit-code 1` build gate on unrelated PRs (e.g. #1579, a release-notes-only change). They are **not** yet present on `main` — `main` only ignores the prior stdlib batch (fixed in 1.25.10/1.26.3).

This follows the repo's established convention (see `internal/otel-upgrade-scripts/updatetrivyignore.sh` / `otelcollector-upgrade.yml`, which auto-commit new CVEs to `.trivyignore`). Entries are appended to the existing stdlib groups with their specific fix version noted.

## Follow-up (proper remediation)

Bump `GOLANG_VERSION` / `FLUENTBIT_GOLANG_VERSION` / `TESTKUBE_GOLANG_VERSION` in `.pipelines/azure-pipeline-build.yml` from `1.25.9` to `1.25.11+` (or 1.26.4) to actually patch the stdlib and clear both this batch and the previously-ignored one.