### PR TITLE
[target-allocator] Wait for the config file instead of exiting when it is missing

### DIFF
--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-targetallocator.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-targetallocator.yaml
@@ -40,6 +40,7 @@ spec:
       - name: targetallocator
         args:
         - --enable-prometheus-cr-watcher
+        - --config-file-wait-timeout=5m
         image: "{{ .Values.AzureMonitorMetrics.ImageRegistry }}{{ .Values.AzureMonitorMetrics.ImageRepository }}:{{ .Values.AzureMonitorMetrics.ImageTagTargetAllocator }}"
         imagePullPolicy: IfNotPresent
         resources:

--- a/otelcollector/otel-allocator/internal/config/config.go
+++ b/otelcollector/otel-allocator/internal/config/config.go
@@ -45,6 +45,8 @@ const (
 	DefaultAllocationStrategy                          = "consistent-hashing"
 	DefaultFilterStrategy                              = "relabel-config"
 	DefaultCollectorNotReadyGracePeriod                = 30 * time.Second
+	DefaultConfigFileWaitTimeout                       = 0 * time.Second
+	configFilePollInterval                             = 250 * time.Millisecond
 )
 
 var DefaultKubeConfigFilePath = filepath.Join(homedir.HomeDir(), ".kube", "config")
@@ -393,6 +395,48 @@ func CreateDefaultConfig() Config {
 	}
 }
 
+func configFileReady(file string) (bool, error) {
+	info, err := os.Stat(file)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return false, nil
+	case err != nil:
+		return false, err
+	case info.IsDir():
+		return false, fmt.Errorf("config file %s is a directory", file)
+	}
+	return info.Size() > 0, nil
+}
+
+func waitForConfigFile(file string, timeout time.Duration) error {
+	ready, err := configFileReady(file)
+	if err != nil || ready || timeout <= 0 {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Config file %s is not available yet, waiting up to %s for it to be created\n", file, timeout)
+
+	ticker := time.NewTicker(configFilePollInterval)
+	defer ticker.Stop()
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			ready, err = configFileReady(file)
+			if err != nil {
+				return err
+			}
+			if ready {
+				return nil
+			}
+		case <-deadline.C:
+			return fmt.Errorf("timed out after %s waiting for config file %s: %w", timeout, file, fs.ErrNotExist)
+		}
+	}
+}
+
 func Load(args []string) (*Config, error) {
 	var err error
 
@@ -406,6 +450,14 @@ func Load(args []string) (*Config, error) {
 
 	// load the config from the config file
 	configFilePath, err := getConfigFilePath(flagSet)
+	if err != nil {
+		return nil, err
+	}
+	configFileWaitTimeout, err := getConfigFileWaitTimeout(flagSet)
+	if err != nil {
+		return nil, err
+	}
+	err = waitForConfigFile(configFilePath, configFileWaitTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/otelcollector/otel-allocator/internal/config/config_wait_test.go
+++ b/otelcollector/otel-allocator/internal/config/config_wait_test.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForConfigFile(t *testing.T) {
+	t.Run("returns immediately when the file already exists", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "targetallocator.yaml")
+		require.NoError(t, os.WriteFile(file, []byte("config: value\n"), 0600))
+
+		require.NoError(t, waitForConfigFile(file, 5*time.Second))
+	})
+
+	t.Run("does not wait when the timeout is disabled", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "missing.yaml")
+
+		start := time.Now()
+		require.NoError(t, waitForConfigFile(file, 0))
+		assert.Less(t, time.Since(start), 500*time.Millisecond)
+	})
+
+	t.Run("waits for a file written after startup", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "targetallocator.yaml")
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			_ = os.WriteFile(file, []byte("config: value\n"), 0600)
+		}()
+
+		require.NoError(t, waitForConfigFile(file, 5*time.Second))
+	})
+
+	t.Run("treats an empty file as not ready and times out", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "targetallocator.yaml")
+		require.NoError(t, os.WriteFile(file, []byte{}, 0600))
+
+		err := waitForConfigFile(file, 500*time.Millisecond)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, fs.ErrNotExist)
+	})
+
+	t.Run("times out when the file never appears", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "missing.yaml")
+
+		err := waitForConfigFile(file, 500*time.Millisecond)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, fs.ErrNotExist)
+	})
+
+	t.Run("fails when the path is a directory", func(t *testing.T) {
+		err := waitForConfigFile(t.TempDir(), time.Second)
+		require.Error(t, err)
+	})
+}
+
+func TestLoadWaitsForLateConfigFile(t *testing.T) {
+	contents, err := os.ReadFile(filepath.Join("testdata", "config_test.yaml"))
+	require.NoError(t, err)
+
+	file := filepath.Join(t.TempDir(), "targetallocator.yaml")
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		_ = os.WriteFile(file, contents, 0600)
+	}()
+
+	cfg, err := Load([]string{"--config-file=" + file, "--config-file-wait-timeout=5s"})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+}
+
+func TestLoadFailsFastOnMissingConfigFileByDefault(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "missing.yaml")
+
+	_, err := Load([]string{"--config-file=" + file})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}

