### PR TITLE
fix(otel-upgrade): authenticate GitHub API calls to avoid rate-limit for curl calls

### DIFF
--- a/.github/workflows/otelcollector-upgrade.yml
+++ b/.github/workflows/otelcollector-upgrade.yml
@@ -19,6 +19,11 @@ jobs:
 
       - name: Upgrade otel
         id: upgrade
+        env:
+          # Forward an authenticated token to the script's curl calls so we don't
+          # hit the 60 req/hour anonymous GitHub API rate limit on shared
+          # GitHub-hosted runner egress IPs.
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           CURRENT_VERSION=$(cat OPENTELEMETRY_VERSION)
           bash -x ./internal/otel-upgrade-scripts/check-otel-version.sh

--- a/internal/otel-upgrade-scripts/check-otel-version.sh
+++ b/internal/otel-upgrade-scripts/check-otel-version.sh
@@ -22,9 +22,18 @@ fi
 # GitHub API URL for the repository releases
 API_URL="https://api.github.com/repos/open-telemetry/opentelemetry-operator/releases/latest"
 
+# Build authenticated curl args when a token is available, to avoid hitting the
+# 60 req/hour anonymous rate limit on shared GitHub-hosted runner egress IPs.
+GH_AUTH_ARGS=()
+if [ -n "${GH_TOKEN:-}" ]; then
+    GH_AUTH_ARGS=(-H "Authorization: Bearer $GH_TOKEN")
+elif [ -n "${GITHUB_TOKEN:-}" ]; then
+    GH_AUTH_ARGS=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+
 # Fetch the latest release information
 echo "Fetching the latest release of opentelemetry-collector-operator..."
-RESPONSE=$(curl -s $API_URL)
+RESPONSE=$(curl -s "${GH_AUTH_ARGS[@]}" "$API_URL")
 
 # Check if curl command was successful
 if [ $? -ne 0 ]; then
@@ -55,7 +64,7 @@ echo -e "\nChecking for matching release in opentelemetry-collector repository..
 COLLECTOR_API_URL="https://api.github.com/repos/open-telemetry/opentelemetry-collector/releases"
 
 # Fetch releases for the collector repository
-COLLECTOR_RESPONSE=$(curl -s "$COLLECTOR_API_URL")
+COLLECTOR_RESPONSE=$(curl -s "${GH_AUTH_ARGS[@]}" "$COLLECTOR_API_URL")
 
 # Check if curl command was successful
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
…failures

The nightly otelcollector-upgrade workflow was failing intermittently during the 'Upgrade otel' step (e.g. run 28123861714) with:

  API rate limit exceeded for <runner-ip>
  Error: Could not extract version information
  exit 1

GitHub-hosted runners share egress IPs with thousands of other workflows, so check-otel-version.sh's unauthenticated curl calls to api.github.com hit the 60 req/hour anonymous limit routinely.

Fix:
- Forward the existing GitHub App-generated token to the Upgrade otel step as GH_TOKEN.
- Have check-otel-version.sh add 'Authorization: Bearer \' (falling back to GITHUB_TOKEN) to its api.github.com curl requests when a token is set. The authenticated limit is 5000 req/hour, removing this failure mode.


[comment]: # (Note that your PR title should follow the conventional commit format: https://conventionalcommits.org/en/v1.0.0/#summary)
# PR Description

[comment]: # (The below checklist is for PRs adding new features. If a box is not checked, add a reason why it's not needed.)
# New Feature Checklist

- [ ] List telemetry added about the feature.
- [ ] Link to the one-pager about the feature.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR.
- [ ] Attach results of scale and perf testing.

[comment]: # (The below checklist is for code changes. Not all boxes necessarily need to be checked. Build, doc, and template changes do not need to fill out the checklist.)
# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? To bootstrap your cluster to run the tests, follow [these instructions](/otelcollector/test/README.md#bootstrap-a-dev-cluster-to-run-ginkgo-tests).
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [ ] Have new tests been added? For features, have tests been added for this feature? For fixes, is there a test that could have caught this issue and could validate that the fix works?
  - [ ] Is a new scrape job needed?
    - [ ] The scrape job was added to the folder [test-cluster-yamls](/otelcollector/test/test-cluster-yamls/) in the correct configmap or as a CR. 
  - [ ] Was a new test label added?
    - [ ] A string constant for the label was added to [constants.go](/otelcollector/test/utils/constants.go).
    - [ ] The label and description was added to the [test README](/otelcollector/test/README.md).
    - [ ] The label was added to this [PR checklist](/.github/pull_request_template).
    - [ ] The label was added as needed to [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
  - [ ] Are additional API server permissions needed for the new tests?
    - [ ] These permissions have been added to [api-server-permissions.yaml](/otelcollector/test/testkube/api-server-permissions.yaml).
  - [ ] Was a new test suite (a new folder under `/tests`) added?
    - [ ] The new test suite is included in [testkube-test-crs.yaml](/otelcollector/test/testkube/testkube-test-crs.yaml).
