### PR TITLE
Add telemetry for pod and service monitors with basic auth/bearer token

### DIFF
--- a/otelcollector/fluent-bit/src/scrape_job_telemetry.go
+++ b/otelcollector/fluent-bit/src/scrape_job_telemetry.go
@@ -1,0 +1,75 @@
+package main
+
+import "strings"
+
+const (
+	basicAuthEnabled                     = "BasicAuthEnabled"
+	bearerTokenEnabledWithFile           = "BearerTokenEnabledWithFile"
+	bearerTokenEnabledWithSecret         = "BearerTokenEnabledWithSecret"
+	serviceMonitorBearerTokenFileEnabled = "ServiceMonitorBearerTokenFileEnabled"
+	podMonitorBearerTokenFileEnabled     = "PodMonitorBearerTokenFileEnabled"
+	serviceMonitorBearerTokenEnabled     = "ServiceMonitorBearerTokenEnabled"
+	podMonitorBearerTokenEnabled         = "PodMonitorBearerTokenEnabled"
+	serviceMonitorBasicAuthEnabled       = "ServiceMonitorBasicAuthEnabled"
+	podMonitorBasicAuthEnabled           = "PodMonitorBasicAuthEnabled"
+)
+
+func scrapeJobMetadata(scrapeJobs map[string]interface{}) map[string]string {
+	telemetryProperties := map[string]string{
+		basicAuthEnabled:                     "false",
+		bearerTokenEnabledWithFile:           "false",
+		bearerTokenEnabledWithSecret:         "false",
+		serviceMonitorBearerTokenFileEnabled: "false",
+		podMonitorBearerTokenFileEnabled:     "false",
+		serviceMonitorBearerTokenEnabled:     "false",
+		podMonitorBearerTokenEnabled:         "false",
+		serviceMonitorBasicAuthEnabled:       "false",
+		podMonitorBasicAuthEnabled:           "false",
+	}
+
+	for jobName, value := range scrapeJobs {
+		job, ok := value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		isServiceMonitor := strings.HasPrefix(jobName, "serviceMonitor/")
+		isPodMonitor := strings.HasPrefix(jobName, "podMonitor/")
+
+		if _, ok := job["basic_auth"]; ok {
+			telemetryProperties[basicAuthEnabled] = "true"
+			switch {
+			case isServiceMonitor:
+				telemetryProperties[serviceMonitorBasicAuthEnabled] = "true"
+			case isPodMonitor:
+				telemetryProperties[podMonitorBasicAuthEnabled] = "true"
+			}
+		}
+
+		auth, ok := job["authorization"].(map[string]interface{})
+		if !ok || auth["type"] != "Bearer" {
+			continue
+		}
+		switch {
+		case isServiceMonitor:
+			telemetryProperties[serviceMonitorBearerTokenEnabled] = "true"
+		case isPodMonitor:
+			telemetryProperties[podMonitorBearerTokenEnabled] = "true"
+		}
+		if _, ok := auth["credentials"]; ok {
+			telemetryProperties[bearerTokenEnabledWithSecret] = "true"
+		}
+		if _, ok := auth["credentials_file"]; !ok {
+			continue
+		}
+
+		telemetryProperties[bearerTokenEnabledWithFile] = "true"
+		switch {
+		case isServiceMonitor:
+			telemetryProperties[serviceMonitorBearerTokenFileEnabled] = "true"
+		case isPodMonitor:
+			telemetryProperties[podMonitorBearerTokenFileEnabled] = "true"
+		}
+	}
+
+	return telemetryProperties
+}