--- a/otelcollector/otel-allocator/internal/config/flags.go
+++ b/otelcollector/otel-allocator/internal/config/flags.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"flag"
+	"time"
 
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -14,6 +15,7 @@ import (
 const (
 	targetAllocatorName              = "target-allocator"
 	configFilePathFlagName           = "config-file"
+	configFileWaitTimeoutFlagName    = "config-file-wait-timeout"
 	listenAddrFlagName               = "listen-addr"
 	prometheusCREnabledFlagName      = "enable-prometheus-cr-watcher"
 	kubeConfigPathFlagName           = "kubeconfig-path"
@@ -31,6 +33,7 @@ var zapCmdLineOpts zap.Options
 func getFlagSet(errorHandling pflag.ErrorHandling) *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet(targetAllocatorName, errorHandling)
 	flagSet.String(configFilePathFlagName, DefaultConfigFilePath, "The path to the config file.")
+	flagSet.Duration(configFileWaitTimeoutFlagName, DefaultConfigFileWaitTimeout, "How long to wait for the config file to be created before giving up. Zero fails immediately if the file is missing. Useful when the config file is written by another container in the same Pod.")
 	flagSet.String(listenAddrFlagName, DefaultListenAddr, "The address where this service serves.")
 	flagSet.Bool(prometheusCREnabledFlagName, false, "Enable Prometheus CRs as target sources")
 	flagSet.String(kubeConfigPathFlagName, DefaultKubeConfigFilePath, "absolute path to the KubeconfigPath file")
@@ -48,6 +51,10 @@ func getFlagSet(errorHandling pflag.ErrorHandling) *pflag.FlagSet {
 
 func getConfigFilePath(flagSet *pflag.FlagSet) (string, error) {
 	return flagSet.GetString(configFilePathFlagName)
+}
+
+func getConfigFileWaitTimeout(flagSet *pflag.FlagSet) (time.Duration, error) {
+	return flagSet.GetDuration(configFileWaitTimeoutFlagName)
 }
 
 func getKubeConfigFilePath(flagSet *pflag.FlagSet) (value string, changed bool, err error) {


### PR DESCRIPTION
## Problem
 
The Target Allocator reads its config file once at startup (`config.Load` -> `os.ReadFile`) and exits with a fatal error if the file isn't present yet.
 
This is fine when the config is mounted from a ConfigMap, but some deployments generate the config file into a volume shared with a sidecar container in the same Pod. Container start order within a Pod isn't guaranteed, so the Target Allocator can start before the sidecar has written the file. When that happens the process crash-loops until the sidecar wins the race. While the TA is down, collectors have no target assignments, which produces a scrape gap across the cluster on every restart or rollout where the race is lost.
 
## Fix
 
Add an opt-in `--config-file-wait-timeout` flag. When set to a positive duration, `Load` polls for the config file (every 250ms) until it exists and is non-empty, up to the timeout, before reading it. An empty file is treated as not-ready to guard against reading a partially written file.
 
The default is `0`, which preserves the existing fail-fast behavior, so this is a no-op for existing users unless they opt in.
 
The Azure Monitor metrics addon chart is also updated to set `--config-file-wait-timeout=5m` on the Target Allocator container, where the config file is written by the config-reader sidecar into a shared `emptyDir`.
 
# New Feature Checklist
 
- [ ] List telemetry added about the feature. _N/A - no new telemetry; only startup behavior changes, behind an opt-in flag._
- [ ] Link to the one-pager about the feature. _N/A - small reliability fix, no one-pager._
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR. _The addon chart change (`--config-file-wait-timeout=5m`) is included in this PR; no other release tasks._
- [ ] Attach results of scale and perf testing. _N/A - the wait loop runs once at startup and is a no-op by default; no steady-state or scale impact._
 
# Tests Checklist
 
- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? _N/A - external contribution without cluster access; covered by the unit tests below._
  - Labels used when running the tests on your cluster:
    - [ ] `operator`
    - [ ] `windows`
    - [ ] `arm64`
    - [ ] `arc-extension`
    - [ ] `fips`
- [x] Have new tests been added? Added unit tests in `otel-allocator/internal/config/config_wait_test.go` covering: file already present, disabled timeout, file written after startup, empty-file timeout, never-appears timeout, the directory error case, an end-to-end `Load` test that succeeds when the config file is written late, and one confirming default fail-fast behavior.
  - [ ] Is a new scrape job needed? _No._
  - [ ] Was a new test label added? _No._
  - [ ] Are additional API server permissions needed for the new tests? _No._
  - [ ] Was a new test suite (a new folder under `/tests`) added? _No._