### PR TITLE
Update remote write release notes for 20260729.1

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -32,6 +32,8 @@ CVE-2026-46597 #golang.org/x/crypto/ssh - incorrectly placed cast from bytes to 
 GHSA-hrxh-6v49-42gf #google.golang.org/grpc - gRPC-Go: xDS RBAC and HTTP/2 Vulnerabilities
 # gobinary - stdlib / Go os.Root (all images, go1.26.4 -> go1.26.5, suppress pending golang toolchain bump)
 CVE-2026-39822 #stdlib os - Go os.Root symlink following vulnerability
+# gobinary - golang.org/x/text (all images) (v0.37.0 -> 0.39.0)
+CVE-2026-56852 #golang.org/x/text - norm.Iter infinite loop on invalid input
 
 # MEDIUM
 # os-pkgs - openssl/openssl-libs (azurelinux 3.0, suppress pending base image rebuild)

--- a/REMOTE-WRITE-RELEASENOTES.md
+++ b/REMOTE-WRITE-RELEASENOTES.md
@@ -1,5 +1,18 @@
 # Azure Monitor managed service for Prometheus remote write
 
+## Release 07-29-2026
+* Image - `mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-remote-write/images:prom-remotewrite-20260729.1`
+* Change log -
+  * golang upgrade 1.25.9 -> 1.25.10 (7 Go stdlib/toolchain CVE fixes)
+* Fixed CVEs:
+    - [CVE-2026-42499](https://avd.aquasec.com/nvd/cve-2026-42499) — `net/mail` quadratic string concatenation in consumePhrase, leading to denial of service.
+    - [CVE-2026-39836](https://avd.aquasec.com/nvd/cve-2026-39836) — `net` panic in Dial and LookupPort when handling a NUL byte on Windows.
+    - [CVE-2026-39820](https://avd.aquasec.com/nvd/cve-2026-39820) — `net/mail` quadratic string concatenation in consumeComment, leading to denial of service.
+    - [CVE-2026-33811](https://avd.aquasec.com/nvd/cve-2026-33811) — `net` crash when handling a long CNAME response.
+    - [CVE-2026-42501](https://avd.aquasec.com/nvd/cve-2026-42501) — `cmd/go` a malicious module proxy can bypass the checksum database.
+    - [CVE-2026-42504](https://avd.aquasec.com/nvd/cve-2026-42504) — `mime` quadratic complexity in WordDecoder.DecodeHeader, leading to denial of service.
+    - [CVE-2026-33814](https://avd.aquasec.com/nvd/cve-2026-33814) — `net/http2` infinite loop when given a bad SETTINGS_MAX_FRAME_SIZE.
+
 ## Release 07-13-2026
 * Image - `mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-remote-write/images:prom-remotewrite-20260713.1`
 * Change log -


### PR DESCRIPTION
Update remote write release notes for `prom-remotewrite-20260729.1`.

**Change:** golang upgrade 1.25.9 -> 1.25.10 (7 Go stdlib/toolchain CVE fixes).

- Image: `mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-remote-write/images:prom-remotewrite-20260729.1`
- Source PR: Merged PR 16615895 (Prom-RemoteWrite-Sidecar)
- Fixed CVEs: CVE-2026-42499, CVE-2026-39836, CVE-2026-39820, CVE-2026-33811, CVE-2026-42501, CVE-2026-42504, CVE-2026-33814
- Deployed and validated on `monitoring-metrics-prod-aks-eus2euap` (live metrics confirmed in all 3 target workspaces via direct query).