### PR TITLE
ci: disable linux python reference app build (pypi.org egress failure)

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -412,91 +412,93 @@ extends:
           workingDirectory: $(Build.ArtifactStagingDirectory)/refappgolanglinux/
           displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/refappgolanglinux/"
           condition: succeeded()
-      - job: Linux_Python_Reference_App
-        displayName: "Build: linux python reference app image"
-        pool:
-          name: Azure-Pipelines-CI-Test-EO
-          image: ci-1es-managed-ubuntu-2204
-          os: linux
-        dependsOn: Image_Tags_and_Ev2_Artifacts
-        variables:
-          skipComponentGovernanceDetection: true
-          LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME'] ]
-          DOCKER_BUILDKIT: 1
-        condition: and(succeeded(), or(eq(variables.IS_PR, true), eq(variables.IS_MAIN_BRANCH, true)))
-        steps:
-        - checkout: self
-          persistCredentials: true
-        - bash: |
-            mkdir -p $(Build.ArtifactStagingDirectory)/refapppythonlinux
-            docker pull mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1
-            docker buildx create --name dockerbuilder --driver docker-container --driver-opt image=mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1 --use 
-            docker buildx inspect --bootstrap
-            docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
-            docker buildx build . --file linux/Dockerfile -t $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) --build-arg "GOLANG_VERSION=$(GOLANG_VERSION)" --metadata-file $(Build.ArtifactStagingDirectory)/refapppythonlinux/metadata.json --push
-            docker pull $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME)  
-          workingDirectory: $(Build.SourcesDirectory)/internal/referenceapp/python
-          displayName: "Build: build and push reference app python linux image to dev ACR"
-        - bash: |
-            MEDIA_TYPE=$(docker manifest inspect -v $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) | jq '.Descriptor.mediaType')
-            DIGEST=$(docker manifest inspect -v $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) | jq '.Descriptor.digest')
-            SIZE=$(docker manifest inspect -v $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) | jq '.Descriptor.size')
-            cat <<EOF >>$(Build.ArtifactStagingDirectory)/refapppythonlinux/payload.json
-            {"targetArtifact":{"mediaType":$MEDIA_TYPE,"digest":$DIGEST,"size":$SIZE}}
-            EOF
-          workingDirectory: $(Build.SourcesDirectory)/internal/referenceapp/python
-          displayName: "Build: Set values in payload.json for signing"
-          condition: succeeded()
-        - task: EsrpCodeSigning@5
-          displayName: "ESRP CodeSigning for Prometheus Python Linux Reference App"
-          inputs:
-            ConnectedServiceName: "ESRPServiceConnectionPrometheus"
-            UseMSIAuthentication: true
-            AppRegistrationClientId: 'bf21d5fe-78bd-45d2-b04d-c61f2e090c9a'
-            AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
-            EsrpClientId: "73f8d5f9-b507-497f-b698-4ed00fcba5a3"
-            AuthAKVName: 'ESRPPrometheusKVProd'
-            AuthCertName: 'ESRPContainerImageSignCert'
-            AuthSignCertName: 'ESRPReqPrometheusProdCert'
-            FolderPath: $(Build.ArtifactStagingDirectory)/refapppythonlinux/
-            Pattern: "*.json"
-            signConfigType: inlineSignParams
-            inlineOperation: |
-              [
-                {
-                    "keyCode": "CP-469451",
-                    "operationSetCode": "NotaryCoseSign",
-                    "parameters": [
-                      {
-                        "parameterName": "CoseFlags",
-                        "parameterValue": "chainunprotected"
-                      }
-                    ],
-                    "toolName": "sign",
-                    "toolVersion": "1.0"
-                }
-              ]
-            SessionTimeout: '60'
-            MaxConcurrency: '50'
-            MaxRetryAttempts: '5'
-            PendingAnalysisWaitTimeoutMinutes: '5'
-        - bash: |
-            set -euxo pipefail
-            curl -LO "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz"
-            mkdir -p oras-install/
-            tar -zxf oras_1.0.0_*.tar.gz -C oras-install/
-            sudo mv oras-install/oras /usr/local/bin/
-            rm -rf oras_1.0.0_*.tar.gz oras-install/
-            oras attach $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) \
-              --artifact-type 'application/vnd.cncf.notary.signature' \
-              ./payload.json:application/cose \
-              -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
-            oras attach $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) \
-              --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
-              --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"
-          workingDirectory: $(Build.ArtifactStagingDirectory)/refapppythonlinux/
-          displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/refapppythonlinux/"
-          condition: succeeded()
+        # Disabled: pypi.org is unreachable from the 1ES CI agents, so 'pip install' in linux/Dockerfile fails with connect timeouts and breaks every build.
+        # Mirrors PR #1390, which disabled the Windows python reference app for the same reason. Re-enable once egress to pypi.org (or an approved mirror) is restored.
+        # - job: Linux_Python_Reference_App
+        #   displayName: "Build: linux python reference app image"
+        #   pool:
+        #     name: Azure-Pipelines-CI-Test-EO
+        #     image: ci-1es-managed-ubuntu-2204
+        #     os: linux
+        #   dependsOn: Image_Tags_and_Ev2_Artifacts
+        #   variables:
+        #     skipComponentGovernanceDetection: true
+        #     LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME: $[ dependencies.Image_Tags_and_Ev2_Artifacts.outputs['setup.LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME'] ]
+        #     DOCKER_BUILDKIT: 1
+        #   condition: and(succeeded(), or(eq(variables.IS_PR, true), eq(variables.IS_MAIN_BRANCH, true)))
+        #   steps:
+        #   - checkout: self
+        #     persistCredentials: true
+        #   - bash: |
+        #       mkdir -p $(Build.ArtifactStagingDirectory)/refapppythonlinux
+        #       docker pull mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1
+        #       docker buildx create --name dockerbuilder --driver docker-container --driver-opt image=mcr.microsoft.com/azuremonitor/containerinsights/cidev/prometheus-collector/images:buildx-stable-1 --use 
+        #       docker buildx inspect --bootstrap
+        #       docker login containerinsightsprod.azurecr.io -u $(ACR_USERNAME) -p $(ACR_PASSWORD)
+        #       docker buildx build . --file linux/Dockerfile -t $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) --build-arg "GOLANG_VERSION=$(GOLANG_VERSION)" --metadata-file $(Build.ArtifactStagingDirectory)/refapppythonlinux/metadata.json --push
+        #       docker pull $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME)  
+        #     workingDirectory: $(Build.SourcesDirectory)/internal/referenceapp/python
+        #     displayName: "Build: build and push reference app python linux image to dev ACR"
+        #   - bash: |
+        #       MEDIA_TYPE=$(docker manifest inspect -v $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) | jq '.Descriptor.mediaType')
+        #       DIGEST=$(docker manifest inspect -v $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) | jq '.Descriptor.digest')
+        #       SIZE=$(docker manifest inspect -v $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) | jq '.Descriptor.size')
+        #       cat <<EOF >>$(Build.ArtifactStagingDirectory)/refapppythonlinux/payload.json
+        #       {"targetArtifact":{"mediaType":$MEDIA_TYPE,"digest":$DIGEST,"size":$SIZE}}
+        #       EOF
+        #     workingDirectory: $(Build.SourcesDirectory)/internal/referenceapp/python
+        #     displayName: "Build: Set values in payload.json for signing"
+        #     condition: succeeded()
+        #   - task: EsrpCodeSigning@5
+        #     displayName: "ESRP CodeSigning for Prometheus Python Linux Reference App"
+        #     inputs:
+        #       ConnectedServiceName: "ESRPServiceConnectionPrometheus"
+        #       UseMSIAuthentication: true
+        #       AppRegistrationClientId: 'bf21d5fe-78bd-45d2-b04d-c61f2e090c9a'
+        #       AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
+        #       EsrpClientId: "73f8d5f9-b507-497f-b698-4ed00fcba5a3"
+        #       AuthAKVName: 'ESRPPrometheusKVProd'
+        #       AuthCertName: 'ESRPContainerImageSignCert'
+        #       AuthSignCertName: 'ESRPReqPrometheusProdCert'
+        #       FolderPath: $(Build.ArtifactStagingDirectory)/refapppythonlinux/
+        #       Pattern: "*.json"
+        #       signConfigType: inlineSignParams
+        #       inlineOperation: |
+        #         [
+        #           {
+        #               "keyCode": "CP-469451",
+        #               "operationSetCode": "NotaryCoseSign",
+        #               "parameters": [
+        #                 {
+        #                   "parameterName": "CoseFlags",
+        #                   "parameterValue": "chainunprotected"
+        #                 }
+        #               ],
+        #               "toolName": "sign",
+        #               "toolVersion": "1.0"
+        #           }
+        #         ]
+        #       SessionTimeout: '60'
+        #       MaxConcurrency: '50'
+        #       MaxRetryAttempts: '5'
+        #       PendingAnalysisWaitTimeoutMinutes: '5'
+        #   - bash: |
+        #       set -euxo pipefail
+        #       curl -LO "https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz"
+        #       mkdir -p oras-install/
+        #       tar -zxf oras_1.0.0_*.tar.gz -C oras-install/
+        #       sudo mv oras-install/oras /usr/local/bin/
+        #       rm -rf oras_1.0.0_*.tar.gz oras-install/
+        #       oras attach $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) \
+        #         --artifact-type 'application/vnd.cncf.notary.signature' \
+        #         ./payload.json:application/cose \
+        #         -a "io.cncf.notary.x509chain.thumbprint#S256=[\"79E6A702361E1F60DAA84AEEC4CBF6F6420DE6BA\"]"
+        #       oras attach $(LINUX_REF_APP_PYTHON_FULL_IMAGE_NAME) \
+        #         --artifact-type 'application/vnd.microsoft.artifact.lifecycle' \
+        #         --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$(date -u -d '-1 hour' +"%Y-%m-%dT%H:%M:%SZ")"
+        #     workingDirectory: $(Build.ArtifactStagingDirectory)/refapppythonlinux/
+        #     displayName: "ORAS Push Artifacts in $(Build.ArtifactStagingDirectory)/refapppythonlinux/"
+        #     condition: succeeded()
       - job: Golang_Windows_Reference_App
         displayName: "Build: windows golang reference app image"
         pool:


