### PR TITLE
Update remote write release notes for prom-remotewrite-20260825.2

### DIFF
--- a/REMOTE-WRITE-RELEASENOTES.md
+++ b/REMOTE-WRITE-RELEASENOTES.md
@@ -1,5 +1,16 @@
 # Azure Monitor managed service for Prometheus remote write
 
+## Release 08-25-2026
+* Image - `mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-remote-write/images:prom-remotewrite-20260825.2`
+* Change log -
+  * Dependency bump only; no Go toolchain change (remains 1.25.13). Both x/ advisories below live in golang.org/x/* modules rather than the Go stdlib, so the earlier 1.25.10 -> 1.25.13 upgrade did not cover them.
+  * golang.org/x/text v0.3.8 -> v0.41.0. The effective build version was pinned to v0.3.8 by a `replace` directive that overrode the `require` line, so the exposure was older than the manifest suggested.
+  * golang.org/x/net v0.55.0 -> v0.58.0, golang.org/x/sys v0.15.0 -> v0.47.0, golang.org/x/crypto v0.52.0 -> v0.55.0 (crypto realigned to match the resolved module graph; no CVE of its own).
+* Fixed CVEs:
+    - [CVE-2026-56852](https://avd.aquasec.com/nvd/cve-2026-56852) - `golang.org/x/text` infinite loop on invalid input, leading to denial of service (fixed in x/text v0.39.0).
+    - [CVE-2026-46600](https://avd.aquasec.com/nvd/cve-2026-46600) - `golang.org/x/net/dns/dnsmessage` panic when parsing an invalid SVCB or HTTPS resource record (fixed in x/net v0.56.0). The stdlib range for this CVE begins at Go 1.26.0, so the 1.25.13 toolchain was not affected.
+    - [CVE-2026-39824](https://avd.aquasec.com/nvd/cve-2026-39824) - `golang.org/x/sys/windows` integer overflow in NewNTUnicodeString (fixed in x/sys v0.44.0). Windows-only and not reachable from this Linux image, cleared to keep dependency scans clean.
+
 ## Release 08-13-2026
 * Image - `mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-remote-write/images:prom-remotewrite-20260813.1`
 * Change log -


### PR DESCRIPTION
Adds the release notes entry for `prom-remotewrite-20260825.2`.

## What shipped

A **dependency-only** bump of vulnerable `golang.org/x/*` modules. No Go toolchain change — the image stays on Go 1.25.13.

This was reported by a downstream consumer running `prom-remotewrite-20260813.1`, whose scans still flagged two advisories after the previous release. They were right: both live in `golang.org/x/*` modules rather than the Go stdlib, so the earlier 1.25.10 -> 1.25.13 upgrade could not have covered them.

| Module | Effective before | After | CVE |
|---|---|---|---|
| `golang.org/x/text` | v0.3.8 | v0.41.0 | CVE-2026-56852 |
| `golang.org/x/net` | v0.55.0 | v0.58.0 | CVE-2026-46600 |
| `golang.org/x/sys` | v0.15.0 | v0.47.0 | CVE-2026-39824 |
| `golang.org/x/crypto` | v0.52.0 | v0.55.0 | alignment only |

## Notable

The `x/text` exposure was worse than the manifest suggested. A `replace` directive was overriding the `require` line, pinning the effective build version to **v0.3.8** while `require` advertised v0.37.0.

`CVE-2026-46600` also lists a stdlib range, but it begins at Go 1.26.0, so the 1.25.13 toolchain was unaffected.

## Validation

- `govulncheck -scan module`: 4 module-level findings -> 1. The remainder (`GO-2026-5932`, `x/crypto/openpgp` unmaintained) has no fix available and is already known/accepted.
- `go build`, `go vet`, `go test` all pass.
- Deployed to `monitoring-metrics-prod-aks-eus2euap`; pod 3/3 Running, 0 restarts, imageID digest matches the MCR manifest.
- 15+ minute soak post-deploy: remote-write `samples_total` advanced 12,274 -> 55,549 with `samples_failed_total=0` and `samples_retried_total=0` across all three targets; sidecar telemetry reported `failedPublishing=0` continuously.
- All three Azure Monitor workspaces queried directly and returned data under 10s old, with `count(up)` continuous across the image swap.
