### PR TITLE
ci: pin k8s-extension to 1.6.7 to unblock Arc dev/prod deploy

### DIFF
--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -1071,6 +1071,14 @@ extends:
             scriptType: 'bash'
             scriptLocation: 'inlineScript'
             inlineScript: |
+              # Pin k8s-extension to 1.6.7, the last release without pypi-hosted
+              # dependencies. k8s-extension >=1.7.0 declares kubernetes/oras deps
+              # (for its preview 'troubleshoot' command) that pip must fetch from
+              # pypi.org, which is not reachable from the hosted build agents, so the
+              # dynamic auto-install fails. The pipeline only uses show/update, both
+              # fully supported by 1.6.7.
+              az config set extension.use_dynamic_install=yes_without_prompt
+              az extension add --name k8s-extension --version 1.6.7 --only-show-errors
               for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
                 do
                   state=$(az k8s-extension show --name azuremonitor-metrics --cluster-name ci-dev-arc-wcus --resource-group ci-dev-arc-wcus --cluster-type connectedClusters | jq -r '.provisioningState')
@@ -1094,6 +1102,9 @@ extends:
             scriptLocation: 'inlineScript'
             inlineScript: |
               az config set extension.use_dynamic_install=yes_without_prompt
+              # Pin k8s-extension to 1.6.7 (last dependency-free release); newer
+              # versions require pypi-hosted deps that the build agents can't reach.
+              az extension add --name k8s-extension --version 1.6.7 --only-show-errors
               az k8s-extension update --name azuremonitor-metrics --resource-group ci-dev-arc-wcus --cluster-name ci-dev-arc-wcus --cluster-type connectedClusters --version $HELM_SEMVER --release-train pipeline
 
       - job: Deploy_AKS_Chart

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -2313,6 +2313,14 @@ extends:
                   scriptType: 'bash'
                   scriptLocation: 'inlineScript'
                   inlineScript: |
+                    # Pin k8s-extension to 1.6.7, the last release without pypi-hosted
+                    # dependencies. k8s-extension >=1.7.0 declares kubernetes/oras deps
+                    # (for its preview 'troubleshoot' command) that pip must fetch from
+                    # pypi.org, which is not reachable from the hosted build agents, so the
+                    # dynamic auto-install fails. The pipeline only uses show/update, both
+                    # fully supported by 1.6.7.
+                    az config set extension.use_dynamic_install=yes_without_prompt
+                    az extension add --name k8s-extension --version 1.6.7 --only-show-errors
                     for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
                       do
                         state=$(az k8s-extension show --name azuremonitor-metrics --cluster-name ci-dev-arc-wcus --resource-group ci-dev-arc-wcus --cluster-type connectedClusters | jq -r '.provisioningState')
@@ -2335,6 +2343,9 @@ extends:
                   scriptLocation: 'inlineScript'
                   inlineScript: |
                     az config set extension.use_dynamic_install=yes_without_prompt
+                    # Pin k8s-extension to 1.6.7 (last dependency-free release); newer
+                    # versions require pypi-hosted deps that the build agents can't reach.
+                    az extension add --name k8s-extension --version 1.6.7 --only-show-errors
                     az k8s-extension update --name azuremonitor-metrics --resource-group ci-dev-arc-wcus --cluster-name ci-dev-arc-wcus --cluster-type connectedClusters --version $HELM_SEMVER --release-train pipeline
                   retryCountOnTaskFailure: 2
 

--- a/.pipelines/azure-pipeline-release.yml
+++ b/.pipelines/azure-pipeline-release.yml
@@ -285,6 +285,12 @@ extends:
                   inlineScript: |
                     # Enable dynamic extension installation
                     az config set extension.use_dynamic_install=yes_without_prompt
+                    # Pin k8s-extension to 1.6.7, the last release without pypi-hosted
+                    # dependencies. k8s-extension >=1.7.0 declares kubernetes/oras deps
+                    # (for its preview 'troubleshoot' command) that pip must fetch from
+                    # pypi.org, which is not reachable from the hosted build agents, so the
+                    # dynamic auto-install fails. Only show/update are used, both in 1.6.7.
+                    az extension add --name k8s-extension --version 1.6.7 --only-show-errors
                     
                     # Update Arc extension with new version
                     echo "Updating azuremonitor-metrics extension to version: $CHART_TAG"


### PR DESCRIPTION
## Summary

Fixes the persistent CI failure in the **Arc dev-cluster Deploy stage** — the task **`Deploy: wait for ci-dev-arc-wcus cluster to be ready`** (and every other `az k8s-extension` call) has been failing on **every `main` build since mid-May 2026** with:

```
WARNING: The command requires the extension k8s-extension. It will be installed first.
ERROR: An error occurred. Pip failed with status code 1. Use --debug for more information.
...
Cluster is installing a different version of the extension
##[error]Script failed with exit code: 1
```

This fails the whole build's Deploy stage. It is **not** tied to any particular PR — it reproduces on unrelated PRs (release notes, otel upgrade, etc.). Last green `main` build was **2026-05-12** (e.g. failing runs: 120048, 120076, 120033, 119652, 119598).

## Root cause

The Arc deploy tasks call `az k8s-extension show/update` without the extension pre-installed, relying on az's **dynamic install**, which always pulls the **latest** version.

- **`k8s-extension` 1.5.1 → 1.6.7** ship a **self-contained wheel with zero `Requires-Dist`** — pip installs only the wheel, which az downloads from Azure blob storage (`azcliprod.blob.core.windows.net`). No pypi needed.
- **`k8s-extension` 1.7.0** (current latest) is the **first release to declare pypi dependencies**: `kubernetes==24.2.0` and `oras==0.2.25` (plus their transitive chain: google-auth, cryptography, cffi, urllib3, jsonschema, …). These were added for the new preview command `az k8s-extension troubleshoot` (its code imports `kubernetes.client.CoreV1Api` to read nodes/configmaps and `oras.client` to pull a diagnostics artifact from MCR).

When dynamic install lands on 1.7.0, pip tries to fetch those deps **from pypi.org**. The hosted build agents **cannot reach pypi** (the same pypi-egress limitation that already forced the Linux Python reference-app job to be disabled). The install fails, so `az k8s-extension show` errors, the wait loop never observes a `provisioningState`, all 20 iterations fall through, and the task `exit 1`s. (az hides the underlying pip error unless `--debug` is passed, which is why the log only shows the generic "Pip failed".)

The trigger was not a repo change — it was the agents losing pypi egress ~mid-May, which turned the always-latest dynamic install of 1.7.0 into a hard failure.

## Fix

Explicitly install the **pinned, dependency-free** version **1.6.7** before any `az k8s-extension` command, so dynamic install never selects 1.7.0 and pip never touches pypi:

```bash
az config set extension.use_dynamic_install=yes_without_prompt
az extension add --name k8s-extension --version 1.6.7 --only-show-errors
```

1.6.7 fully supports the only commands this pipeline uses (`show`, `update --version --release-train`) and its `minCliCoreVersion` (2.51.0) is satisfied by the agent's az 2.87.0.

Because each `AzureCLI@2` task runs with a **fresh `AZURE_CONFIG_DIR`** (hence its own `cliextensions` dir, so extensions do **not** persist across tasks), the pin is added to **every** task that calls `az k8s-extension`:

| File | Task(s) |
|------|---------|
| `.pipelines/azure-pipeline-build.yml` | `wait for ci-dev-arc-wcus cluster to be ready`, `Deploy: ci-dev-arc-wcus cluster` (update) |
| `.pipelines/OneBranch.Official.yml` | `wait for ci-dev-arc-wcus cluster to be ready`, `ci-dev-arc-wcus cluster` (update) |
| `.pipelines/azure-pipeline-release.yml` | prod `az k8s-extension update` (proactive — same latent failure on the prod release path) |

## Verification

- **Wheel metadata:** 1.6.7 → `0` `Requires-Dist`; 1.7.0 → `kubernetes==24.2.0`, `oras==0.2.25`.
- **Behavioral, with pypi blocked (`PIP_NO_INDEX=1`, reproducing the CI condition):**
  - `az extension add --name k8s-extension --version 1.6.7` → **exit 0** ("Successfully installed k8s-extension-1.6.7")
  - `az extension add --name k8s-extension --version 1.7.0` → **exit 1** ("Pip failed with status code 1") — identical to the CI error.
- **Extension-dir isolation:** confirmed `az` installs into `$AZURE_CONFIG_DIR/cliextensions`, and `AzureCLI@2` sets a fresh `AZURE_CONFIG_DIR` per task → the pin is required in each task (not just once).
- All three pipeline YAML files parse cleanly.

## Notes / follow-ups

- This unpins nothing else and changes no runtime image — it only affects how the CI/release agents install the `k8s-extension` CLI tool.
- If a future pipeline command needs a 1.7.0+ feature (e.g. `troubleshoot`), the durable fix would be pypi egress on the agents or a pre-seeded offline wheel cache for `kubernetes`/`oras`; for today's `show`/`update` usage, 1.6.7 is sufficient.