--- a/otelcollector/fluent-bit/src/telemetry.go
+++ b/otelcollector/fluent-bit/src/telemetry.go
@@ -183,9 +183,6 @@ const (
 	fluentbitFailedScrapeTag              = "prometheus.log.failedscrape"
 	keepListRegexHashFilePath             = "/opt/microsoft/configmapparser/config_def_targets_metrics_keep_list_hash"
 	intervalHashFilePath                  = "/opt/microsoft/configmapparser/config_def_targets_scrape_intervals_hash"
-	basicAuthEnabled                      = "BasicAuthEnabled"
-	bearerTokenEnabledWithFile            = "BearerTokenEnabledWithFile"
-	bearerTokenEnabledWithSecret          = "BearerTokenEnabledWithSecret"
 )
 
 var (
@@ -604,11 +601,6 @@ func GetAndSendContainerCPUandMemoryFromCadvisorJSON(container Container, cpuMet
 }
 
 func addScrapeJobMetadataToTelemetryItem() map[string]string {
-	telemetryPropertiesString := map[string]string{
-		basicAuthEnabled:             "false",
-		bearerTokenEnabledWithFile:   "false",
-		bearerTokenEnabledWithSecret: "false",
-	}
 	taEndpoint := "http://ama-metrics-operator-targets.kube-system.svc.cluster.local/scrape_configs"
 
 	// Send metric to app insights for target allocator metrics
@@ -616,64 +608,17 @@ func addScrapeJobMetadataToTelemetryItem() map[string]string {
 		taEndpoint = "https://ama-metrics-operator-targets.kube-system.svc.cluster.local:443/scrape_configs"
 	}
 	scrapeJobs := getTargetAllocatorResponse(taEndpoint)
-	if scrapeJobs != nil {
-		var scrapeJobsMap map[string]interface{}
-		err := json.Unmarshal(scrapeJobs, &scrapeJobsMap)
-		if err != nil {
-			Log(fmt.Sprintf("Error unmarshalling scrape jobs JSON: %v", err))
-			SendException(err)
-			return nil
-		} else {
-			hasBasicAuth := false
-			hasBearerToken := false
-			hasBearerTokenInFile := false
-			hasBearerTokenInSecret := false
-			var checkForConfigProperties func(map[string]interface{})
-			checkForConfigProperties = func(data map[string]interface{}) {
-				for _, value := range data {
-					job := value.(map[string]interface{})
-					if _, ok := job["basic_auth"]; ok {
-						hasBasicAuth = true
-						// break
-					}
-					if auth, ok := job["authorization"]; ok {
-						authValue := auth.(map[string]interface{})
-						if typeValue, ok := authValue["type"]; ok {
-							if typeValue == "Bearer" {
-								hasBearerToken = true
-							}
-							if hasBearerToken {
-								if _, ok := authValue["credentials_file"]; ok {
-									hasBearerTokenInFile = true
-								}
-								if _, ok := authValue["credentials"]; ok {
-									hasBearerTokenInSecret = true
-								}
-							}
-							// break
-						}
-					}
-
-					if hasBasicAuth && hasBearerTokenInFile && hasBearerTokenInSecret {
-						break
-					}
-				}
-			}
-			checkForConfigProperties(scrapeJobsMap)
-			if hasBasicAuth {
-				telemetryPropertiesString[basicAuthEnabled] = "true"
-			}
-
-			if hasBearerTokenInFile {
-				telemetryPropertiesString[bearerTokenEnabledWithFile] = "true"
-			}
-			if hasBearerTokenInSecret {
-				telemetryPropertiesString[bearerTokenEnabledWithSecret] = "true"
-			}
-		}
+	if scrapeJobs == nil {
+		return scrapeJobMetadata(nil)
 	}
-	return telemetryPropertiesString
 
+	var scrapeJobsMap map[string]interface{}
+	if err := json.Unmarshal(scrapeJobs, &scrapeJobsMap); err != nil {
+		Log(fmt.Sprintf("Error unmarshalling scrape jobs JSON: %v", err))
+		SendException(err)
+		return nil
+	}
+	return scrapeJobMetadata(scrapeJobsMap)
 }
 
 // Get scrape jobs for basic auth and bearer token telemetry

--- a/otelcollector/fluent-bit/src/telemetry_test.go
+++ b/otelcollector/fluent-bit/src/telemetry_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestScrapeJobMetadataBearerTokenFileMonitorTypes(t *testing.T) {
+	scrapeJobs := map[string]interface{}{
+		"serviceMonitor/test/service/0": map[string]interface{}{
+			"authorization": map[string]interface{}{
+				"type":             "Bearer",
+				"credentials_file": "/var/run/secrets/service-token",
+			},
+		},
+		"podMonitor/test/pod/0": map[string]interface{}{
+			"authorization": map[string]interface{}{
+				"type":             "Bearer",
+				"credentials_file": "/var/run/secrets/pod-token",
+			},
+		},
+	}
+
+	metadata := scrapeJobMetadata(scrapeJobs)
+
+	assertTelemetryProperty(t, metadata, bearerTokenEnabledWithFile, "true")
+	assertTelemetryProperty(t, metadata, serviceMonitorBearerTokenFileEnabled, "true")
+	assertTelemetryProperty(t, metadata, podMonitorBearerTokenFileEnabled, "true")
+	assertTelemetryProperty(t, metadata, serviceMonitorBearerTokenEnabled, "true")
+	assertTelemetryProperty(t, metadata, podMonitorBearerTokenEnabled, "true")
+}
+
+func TestScrapeJobMetadataDoesNotAttributeNonMonitorBearerTokenFile(t *testing.T) {
+	scrapeJobs := map[string]interface{}{
+		"custom-scrape-job": map[string]interface{}{
+			"authorization": map[string]interface{}{
+				"type":             "Bearer",
+				"credentials_file": "/var/run/secrets/custom-token",
+			},
+		},
+	}
+
+	metadata := scrapeJobMetadata(scrapeJobs)
+
+	assertTelemetryProperty(t, metadata, bearerTokenEnabledWithFile, "true")
+	assertTelemetryProperty(t, metadata, serviceMonitorBearerTokenFileEnabled, "false")
+	assertTelemetryProperty(t, metadata, podMonitorBearerTokenFileEnabled, "false")
+	assertTelemetryProperty(t, metadata, serviceMonitorBearerTokenEnabled, "false")
+	assertTelemetryProperty(t, metadata, podMonitorBearerTokenEnabled, "false")
+}
+
+func TestScrapeJobMetadataBearerTokenSecretIsNotFileUsage(t *testing.T) {
+	scrapeJobs := map[string]interface{}{
+		"serviceMonitor/test/service/0": map[string]interface{}{
+			"authorization": map[string]interface{}{
+				"type":        "Bearer",
+				"credentials": "token",
+			},
+		},
+	}
+
+	metadata := scrapeJobMetadata(scrapeJobs)
+
+	assertTelemetryProperty(t, metadata, bearerTokenEnabledWithSecret, "true")
+	assertTelemetryProperty(t, metadata, bearerTokenEnabledWithFile, "false")
+	assertTelemetryProperty(t, metadata, serviceMonitorBearerTokenFileEnabled, "false")
+	assertTelemetryProperty(t, metadata, serviceMonitorBearerTokenEnabled, "true")
+}
+
+func TestScrapeJobMetadataBasicAuthMonitorTypes(t *testing.T) {
+	scrapeJobs := map[string]interface{}{
+		"serviceMonitor/test/service/0": map[string]interface{}{
+			"basic_auth": map[string]interface{}{
+				"username": "service-user",
+				"password": "service-password",
+			},
+		},
+		"podMonitor/test/pod/0": map[string]interface{}{
+			"basic_auth": map[string]interface{}{
+				"username": "pod-user",
+				"password": "pod-password",
+			},
+		},
+	}
+
+	metadata := scrapeJobMetadata(scrapeJobs)
+
+	assertTelemetryProperty(t, metadata, basicAuthEnabled, "true")
+	assertTelemetryProperty(t, metadata, serviceMonitorBasicAuthEnabled, "true")
+	assertTelemetryProperty(t, metadata, podMonitorBasicAuthEnabled, "true")
+}
+
+func assertTelemetryProperty(t *testing.T, properties map[string]string, name, expected string) {
+	t.Helper()
+	if actual := properties[name]; actual != expected {
+		t.Fatalf("property %q = %q, want %q", name, actual, expected)
+	}
+}

--- a/testartifacts/auth-monitor-telemetry/00-namespace.yaml
+++ b/testartifacts/auth-monitor-telemetry/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ama-metrics-auth-telemetry-test

--- a/testartifacts/auth-monitor-telemetry/01-auth-secret.yaml
+++ b/testartifacts/auth-monitor-telemetry/01-auth-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: monitor-auth
+  namespace: ama-metrics-auth-telemetry-test
+type: Opaque
+stringData:
+  username: telemetry-user
+  password: telemetry-password
+  bearer-token: telemetry-bearer-token

--- a/testartifacts/auth-monitor-telemetry/02-metrics-target.yaml
+++ b/testartifacts/auth-monitor-telemetry/02-metrics-target.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-target
+  namespace: ama-metrics-auth-telemetry-test
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location /metrics {
+        default_type text/plain;
+        alias /usr/share/nginx/html/metrics;
+      }
+    }
+  metrics: |
+    # HELP auth_monitor_telemetry_test Test metric for monitor authentication telemetry.
+    # TYPE auth_monitor_telemetry_test gauge
+    auth_monitor_telemetry_test 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-target
+  namespace: ama-metrics-auth-telemetry-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auth-monitor-telemetry-test
+  template:
+    metadata:
+      labels:
+        app: auth-monitor-telemetry-test
+    spec:
+      containers:
+        - name: nginx
+          image: mcr.microsoft.com/oss/nginx/nginx:1.25.5
+          ports:
+            - name: metrics
+              containerPort: 8080
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            - name: config
+              mountPath: /usr/share/nginx/html/metrics
+              subPath: metrics
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: metrics-target
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-target
+  namespace: ama-metrics-auth-telemetry-test
+  labels:
+    app: auth-monitor-telemetry-test
+spec:
+  selector:
+    app: auth-monitor-telemetry-test
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics

--- a/testartifacts/auth-monitor-telemetry/10-service-monitors.yaml
+++ b/testartifacts/auth-monitor-telemetry/10-service-monitors.yaml
@@ -1,0 +1,69 @@
+# Verifies ServiceMonitor Basic Auth telemetry using username and password
+# references from the monitor-auth Kubernetes Secret.
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: basic-auth
+  namespace: ama-metrics-auth-telemetry-test
+spec:
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchLabels:
+      app: auth-monitor-telemetry-test
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      basicAuth:
+        username:
+          name: monitor-auth
+          key: username
+        password:
+          name: monitor-auth
+          key: password
+---
+# Verifies ServiceMonitor Bearer token telemetry using a token referenced from
+# the monitor-auth Kubernetes Secret.
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: bearer-token-secret
+  namespace: ama-metrics-auth-telemetry-test
+spec:
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchLabels:
+      app: auth-monitor-telemetry-test
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      authorization:
+        type: Bearer
+        credentials:
+          name: monitor-auth
+          key: bearer-token
+---
+# Verifies ServiceMonitor file-based Bearer token telemetry using the
+# service-account token mounted in the collector container.
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: bearer-token-file
+  namespace: ama-metrics-auth-telemetry-test
+spec:
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchLabels:
+      app: auth-monitor-telemetry-test
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/testartifacts/auth-monitor-telemetry/20-pod-monitors.yaml
+++ b/testartifacts/auth-monitor-telemetry/20-pod-monitors.yaml
@@ -1,0 +1,49 @@
+# Verifies PodMonitor Basic Auth telemetry using username and password
+# references from the monitor-auth Kubernetes Secret.
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: basic-auth
+  namespace: ama-metrics-auth-telemetry-test
+spec:
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchLabels:
+      app: auth-monitor-telemetry-test
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      basicAuth:
+        username:
+          name: monitor-auth
+          key: username
+        password:
+          name: monitor-auth
+          key: password
+---
+# Verifies PodMonitor Bearer token telemetry using a token referenced from the
+# monitor-auth Kubernetes Secret.
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: bearer-token-secret
+  namespace: ama-metrics-auth-telemetry-test
+spec:
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchLabels:
+      app: auth-monitor-telemetry-test
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      authorization:
+        type: Bearer
+        credentials:
+          name: monitor-auth
+          key: bearer-token

--- a/testartifacts/auth-monitor-telemetry/README.md
+++ b/testartifacts/auth-monitor-telemetry/README.md
@@ -1,0 +1,61 @@
+# Authentication monitor telemetry test
+
+These manifests create one metrics endpoint and five monitors:
+
+| Monitor | Authentication |
+|---|---|
+| ServiceMonitor | Basic Auth |
+| ServiceMonitor | Bearer token from a Kubernetes Secret |
+| ServiceMonitor | Bearer token from a file |
+| PodMonitor | Basic Auth |
+| PodMonitor | Bearer token from a Kubernetes Secret |
+
+The `azmonitoring.coreos.com/v1` PodMonitor CRD does not support
+`bearerTokenFile`, so there is no valid PodMonitor example for that field.
+
+The test endpoint does not enforce authentication. The purpose of these
+artifacts is to exercise generated scrape configuration and telemetry, not to
+validate authentication at the HTTP server.
+
+## Deploy
+
+```powershell
+kubectl apply -f .\testartifacts\auth-monitor-telemetry
+```
+
+If scoped Secret access is enabled, ensure the target allocator is configured
+to read Secrets from the `ama-metrics-auth-telemetry-test` namespace.
+
+The file-based ServiceMonitor uses the collector's standard service-account
+token path:
+
+```text
+/var/run/secrets/kubernetes.io/serviceaccount/token
+```
+
+Run this only on a test cluster. When `DenyFSAccessThroughSMs` is enabled, the
+file-based ServiceMonitor scrape job is intentionally dropped and its
+file-specific telemetry remains false.
+
+## Verify resources
+
+```powershell
+kubectl get servicemonitors.azmonitoring.coreos.com,podmonitors.azmonitoring.coreos.com -n ama-metrics-auth-telemetry-test
+```
+
+The following `ClusterCoreCapacity` dimensions should become true after the
+next telemetry interval:
+
+```text
+ServiceMonitorBasicAuthEnabled
+ServiceMonitorBearerTokenEnabled
+ServiceMonitorBearerTokenFileEnabled
+PodMonitorBasicAuthEnabled
+PodMonitorBearerTokenEnabled
+```
+
+## Remove
+
+```powershell
+kubectl delete namespace ama-metrics-auth-telemetry-test
+```


### PR DESCRIPTION
# PR Description

Adds Application Insights telemetry to identify clusters with ServiceMonitor and PodMonitor scrape jobs that use Basic Auth or Bearer token authentication.

The telemetry is attached to the existing `ClusterCoreCapacity` metric and classifies generated target allocator scrape jobs by their `serviceMonitor/` and `podMonitor/` job-name prefixes.

## Telemetry dimensions

The following cluster-level boolean dimensions are added:

| Dimension | Meaning |
|---|---|
| `ServiceMonitorBasicAuthEnabled` | At least one ServiceMonitor scrape job uses Basic Auth. |
| `PodMonitorBasicAuthEnabled` | At least one PodMonitor scrape job uses Basic Auth. |
| `ServiceMonitorBearerTokenEnabled` | At least one ServiceMonitor scrape job uses Bearer authentication with file- or Secret-backed credentials. |
| `PodMonitorBearerTokenEnabled` | At least one PodMonitor scrape job uses Bearer authentication with file- or Secret-backed credentials. |
| `ServiceMonitorBearerTokenFileEnabled` | At least one ServiceMonitor scrape job uses `bearerTokenFile`/`authorization.credentials_file`. |
| `PodMonitorBearerTokenFileEnabled` | At least one PodMonitor scrape job uses `authorization.credentials_file`, if supported by the generated configuration. |

Existing dimensions `BasicAuthEnabled`, `BearerTokenEnabledWithFile`, and `BearerTokenEnabledWithSecret` are preserved.

## Implementation

- Extracts scrape-job authentication classification into a testable helper.
- Uses safe type checks while parsing target allocator `/scrape_configs` output.
- Keeps non-monitor scrape jobs from being attributed to ServiceMonitor or PodMonitor telemetry.
- Adds manual cluster test artifacts under `testartifacts/auth-monitor-telemetry` for Basic Auth, Secret-backed Bearer authentication, and ServiceMonitor `bearerTokenFile` scenarios.
- Documents that the current PodMonitor CRD does not expose `bearerTokenFile`.

## Validation

- `go test scrape_job_telemetry.go telemetry_test.go`
- `kubectl apply --dry-run=client -f .\testartifacts\auth-monitor-telemetry -o name`

# New Feature Checklist

- [x] List telemetry added about the feature — documented above.
- [ ] Link to the one-pager about the feature — not needed; this adds internal usage telemetry without changing the customer-facing authentication feature.
- [ ] List any tasks necessary for release after merging — none; dimensions are emitted through the existing `ClusterCoreCapacity` telemetry path.
- [ ] Attach results of scale and perf testing — not needed; this performs one linear scan of the existing scrape-job response during the existing 10-minute telemetry interval.

# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? Not run; the change is covered by focused unit tests and deployable manual test artifacts.
- [x] Have new tests been added? Unit tests cover ServiceMonitor and PodMonitor Basic Auth, file-backed and Secret-backed Bearer authentication, and non-monitor scrape jobs.
  - [ ] Is a new Ginkgo scrape job needed? No; manual manifests are provided under `testartifacts/auth-monitor-telemetry`.
  - [ ] Was a new test label added? No new Ginkgo suite or label is required.
  - [ ] Are additional API server permissions needed for new tests? No.
  - [ ] Was a new test suite added? No.