### PR DESCRIPTION
## Problem

Every `Azure.prometheus-collector` build has failed since ~2026-06-15. On otherwise-green PRs (e.g. #1582, #1583) the **only** remaining red leg is **`Build: linux python reference app image`**.

It fails in the Docker build at:

```
#10 [3/4] RUN pip install prometheus-client opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
  WARNING: Retrying ... 'Connection to pypi.org timed out. (connect timeout=15)'   (x5)
  ERROR: Could not find a version that satisfies the requirement prometheus-client
ERROR: failed to solve: process "/bin/sh -c pip install ..." did not complete successfully: exit code: 1
```

The 1ES CI agents can no longer reach **pypi.org**, so the `pip install` in `internal/referenceapp/python/linux/Dockerfile` fails with connect timeouts (5 built-in retries exhausted). This is purely environmental — re-running does not help (multiple consecutive builds fail identically).

## Fix

Comment out the `Linux_Python_Reference_App` job in `.pipelines/azure-pipeline-build.yml`, **mirroring PR #1390**, which disabled the *Windows* python reference app for this exact pypi.org reason.

### Why this is safe
- The job is a **leaf** — no other job has `dependsOn: Linux_Python_Reference_App`.
- The reference-app test manifests under `internal/referenceapp/*.yaml` **pin previously-published image tags** (e.g. `…-ref-app-python`), not the per-PR build output, so no test/deploy stage consumes this job's artifact.
- The python reference app is single-arch (amd64), so no multi-arch manifest-combine job depends on it.

### Scope
- Touches only `.pipelines/azure-pipeline-build.yml` (the PR/CI build pipeline that gates merges), exactly as PR #1390 did. The official release pipeline (`OneBranch.Official.yml`) is intentionally left unchanged, consistent with that precedent.

Re-enable this job once egress to pypi.org (or an approved internal mirror) is restored.

## Validation
- `git diff` is scoped to the single job block (85 lines commented + 2-line reason comment).
- YAML still parses (`yaml.safe_load`).
