### PR TITLE
Suppress openssl azurelinux 3.0 CVEs in .trivyignore pending base image rebuild

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -35,6 +35,11 @@ CVE-2026-46597 #golang.org/x/crypto/ssh - incorrectly placed cast from bytes to 
 # gobinary - stdlib (target-allocator, otelcollector, promconfigvalidator, configurationreader, ccp-prometheus-collector)
 CVE-2026-27145 #stdlib - crypto/x509 (*Certificate).VerifyHostname matching regression (v1.25.9 -> 1.25.11, 1.26.4)
 CVE-2026-42504 #stdlib - net/textproto DoS decoding crafted MIME header (v1.25.9 -> 1.25.11, 1.26.4)
+# os-pkgs - openssl/openssl-libs (azurelinux 3.0, 3.3.5-5.azl3 -> 3.3.7-3.azl3, suppress pending base image rebuild)
+CVE-2026-34180 #openssl - Heap buffer over-read in ASN.1 decoding can lead to DoS
+CVE-2026-7383 #openssl - Heap buffer overflow due to signed integer overflow in Unicode processing
+CVE-2026-9076 #openssl - DoS due to heap out-of-bounds read in CMS
+CVE-2026-45445 #openssl - AES-OCB IV ignored on EVP_Cipher() path
 
 # MEDIUM
 # gobinary - target-allocator
@@ -53,6 +58,11 @@ CVE-2026-28389 #openssl - DoS vulnerability in CMS processing
 CVE-2026-28390 #openssl - DoS due to NULL pointer dereference in CMS
 CVE-2026-31789 #openssl - Heap buffer overflow on 32-bit systems from large X.509 certificate
 CVE-2026-31790 #openssl - Information disclosure from uninitialized memory via invalid RSA public key
+# os-pkgs - openssl/openssl-libs (azurelinux 3.0, 3.3.5-5.azl3 -> 3.3.7-3.azl3, suppress pending base image rebuild)
+CVE-2026-34183 #openssl - Unbounded memory growth in QUIC PATH_CHALLENGE handler
+CVE-2026-42766 #openssl - Possible NULL dereference in password-based CMS decryption
+CVE-2026-42767 #openssl - NULL pointer dereference in CRMF EncryptedValue decryption
+CVE-2026-45446 #openssl - Incorrect tag processing for empty messages in AES-GCM-SIV/AES-SIV modes
 # os-pkgs - glibc in upstream kube-state-metrics image (azurelinux 3.0, 2.38-18.azl3 -> 2.38-19.azl3)
 CVE-2026-4437 #glibc - Incorrect DNS response parsing via crafted DNS server response
 CVE-2026-4438 #glibc - Invalid DNS hostname returned via gethostbyaddr functions


### PR DESCRIPTION
## Problem

The `Build: run trivy scan` step is **failing on every image build** (config reader, linux CCP, linux prometheus-collector, target allocator) on `main` and all open PRs (e.g. #1579, build `119800`). The pipeline runs:

```
trivy image --exit-code 1 --ignore-unfixed --no-progress --severity HIGH,CRITICAL,MEDIUM $image
```

Trivy started flagging **8 newly published openssl / openssl-libs CVEs** in the Azure Linux 3.0 base once they entered trivy's vulnerability DB (builds flipped red on 2026-06-26 with no related code change; the same branch passed ~4h earlier).

| Severity | CVEs | Installed | Fixed |
|---|---|---|---|
| HIGH | CVE-2026-34180, CVE-2026-7383, CVE-2026-9076, CVE-2026-45445 | `openssl 3.3.5-5.azl3` | `3.3.7-3.azl3` |
| MEDIUM | CVE-2026-34183, CVE-2026-42766, CVE-2026-42767, CVE-2026-45446 | `openssl 3.3.5-5.azl3` | `3.3.7-3.azl3` |

## Why suppress instead of rebuilding against a patched base

openssl/openssl-libs in the **final image comes from `mcr.microsoft.com/azurelinux/distroless/base:3.0`**. The newest published base tag (`3.0.20260204`) still ships `openssl-libs 3.3.5-5.azl3` — the fixed `3.3.7-3.azl3` is **not yet available in any base image**. The final stage is distroless, so openssl cannot be `tdnf update`d, and copying `libssl.so.3`/`libcrypto.so.3` from the builder breaks FIPS HMAC verification (per the Dockerfile comments).

This is the same situation as the existing `CVE-2026-34182 # suppress pending base image rebuild` entry, so these are suppressed the same way until MCR rebuilds the distroless base. The Go-binary-oriented `updatetrivyignore.sh` preserves os-pkgs entries, so this manual addition is consistent with how openssl/glibc CVEs are already maintained.

## Verification

Validated locally with **trivy 0.71.2** using the pipeline's exact flags against `mcr.microsoft.com/azurelinux/distroless/base:3.0` (same openssl version as the built images):

- **Before** (empty ignore file): `Total: 18 (MEDIUM: 8, HIGH: 8, CRITICAL: 2)` -> **exit 1**
- **After** (this `.trivyignore`): no findings -> **exit 0**

## Follow-up

When MCR publishes an Azure Linux 3.0 base image with `openssl >= 3.3.7-3.azl3`, these entries (and `CVE-2026-34182`) should be removed so the CVEs are scanned again.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
