### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,8 @@ updates:
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 2
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     directory: "/internal/referenceapp/golang" # reference app package manifests
     schedule:

--- a/.github/workflows/build-and-push-dependent-helm-charts.yml
+++ b/.github/workflows/build-and-push-dependent-helm-charts.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set-MCR-HELM-CHART-Repository-Root
         run: echo "MCR_REPOSITORY_ROOT=mcr.microsoft.com/azuremonitor/containerinsights/cidev/" >> $GITHUB_ENV
       - name: Checkout-code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Lint-HELM-Chart
         run: helm lint ./otelcollector/deploy/dependentcharts/${{ github.event.inputs.dependentHelmChartName }}/
       - name: Run-trivy-scanner-on-HELM-chart-fs

--- a/.github/workflows/build-and-release-mixin.yml
+++ b/.github/workflows/build-and-release-mixin.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Set-commit-sha
         run: echo "COMMIT_SHA=${GITHUB_SHA::8}" >> $GITHUB_ENV
       - name: get-go-version-greater-than-1-16
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '^1.17.3' 
       - name: Checkout-code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Set-HELM-Chart-Version
         run: version=$(cat ./otelcollector/VERSION) && echo "HELM_CHART_VERSION=${version}" >> $GITHUB_ENV
       - name: Set-semver
@@ -70,7 +70,7 @@ jobs:
       #    timeout: '5m0s'
       - name: Create-release
         id: create-release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         if: github.event_name != 'pull_request' # && env.BRANCH_NAME == 'vishwa-dash'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +86,7 @@ jobs:
           prerelease: true
       - name: Upload-Release-Asset
         id: upload-Release-Asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         if: github.event_name != 'pull_request' # && env.BRANCH_NAME == 'vishwa-dash'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/otelcollector-upgrade.yml
+++ b/.github/workflows/otelcollector-upgrade.yml
@@ -9,10 +9,10 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -83,7 +83,7 @@ jobs:
       - name: Create Pull Request
         if: ${{ env.ISNEWVERSION == 'true' && steps.check_existing_pr.outputs.exists == '0' }}
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ steps.generate-token.outputs.token }}
           commit-message: Upgrade otelcollector to ${{ env.VERSION }}
@@ -113,7 +113,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Checkout PR branch if it exists
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         if: steps.check_new_pr.outputs.exists != '0'
         with:
           ref: bot/otelcollector-upgrade-${{ env.VERSION }}
@@ -137,7 +137,7 @@ jobs:
 
       - name: Comment Build Failed on PR
         if: ${{ steps.cpr.outputs.pull-request-number && steps.run-make.outputs.make_failed == 'true' }}
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           issue-number: ${{ steps.cpr.outputs.pull-request-number }}
@@ -154,7 +154,7 @@ jobs:
 
       - name: Comment Build Succeeded on PR
         if: ${{ steps.cpr.outputs.pull-request-number && steps.run-make.outputs.make_failed == 'false' }}
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           issue-number: ${{ steps.cpr.outputs.pull-request-number }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: Comment CVE changes on PR
         if: ${{ steps.cpr.outputs.pull-request-number && steps.run-make.outputs.make_failed == 'false' && steps.trivy-scan.outputs.cve_changes }}
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           issue-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: write
     steps:
       - name: size-label
-        uses: "pascalgn/size-label-action@v0.5.7"
+        uses: "pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff" # v0.5.7
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v11
+    - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-issue-stale: 7


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
