### PR TITLE
[golang] bump Go toolchain versions for stdlib CVE fixes (Bug 38745864)

### DIFF
--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -28,9 +28,9 @@ variables:
   IS_OTEL_UPGRADE_BRANCH: $[startsWith(variables['Build.SourceBranchName'], 'otelcollector-upgrade-')]
   BUILD_WINDOWS: true
   Codeql.Enabled: true
-  GOLANG_VERSION: '1.26.4'
-  FLUENTBIT_GOLANG_VERSION: '1.25.9'
-  TESTKUBE_GOLANG_VERSION: '1.25.9'
+  GOLANG_VERSION: '1.26.5'
+  FLUENTBIT_GOLANG_VERSION: '1.25.12'
+  TESTKUBE_GOLANG_VERSION: '1.25.12'
   FLUENT_BIT_VERSION: '4.2.2'
   PROMETHEUS_VERSION: '3.2.1'
   HELM_VERSION: '3.12.3'

--- a/.pipelines/azure-pipeline-config-tests.yml
+++ b/.pipelines/azure-pipeline-config-tests.yml
@@ -40,7 +40,7 @@ variables:
   BUILD_WINDOWS: true
   Codeql.Enabled: true
   GOLANG_VERSION: '1.24.9'
-  TESTKUBE_GOLANG_VERSION: '1.25.9'
+  TESTKUBE_GOLANG_VERSION: '1.25.12'
   FLUENT_BIT_VERSION: '3.2.2'
 
 stages:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,7 @@
   + build(deps): bump golang.org/x/net from 0.43.0 to 0.55.0 in /otelcollector/test/ginkgo-e2e/regionTests (https://github.com/Azure/prometheus-collector/pull/1596)
   + build(deps): bump golang.org/x/net from 0.43.0 to 0.55.0 in /otelcollector/test/ginkgo-e2e/containerstatus (https://github.com/Azure/prometheus-collector/pull/1601)
   + build(deps): bump google.golang.org/grpc from 1.81.0 to 1.82.0 in /internal/referenceapp/golang (https://github.com/Azure/prometheus-collector/pull/1599)
+  + [golang] bump Go toolchain versions for stdlib CVE fixes (CVE-2026-39822, CVE-2026-42505) (https://github.com/Azure/prometheus-collector/pull/1608)
 
 * Pipeline/Docs/Templates Updates:
   + Skills for dev and prod image release validation (https://github.com/Azure/prometheus-collector/pull/1545)


### PR DESCRIPTION
## Summary

Bumps the Go toolchain versions used to build our own container images to pick up recent Go stdlib CVE fixes.

| Variable | File | Before | After |
|---|---|---|---|
| `GOLANG_VERSION` | azure-pipeline-build.yml | 1.26.4 | **1.26.5** |
| `FLUENTBIT_GOLANG_VERSION` | azure-pipeline-build.yml | 1.25.9 | **1.25.12** |
| `TESTKUBE_GOLANG_VERSION` | azure-pipeline-build.yml | 1.25.9 | **1.25.12** |
| `TESTKUBE_GOLANG_VERSION` | azure-pipeline-config-tests.yml | 1.25.9 | **1.25.12** |

## CVEs addressed

- **CVE-2026-39822** — `os` root escape via symlink + trailing slash (fixed in Go 1.26.5 / 1.25.12)
- **CVE-2026-42505** — `crypto/tls` Encrypted Client Hello (ECH) privacy leak (fixed in Go 1.26.5 / 1.25.12)

Fix versions confirmed via the oss-security announcement (2026-07-08), go.dev release notes, and the golang/go patch commits. These remediate the stdlib CVEs in the images we build ourselves: collector, target-allocator, config-reader, CCP, and the fluent-bit plugin (plus the arc-conformance test image).

Microsoft Go base images are already present on MCR (`mcr.microsoft.com/oss/go/microsoft/golang:1.26.5` and `:1.25.12`, both manifests resolve), so there is no build blocker.

## Scope note

This does **not** resolve the `kube-state-metrics` image flagged by the originating ICM — that is an external OSS image (`KUBE_STATE_METRICS_IMAGE`) blocked on an updated upstream build and is tracked separately.

## Testing / QA

Pre-PR checks performed locally:
- Both edited pipeline YAMLs parse cleanly with the expected values.
- Both target Go base image manifests resolve on MCR (HTTP 200).
- CVE fix versions confirmed against authoritative Go sources.

CI gate on this PR runs Trivy (CRITICAL/HIGH) scans on collector/CCP/TA/config-reader, plus SDL (Policheck/binary/credscan), ESLint, and Helm lint.

## Risk

**Low** — patch-level Go bumps within the same minor lines; toolchain-only change (no source or dependency changes); base images verified available.

Related work item: Bug 38745864 (ICM 831206288)