### PR TITLE
Fix upgrade bot where auto creattion of upgrade prs are failing due to go mod restructuting

### DIFF
--- a/internal/otel-upgrade-scripts/upgrade.sh
+++ b/internal/otel-upgrade-scripts/upgrade.sh
@@ -218,6 +218,18 @@ rm -rf otelcollector/otel-allocator
 mkdir -p otelcollector/otel-allocator
 cp -r opentelemetry-operator/cmd/otel-allocator/* otelcollector/otel-allocator/
 
+# Upstream opentelemetry-operator (>= v0.151.0) split the `apis` package into its
+# own go sub-module and the root go.mod references it via:
+#     replace github.com/open-telemetry/opentelemetry-operator/apis v0.0.0-unpublished => ./apis
+# Since we vendor only cmd/otel-allocator/* plus the root go.mod, we must also
+# carry the sibling apis/ sub-module so the relative replace path resolves and
+# `go mod tidy` doesn't fail with "reading apis/go.mod: no such file or directory".
+if [ -f "opentelemetry-operator/apis/go.mod" ]; then
+	echo "Copying opentelemetry-operator/apis sub-module into otel-allocator/apis"
+	mkdir -p otelcollector/otel-allocator/apis
+	cp -r opentelemetry-operator/apis/. otelcollector/otel-allocator/apis/
+fi
+
 echo "Restoring custom Dockerfile and Makefile"
 cp otelcollector/Dockerfile.backup otelcollector/otel-allocator/Dockerfile
 rm otelcollector/Dockerfile.backup
@@ -235,7 +247,10 @@ fi
 cd otelcollector/otel-allocator
 cp "$CURRENT_DIR/opentelemetry-operator/go.mod" .
 sed -i '1s#.*#module github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator#' go.mod
-go mod tidy
+if ! go mod tidy; then
+	echo "ERROR: go mod tidy failed in otelcollector/otel-allocator. This usually means upstream opentelemetry-operator restructured its modules (e.g. split out apis/ or another sub-module). Inspect the operator root go.mod for new relative './<path>' replace directives and update upgrade.sh to vendor those directories too." >&2
+	exit 1
+fi
 #make
 #rm -f targetallocator
 cd "$CURRENT_DIR"


### PR DESCRIPTION
…solves

Upstream open-telemetry/opentelemetry-operator >= v0.151.0 split the apis package into its own go sub-module. The root go.mod now contains:

  replace github.com/open-telemetry/opentelemetry-operator/apis v0.0.0-unpublished => ./apis

Our upgrade.sh only vendored cmd/otel-allocator/* plus the operator root go.mod, so the relative ./apis replace path was dangling and go mod tidy failed with hundreds of import-chain errors of the form:

  reading apis/go.mod: open .../otelcollector/otel-allocator/apis/go.mod: no such file or directory

This was breaking the nightly otelcollector-upgrade scheduled workflow (run 28084644586) when bumping v0.150.0 -> v0.153.0.

Fix:
- Copy opentelemetry-operator/apis/ into otelcollector/otel-allocator/apis/ when the upstream apis sub-module exists, so the relative replace directive resolves.
- Fail-fast on go mod tidy errors with a clear message pointing future debuggers at the next upstream restructure rather than burying the cause under a long import chain.


[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
