### PR TITLE
Onboard build pipeline to CFS network isolation (CFSClean) in audit mode

### DIFF
--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -55,6 +55,12 @@ extends:
   template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     customTags: 'ES365AIMigrationTooling-BulkMigrated'
+    featureFlags:
+      # SFI SR21 (MountainPass): onboard to CFS network isolation in AUDIT mode.
+      # 'Permissive' reports public-feed (CFSClean) violations without failing the
+      # build. Drop 'Permissive' to flip to enforcing once builds are violation-free.
+      networkisolation:
+        policy: Permissive,CFSClean
     stages:
     - stage: BuildAndDeploy
       jobs:


### PR DESCRIPTION
## What
Onboards the OneBranch build pipeline (`.pipelines/OneBranch.Official.yml`) to the **CFSClean** network isolation policy in **audit mode** (`policy: Permissive,CFSClean`).

## Why
Part of SFI Network Isolation / AzRel Red Flag **MountainPass SR21** (CFS adoption). This pipeline (ADO `github-private/azure`, id 978) is flagged for restoring packages from public feeds. `Permissive` reports CFSClean violations on each run **without failing the build**, so this can land safely and surface the exact violating endpoints before remediation.

## Effect
- Non-breaking: builds continue to pass; violations are reported in the "Stop Network Isolation" task / `GetPolicyViolationDetails`.
- No package-restore behavior changes in this PR.

## Next steps (follow-up PRs)
- Vendor Go modules; route/pre-bake Ruby gems; mirror GitHub-release binaries (ORAS/Trivy/Prometheus web UI/fluent-bit); route pip via CFS PyPI; mirror the Docker Hub qemu image.
- Once builds are violation-free, drop `Permissive` to enforce and reach the 7-day lock-in.