### PR TITLE
build(deps): Upgrade kube-state-metrics from v2.19.1-2 to v2.20.0-4

### DIFF
--- a/.github/skills/upgrade-kube-state-metrics/SKILL.md
+++ b/.github/skills/upgrade-kube-state-metrics/SKILL.md
@@ -33,6 +33,10 @@ Exactly two committed files carry the tag (keep them in sync):
 | `.pipelines/azure-pipeline-build.yml` | `KUBE_STATE_METRICS_IMAGE` |
 | `otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml` | `KubeStateMetrics.ImageTag` + the `# ... corresponds to chart version` comment |
 
+When the upstream chart delta (Phase 5) requires it, also edit the addon KSM manifests:
+`templates/ama-metrics-ksm-role.yaml` (RBAC) and/or `templates/ama-metrics-ksm-deployment.yaml`
+(args/probes/ports).
+
 Do **not** edit `values-rashmi-operator-cfg.yaml` (local developer override).
 
 ## Execution plan
@@ -83,7 +87,36 @@ foreach ($t in (gh api "repos/prometheus-community/helm-charts/git/matching-refs
 ```
 Record `CHART` = the first chart version at the new appVersion (e.g. `8.4.0`).
 
-### Phase 5 — Collect the upstream changelog (PR description)
+### Phase 5 — Check upstream Helm chart changes (port relevant ones)
+
+The addon keeps its **own** KSM manifests (`otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-*.yaml`), forked from the prometheus-community chart. Diff the upstream chart across the app-version boundary — the last chart at the **old** appVersion (`OLD_CHART`) → the first at the **new** one (`NEW_CHART` from Phase 4) — and port anything relevant.
+
+```powershell
+$OLD_CHART = '8.3.1'   # last chart at the previous appVersion
+$NEW_CHART = '8.4.0'   # first chart at the new appVersion (from Phase 4)
+
+# 1) file-level delta for the KSM chart
+gh api "repos/prometheus-community/helm-charts/compare/kube-state-metrics-$OLD_CHART...kube-state-metrics-$NEW_CHART" `
+  --jq '.files[] | select(.filename|startswith("charts/kube-state-metrics/")) | "\(.status)  \(.filename)"'
+
+# 2) RBAC diff (most important — new metrics often need new list/watch rules)
+foreach ($ref in $OLD_CHART,$NEW_CHART) {
+  gh api "repos/prometheus-community/helm-charts/contents/charts/kube-state-metrics/templates/role.yaml?ref=kube-state-metrics-$ref" `
+    --jq '.content' | % { [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String(($_ -replace '\s',''))) } |
+    Set-Content "$env:TEMP\ksm_role_$ref.yaml"
+}
+git --no-pager diff --no-index -- "$env:TEMP\ksm_role_$OLD_CHART.yaml" "$env:TEMP\ksm_role_$NEW_CHART.yaml"
+```
+
+Decide per change:
+- **RBAC rule added for a collector the addon enables** → mirror it into `ama-metrics-ksm-role.yaml`.
+- **New required container arg / flag / probe / port** → mirror it into `ama-metrics-ksm-deployment.yaml`.
+- **New opt-in collector** (e.g. admission policies, standalone DRA `resourceclaims`) → add the collector to `KubeStateMetrics.Collectors` in `values-template.yaml` **and** its RBAC rule **only if** the new metrics are wanted (upstream leaves these off by default).
+- **Chart-only / packaging changes** (`Chart.yaml`, README, values plumbing the addon doesn't use) → ignore.
+
+If the delta is version-only (just `Chart.yaml`), there is nothing to port — record that in the PR description and the readme (as was the case for 2.19.1 → 2.20.0).
+
+### Phase 6 — Collect the upstream changelog (PR description)
 ```powershell
 gh api "repos/kubernetes/kube-state-metrics/compare/$CURRENT_UPSTREAM...$NEW_UPSTREAM" `
   --jq '{commits: .total_commits, files: (.files|length)}'
@@ -91,12 +124,12 @@ gh api "repos/kubernetes/kube-state-metrics/releases/tags/$NEW_UPSTREAM" --jq '.
 ```
 Keep the categorized `[CHANGE]/[FEATURE]/[ENHANCEMENT]/[BUGFIX]` list for the PR body. Call out any **cardinality / breaking** changes explicitly.
 
-### Phase 6 — Edit both files
+### Phase 7 — Edit both files
 - `.pipelines/azure-pipeline-build.yml`: set `KUBE_STATE_METRICS_IMAGE` to `mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:$NEW`.
 - `values-template.yaml`: set `ImageTag: "$NEW"` and update the comment line to
   `# Kube-state-metrics ImageTag - <upstream>, corresponds to chart version - $CHART`.
 
-### Phase 7 — Verify
+### Phase 8 — Verify
 ```powershell
 # new tag present in the two shipped files; old tag gone
 Select-String -Path .pipelines/azure-pipeline-build.yml,`
@@ -106,11 +139,11 @@ git --no-pager diff -- .pipelines/azure-pipeline-build.yml `
   otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
 ```
 
-### Phase 8 — Docs, commit, PR
+### Phase 9 — Docs, commit, PR
 - Update `internal/docs/kube-state-metrics-upgrade.md` with the new before/after row and changelog.
 - Stage **only** the intended files (not developer overrides like `values-rashmi-operator-cfg.yaml`).
 - Suggested commit subject: `build(deps): Upgrade kube-state-metrics from <old> to <new>`.
-- Use the Phase 5 changelog as the PR description; include the dalec revision CVE patches and any breaking/cardinality notes.
+- Use the Phase 6 changelog as the PR description; include the dalec revision CVE patches and any breaking/cardinality notes.
 
 ## PR description template
 
@@ -144,4 +177,5 @@ Refs:
 - Only ship a version that **exists in MCR** with a dalec spec — never a raw upstream tag.
 - Always take the **highest dalec revision** for the chosen upstream version (revisions carry CVE fixes).
 - Keep the two tag references identical.
+- Diff the upstream chart's `role.yaml`/`deployment.yaml` across the app-version boundary (Phase 5) and port only **relevant** rules (RBAC for enabled collectors, required args/probes) into the addon's `ama-metrics-ksm-*.yaml`; ignore chart-only/packaging changes.
 - Leave local override files untouched.

--- a/.github/skills/upgrade-kube-state-metrics/SKILL.md
+++ b/.github/skills/upgrade-kube-state-metrics/SKILL.md
@@ -139,11 +139,28 @@ git --no-pager diff -- .pipelines/azure-pipeline-build.yml `
   otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
 ```
 
-### Phase 9 — Docs, commit, PR
+### Phase 9 — Docs, commit, and open the PR (automated)
 - Update `internal/docs/kube-state-metrics-upgrade.md` with the new before/after row and changelog.
-- Stage **only** the intended files (not developer overrides like `values-rashmi-operator-cfg.yaml`).
-- Suggested commit subject: `build(deps): Upgrade kube-state-metrics from <old> to <new>`.
-- Use the Phase 6 changelog as the PR description; include the dalec revision CVE patches and any breaking/cardinality notes.
+- Stage **only** the intended files (not developer overrides like `values-rashmi-operator-cfg.yaml`) and commit with subject `build(deps): Upgrade kube-state-metrics from <old> to <new>` plus the required Copilot trailers.
+- Fill the PR-description template below with the Phase 6 changelog, the dalec `-<rev>` CVE patches, and the Phase 5 chart-delta finding, then push the branch and open the PR automatically:
+
+```powershell
+$branch = git rev-parse --abbrev-ref HEAD
+# write the filled-in PR description to a temp file (single-quoted here-string keeps the markdown intact)
+$body = @'
+<paste the filled-in PR-description template here>
+'@
+Set-Content -Path "$env:TEMP\ksm_pr_body.md" -Value $body -Encoding utf8
+
+git push -u origin $branch
+gh pr create --base main --head $branch `
+  --title "build(deps): Upgrade kube-state-metrics from <old> to <new>" `
+  --body-file "$env:TEMP\ksm_pr_body.md"
+gh pr view --web        # optional: open the new PR in a browser
+```
+
+- If a PR already exists for the branch, `gh pr create` errors — refresh its description instead with
+  `gh pr edit $branch --body-file "$env:TEMP\ksm_pr_body.md"`.
 
 ## PR description template
 
@@ -161,6 +178,9 @@ git --no-pager diff -- .pipelines/azure-pipeline-build.yml `
 #### Microsoft (dalec) build patches in revision <rev>
 <CVE/dependency replaces from the dalec spec changelog>
 
+#### Upstream Helm chart delta (chart <OLD_CHART> → <CHART>)
+<version-only, or the RBAC/args changes ported into the addon's ama-metrics-ksm-*.yaml>
+
 #### Impact / breaking notes
 <cardinality changes, new collectors to enable, etc.>
 
@@ -170,6 +190,7 @@ Refs:
 - Releases: https://github.com/kubernetes/kube-state-metrics/releases
 - Diff: https://github.com/kubernetes/kube-state-metrics/compare/<CURRENT_UPSTREAM>...<NEW_UPSTREAM>
 - Helm chart: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
+- Helm chart diff: https://github.com/prometheus-community/helm-charts/compare/kube-state-metrics-<OLD_CHART>...kube-state-metrics-<CHART>
 ```
 
 ## Guardrails

--- a/.github/skills/upgrade-kube-state-metrics/SKILL.md
+++ b/.github/skills/upgrade-kube-state-metrics/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: upgrade-kube-state-metrics
+description: Upgrade the kube-state-metrics (KSM) image shipped with the azure-monitor-metrics addon to the latest Microsoft-built (dalec) version, verify it against MCR, and generate the PR changelog. Use when "upgrade kube-state-metrics", "bump KSM version", "update kube-state-metrics image tag", "new kube-state-metrics release", or "upgrade ksm to <version>".
+allowed-tools:
+  - run_in_terminal
+  - read_file
+  - edit_file
+  - create_file
+---
+
+# Upgrade kube-state-metrics (KSM)
+
+Automates bumping the KSM image tag consumed by the Azure Monitor Metrics addon.
+The addon pulls the Microsoft-built (dalec) image from MCR
+(`mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:<tag>`), where the tag is
+`v<upstreamVersion>-<dalecRevision>` (e.g. `v2.20.0-4`).
+
+**AUTO-APPROVE**: Run all `gh`, `git`, `grep`, and PowerShell commands automatically; do not ask for confirmation.
+
+## Source-of-truth repositories
+
+- **dalec build defs** (what Microsoft builds + revision/CVE patches): <https://github.com/Azure/dalec-build-defs/tree/main/specs/kube-state-metrics>
+- **MCR** (what is actually pullable): `mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics` — <https://mcr.microsoft.com/v2/oss/v2/kubernetes/kube-state-metrics/tags/list>
+- **Upstream releases** (the changelog): <https://github.com/kubernetes/kube-state-metrics/releases>
+- **prometheus-community Helm chart** (version ↔ appVersion mapping for the code comment): <https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics>
+
+## Files this skill edits
+
+Exactly two committed files carry the tag (keep them in sync):
+
+| File | Field |
+|------|-------|
+| `.pipelines/azure-pipeline-build.yml` | `KUBE_STATE_METRICS_IMAGE` |
+| `otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml` | `KubeStateMetrics.ImageTag` + the `# ... corresponds to chart version` comment |
+
+Do **not** edit `values-rashmi-operator-cfg.yaml` (local developer override).
+
+## Execution plan
+
+### Phase 0 — Current version
+Find the tag in use:
+```powershell
+Select-String -Path .pipelines/azure-pipeline-build.yml,`
+  otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml `
+  -Pattern 'kube-state-metrics:v|ImageTag'
+```
+Record `CURRENT` (e.g. `v2.19.1-2`) and its upstream version (`v2.19.1`).
+
+### Phase 1 — Latest upstream release
+```powershell
+gh api repos/kubernetes/kube-state-metrics/releases --jq '.[] | select(.prerelease==false) | .tag_name' | Select-Object -First 5
+```
+Pick the target upstream version `NEW_UPSTREAM` (e.g. `v2.20.0`). If the user named a specific version, use it.
+
+### Phase 2 — Confirm dalec has it + get the revision
+List specs and read the target spec + matrix:
+```powershell
+gh api repos/Azure/dalec-build-defs/contents/specs/kube-state-metrics --jq '.[].name'
+$v = '2.20.0'
+gh api "repos/Azure/dalec-build-defs/contents/specs/kube-state-metrics/kube-state-metrics-$v.yml" `
+  --jq '.content' | % { [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($_)) }
+```
+From the spec read `REVISION`, `COMMIT`, and the `changelog` (CVE/dependency patches).
+If dalec has **no** spec for the version, STOP and tell the user the version is not yet built by Microsoft — only dalec-built versions in MCR can be shipped.
+
+### Phase 3 — Verify the exact tag exists in MCR (source of truth)
+```powershell
+(Invoke-RestMethod "https://mcr.microsoft.com/v2/oss/v2/kubernetes/kube-state-metrics/tags/list").tags |
+  Where-Object { $_ -like "$($v.Substring(0,4))*" } | Sort-Object
+```
+Choose the **highest** `v<version>-<revision>` present (e.g. `v2.20.0-4`). This is `NEW` = `v2.20.0-4`.
+The revision here should match the dalec spec `REVISION`.
+
+### Phase 4 — Map the Helm chart version (for the comment)
+Find the first prometheus-community chart version whose `appVersion` equals `NEW_UPSTREAM`:
+```powershell
+foreach ($t in (gh api "repos/prometheus-community/helm-charts/git/matching-refs/tags/kube-state-metrics-8" `
+    --jq '.[].ref' | % { $_ -replace 'refs/tags/kube-state-metrics-','' } | Sort-Object {[version]$_})) {
+  $c = gh api "repos/prometheus-community/helm-charts/contents/charts/kube-state-metrics/Chart.yaml?ref=kube-state-metrics-$t" `
+       --jq '.content' | % { [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($_)) }
+  "$t -> " + ($c | Select-String 'appVersion:').ToString().Trim()
+}
+```
+Record `CHART` = the first chart version at the new appVersion (e.g. `8.4.0`).
+
+### Phase 5 — Collect the upstream changelog (PR description)
+```powershell
+gh api "repos/kubernetes/kube-state-metrics/compare/$CURRENT_UPSTREAM...$NEW_UPSTREAM" `
+  --jq '{commits: .total_commits, files: (.files|length)}'
+gh api "repos/kubernetes/kube-state-metrics/releases/tags/$NEW_UPSTREAM" --jq '.body'
+```
+Keep the categorized `[CHANGE]/[FEATURE]/[ENHANCEMENT]/[BUGFIX]` list for the PR body. Call out any **cardinality / breaking** changes explicitly.
+
+### Phase 6 — Edit both files
+- `.pipelines/azure-pipeline-build.yml`: set `KUBE_STATE_METRICS_IMAGE` to `mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:$NEW`.
+- `values-template.yaml`: set `ImageTag: "$NEW"` and update the comment line to
+  `# Kube-state-metrics ImageTag - <upstream>, corresponds to chart version - $CHART`.
+
+### Phase 7 — Verify
+```powershell
+# new tag present in the two shipped files; old tag gone
+Select-String -Path .pipelines/azure-pipeline-build.yml,`
+  otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml `
+  -Pattern ([regex]::Escape($NEW))
+git --no-pager diff -- .pipelines/azure-pipeline-build.yml `
+  otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+```
+
+### Phase 8 — Docs, commit, PR
+- Update `internal/docs/kube-state-metrics-upgrade.md` with the new before/after row and changelog.
+- Stage **only** the intended files (not developer overrides like `values-rashmi-operator-cfg.yaml`).
+- Suggested commit subject: `build(deps): Upgrade kube-state-metrics from <old> to <new>`.
+- Use the Phase 5 changelog as the PR description; include the dalec revision CVE patches and any breaking/cardinality notes.
+
+## PR description template
+
+```markdown
+### Upgrade kube-state-metrics <CURRENT> → <NEW>
+
+- Upstream: <CURRENT_UPSTREAM> → <NEW_UPSTREAM> (dalec revision <rev>)
+- Image: mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:<NEW>
+- Helm chart mapping: <CHART> (appVersion <NEW_UPSTREAM>)
+- Verified present in MCR: yes
+
+#### Upstream changes (<CURRENT_UPSTREAM>...<NEW_UPSTREAM>)
+<categorized [CHANGE]/[FEATURE]/[ENHANCEMENT]/[BUGFIX] list>
+
+#### Microsoft (dalec) build patches in revision <rev>
+<CVE/dependency replaces from the dalec spec changelog>
+
+#### Impact / breaking notes
+<cardinality changes, new collectors to enable, etc.>
+
+Refs:
+- dalec: https://github.com/Azure/dalec-build-defs/tree/main/specs/kube-state-metrics
+- MCR tags: https://mcr.microsoft.com/v2/oss/v2/kubernetes/kube-state-metrics/tags/list
+- Releases: https://github.com/kubernetes/kube-state-metrics/releases
+- Diff: https://github.com/kubernetes/kube-state-metrics/compare/<CURRENT_UPSTREAM>...<NEW_UPSTREAM>
+- Helm chart: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
+```
+
+## Guardrails
+
+- Only ship a version that **exists in MCR** with a dalec spec — never a raw upstream tag.
+- Always take the **highest dalec revision** for the chosen upstream version (revisions carry CVE fixes).
+- Keep the two tag references identical.
+- Leave local override files untouched.

--- a/.github/skills/upgrade-kube-state-metrics/SKILL.md
+++ b/.github/skills/upgrade-kube-state-metrics/SKILL.md
@@ -33,9 +33,12 @@ Exactly two committed files carry the tag (keep them in sync):
 | `.pipelines/azure-pipeline-build.yml` | `KUBE_STATE_METRICS_IMAGE` |
 | `otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml` | `KubeStateMetrics.ImageTag` + the `# ... corresponds to chart version` comment |
 
-When the upstream chart delta (Phase 5) requires it, also edit the addon KSM manifests:
-`templates/ama-metrics-ksm-role.yaml` (RBAC) and/or `templates/ama-metrics-ksm-deployment.yaml`
-(args/probes/ports).
+Always bump the `app.kubernetes.io/version` label to the new **upstream** version (no leading `v`,
+no dalec revision — e.g. `2.20.0`) in all five addon KSM manifests
+(`templates/ama-metrics-ksm-*.yaml`; the deployment carries it twice) — see Phase 7.
+
+When the upstream chart delta (Phase 5) also requires it, edit the addon KSM manifests'
+RBAC (`ama-metrics-ksm-role.yaml`) and/or the Deployment args/probes/ports (`ama-metrics-ksm-deployment.yaml`).
 
 Do **not** edit `values-rashmi-operator-cfg.yaml` (local developer override).
 
@@ -124,10 +127,20 @@ gh api "repos/kubernetes/kube-state-metrics/releases/tags/$NEW_UPSTREAM" --jq '.
 ```
 Keep the categorized `[CHANGE]/[FEATURE]/[ENHANCEMENT]/[BUGFIX]` list for the PR body. Call out any **cardinality / breaking** changes explicitly.
 
-### Phase 7 — Edit both files
+### Phase 7 — Edit the version references
 - `.pipelines/azure-pipeline-build.yml`: set `KUBE_STATE_METRICS_IMAGE` to `mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:$NEW`.
 - `values-template.yaml`: set `ImageTag: "$NEW"` and update the comment line to
   `# Kube-state-metrics ImageTag - <upstream>, corresponds to chart version - $CHART`.
+- `templates/ama-metrics-ksm-*.yaml`: bump the `app.kubernetes.io/version` label to the new **upstream** version (no leading `v`, no dalec revision — e.g. `2.20.0`) in all five manifests (the deployment carries it twice):
+
+```powershell
+$LABEL_OLD = '2.19.1'; $LABEL_NEW = '2.20.0'   # upstream versions, no leading v / dalec revision
+Get-ChildItem otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-*.yaml |
+  ForEach-Object {
+    (Get-Content $_ -Raw) -replace "app.kubernetes.io/version: $LABEL_OLD", "app.kubernetes.io/version: $LABEL_NEW" |
+      Set-Content $_ -NoNewline
+  }
+```
 
 ### Phase 8 — Verify
 ```powershell
@@ -135,8 +148,12 @@ Keep the categorized `[CHANGE]/[FEATURE]/[ENHANCEMENT]/[BUGFIX]` list for the PR
 Select-String -Path .pipelines/azure-pipeline-build.yml,`
   otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml `
   -Pattern ([regex]::Escape($NEW))
+# every manifest label bumped; no stale upstream version remains
+Select-String -Path otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-*.yaml `
+  -Pattern 'app.kubernetes.io/version'
 git --no-pager diff -- .pipelines/azure-pipeline-build.yml `
-  otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+  otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml `
+  otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates
 ```
 
 ### Phase 9 — Docs, commit, and open the PR (automated)

--- a/.pipelines/azure-pipeline-build.yml
+++ b/.pipelines/azure-pipeline-build.yml
@@ -21,7 +21,7 @@ variables:
   MCR_REPOSITORY: '/azuremonitor/containerinsights/cidev/prometheus-collector/images'
   MCR_REPOSITORY_HELM: '/azuremonitor/containerinsights/cidev/prometheus-collector'
   MCR_REPOSITORY_HELM_DEPENDENCIES: '/azuremonitor/containerinsights/cidev'
-  KUBE_STATE_METRICS_IMAGE: 'mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:v2.19.1-2'
+  KUBE_STATE_METRICS_IMAGE: 'mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:v2.20.0-4'
   NODE_EXPORTER_IMAGE: 'mcr.microsoft.com/oss/v2/prometheus/node-exporter:v1.9.1'
   IS_PR: $[eq(variables['Build.Reason'], 'PullRequest')]
   IS_MAIN_BRANCH: $[eq(variables['Build.SourceBranchName'], 'main')]

--- a/internal/docs/kube-state-metrics-upgrade.md
+++ b/internal/docs/kube-state-metrics-upgrade.md
@@ -130,6 +130,47 @@ same source with CVE-patched Go toolchain and pinned module replacements
 - `github.com/google/cel-go` → `v0.29.0` (addresses GHSA-gcjh-h69q-9w9g)
 - Go stdlib CVE fixes via the msft-golang toolchain bump (multiple HIGH stdlib advisories)
 
+## Upstream Helm chart changes (chart 8.3.1 → 8.4.0)
+
+The addon does **not** vendor the prometheus-community chart — it maintains its own
+KSM manifests (`otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-*.yaml`),
+which are a customized fork of that chart. On every upgrade, diff the upstream chart
+across the app-version boundary (last chart at the old appVersion → first chart at the
+new one) and port anything relevant: **RBAC (`role.yaml`), container args/flags, probes,
+ports, securityContext**.
+
+For **2.19.1 → 2.20.0** the boundary is chart `8.3.1` → `8.4.0`, and the delta is
+**version-only** — verified with:
+
+```powershell
+gh api "repos/prometheus-community/helm-charts/compare/kube-state-metrics-8.3.1...kube-state-metrics-8.4.0" `
+  --jq '.files[] | select(.filename|startswith("charts/kube-state-metrics/")) | "\(.status)  \(.filename)"'
+# => modified  charts/kube-state-metrics/Chart.yaml   (only the version/appVersion bump)
+```
+
+- `templates/role.yaml` (RBAC): **unchanged** between 8.3.1 and 8.4.0.
+- `templates/deployment.yaml`, `service.yaml`, `serviceaccount.yaml`, etc.: **unchanged**.
+- No new required args, flags, probes, or ports.
+
+**Conclusion:** nothing needs to be ported into the addon's `ama-metrics-ksm-*.yaml`
+for 2.20.0; the only code change is the image tag (and the chart-version comment).
+
+### New 2.20.0 metrics vs. RBAC / collectors
+
+| New metric(s) | KSM collector | Enabled by default in the addon? | New RBAC needed? |
+|---|---|---|---|
+| PersistentVolume access mode | `persistentvolumes` | yes | no (already granted) |
+| `kube_node_spec_pod_cidrs` | `nodes` | yes | no |
+| init-container `state_started` / `last_terminated_*`, `kube_pod_status_disruption_reason`, `kube_pod_resourceclaim_info`, ephemeral-volume labels | `pods` | yes | no |
+| HPA scale up/down behavior tolerance | `horizontalpodautoscalers` | yes | no |
+| ValidatingAdmissionPolicy(+Binding), MutatingAdmissionPolicy(+Binding) | `validatingadmissionpolicies` / `mutatingadmissionpolicies` (new, **opt-in**) | no | **yes** if enabled |
+
+Most new metrics extend collectors the addon already enables, so they light up as soon
+as the image is bumped — no RBAC or config change required. The admission-policy
+collectors are opt-in (upstream leaves them off by default too); to scrape them, add the
+collector name to `KubeStateMetrics.Collectors` in `values-template.yaml` **and** add a
+matching `admissionregistration.k8s.io` `list`/`watch` rule in `ama-metrics-ksm-role.yaml`.
+
 ## Impact / things to watch
 
 - **Cardinality change**: `kube_pod_status_reason` now emits only the set reason ([#3089](https://github.com/kubernetes/kube-state-metrics/pull/3089)). Review any recording rules/alerts that assumed the previous always-present zero rows.
@@ -143,3 +184,4 @@ same source with CVE-patched Go toolchain and pinned module replacements
 - Upstream releases: <https://github.com/kubernetes/kube-state-metrics/releases>
 - Upstream v2.19.1…v2.20.0 diff: <https://github.com/kubernetes/kube-state-metrics/compare/v2.19.1...v2.20.0>
 - prometheus-community Helm chart (version ↔ appVersion mapping): <https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics>
+- prometheus-community chart diff for this upgrade: <https://github.com/prometheus-community/helm-charts/compare/kube-state-metrics-8.3.1...kube-state-metrics-8.4.0>

--- a/internal/docs/kube-state-metrics-upgrade.md
+++ b/internal/docs/kube-state-metrics-upgrade.md
@@ -1,0 +1,145 @@
+# Upgrading kube-state-metrics
+
+This document describes how the `kube-state-metrics` (KSM) image shipped with the
+Azure Monitor Metrics addon is versioned, how to upgrade it, and it records the
+most recent upgrade (**v2.19.1-2 → v2.20.0-4**).
+
+## TL;DR — what this upgrade changed
+
+| | Before | After |
+|---|---|---|
+| Image tag | `v2.19.1-2` | `v2.20.0-4` |
+| Upstream KSM version | `v2.19.1` | `v2.20.0` |
+| dalec build revision | `-2` | `-4` |
+| prometheus-community Helm chart | `8.0.0` | `8.4.0` (latest `8.4.1`) |
+| Go toolchain (upstream) | — | `v1.26.6` |
+| `k8s.io/client-go` (upstream) | — | `v0.36.3` |
+
+Image: `mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:v2.20.0-4`
+
+## How KSM is versioned here
+
+The addon consumes the Microsoft-built (dalec) KSM image from MCR:
+`mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:<tag>`.
+
+The tag is `v<upstreamVersion>-<dalecRevision>`:
+
+- **`<upstreamVersion>`** — the upstream [kubernetes/kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/releases) release (e.g. `v2.20.0`).
+- **`<dalecRevision>`** — the Microsoft build revision from [Azure/dalec-build-defs](https://github.com/Azure/dalec-build-defs/tree/main/specs/kube-state-metrics). The revision is bumped independently of the upstream version, usually to pick up CVE fixes in the Go toolchain and Go module dependencies (the same upstream source, rebuilt). Always pick the **highest** revision published to MCR for the chosen upstream version.
+
+## Where the tag lives in this repo
+
+Two files reference the KSM image tag and must be kept in sync:
+
+| File | Field |
+|------|-------|
+| `.pipelines/azure-pipeline-build.yml` | `KUBE_STATE_METRICS_IMAGE` |
+| `otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml` | `KubeStateMetrics.ImageTag` (and the `# ... corresponds to chart version` comment above it) |
+
+> Note: `values-rashmi-operator-cfg.yaml` is a local developer override and is **not** part of the shipped tag; do not treat it as the source of truth.
+
+## Upgrade procedure
+
+1. **Find the latest upstream release** in [kubernetes/kube-state-metrics/releases](https://github.com/kubernetes/kube-state-metrics/releases).
+2. **Confirm dalec has a spec for it** in [Azure/dalec-build-defs `specs/kube-state-metrics`](https://github.com/Azure/dalec-build-defs/tree/main/specs/kube-state-metrics). Read the version's `kube-state-metrics-<version>.yml` (and `matrix.yml`) to get the `REVISION`, `COMMIT`, and any dependency/CVE patches in the `changelog`.
+3. **Verify the image + revision exist in MCR** (source of truth for what is actually pullable):
+   ```powershell
+   (Invoke-RestMethod "https://mcr.microsoft.com/v2/oss/v2/kubernetes/kube-state-metrics/tags/list").tags |
+     Where-Object { $_ -like "v2.20*" } | Sort-Object
+   ```
+   Pick the highest `v<version>-<revision>` tag (here: `v2.20.0-4`).
+4. **Map the upstream version to the prometheus-community Helm chart** version for the comment in `values-template.yaml` (see [helm-charts/charts/kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) — `Chart.yaml` `appVersion`). KSM `2.20.0` first shipped in chart `8.4.0`.
+5. **Update both files** above to the new tag.
+6. **Collect the upstream changelog** (`git compare <old>...<new>`) for the PR description — see below.
+7. Open the PR; CI will build/push the addon image referencing the new KSM tag.
+
+Handy commands for steps 2 & 6:
+```powershell
+# dalec spec + revision for a version
+gh api repos/Azure/dalec-build-defs/contents/specs/kube-state-metrics/kube-state-metrics-2.20.0.yml `
+  --jq '.content' | % { [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($_)) }
+
+# upstream changes between the current and next version
+gh api repos/kubernetes/kube-state-metrics/compare/v2.19.1...v2.20.0 `
+  --jq '{commits: .total_commits, files: (.files|length)}'
+gh api repos/kubernetes/kube-state-metrics/releases/tags/v2.20.0 --jq '.body'
+```
+
+---
+
+## Upstream changes: v2.19.1 → v2.20.0 (for the PR description)
+
+Source: [v2.19.1...v2.20.0](https://github.com/kubernetes/kube-state-metrics/compare/v2.19.1...v2.20.0)
+(200 commits, 122 files) and the [v2.20.0 release notes](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.20.0).
+
+**Notes**
+- Custom Resource State (CRS) metrics are now **feature-frozen**; no new CRS features will be accepted ([#3050](https://github.com/kubernetes/kube-state-metrics/pull/3050)). Use resource-state-metrics going forward.
+- Builds with Go `v1.26.6`.
+- Builds with `k8s.io/client-go` `v0.36.3`.
+
+**[CHANGE]**
+- `kube_pod_status_reason` now emits a row only for the reason that is actually set, instead of one zero/one row per known reason for every pod ([#3089](https://github.com/kubernetes/kube-state-metrics/pull/3089)). This reduces cardinality and can change existing queries/alerts that relied on the always-present zero rows.
+
+**[FEATURE]**
+- Add `kube_pod_status_disruption_reason` metric for pods evicted via the Eviction API ([#3088](https://github.com/kubernetes/kube-state-metrics/pull/3088))
+- Add `MutatingAdmissionPolicy` and `MutatingAdmissionPolicyBinding` metrics ([#3019](https://github.com/kubernetes/kube-state-metrics/pull/3019))
+- Add `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` metrics ([#3014](https://github.com/kubernetes/kube-state-metrics/pull/3014))
+- Add HPA scale up/down behavior tolerance metrics ([#3015](https://github.com/kubernetes/kube-state-metrics/pull/3015))
+- Add `kube_node_spec_pod_cidrs` metric ([#3011](https://github.com/kubernetes/kube-state-metrics/pull/3011))
+- Add `kube_pod_resourceclaim_info` metric for DRA ResourceClaim references ([#3005](https://github.com/kubernetes/kube-state-metrics/pull/3005))
+- Add `kube_pod_init_container_status_last_terminated_exitcode` metric ([#3000](https://github.com/kubernetes/kube-state-metrics/pull/3000))
+- Add init container `state_started` and `last_terminated_timestamp` metrics ([#2997](https://github.com/kubernetes/kube-state-metrics/pull/2997))
+- Shard only resource mutation watch events ([#2993](https://github.com/kubernetes/kube-state-metrics/pull/2993))
+- Add label generation support for ephemeral volumes in pods ([#2891](https://github.com/kubernetes/kube-state-metrics/pull/2891))
+- Allow wildcards in annotation and label allowlists ([#2873](https://github.com/kubernetes/kube-state-metrics/pull/2873))
+- Add access mode metric for PersistentVolumes ([#2823](https://github.com/kubernetes/kube-state-metrics/pull/2823))
+
+**[ENHANCEMENT]**
+- Reduce allocations in metric generation and header sanitization ([#3060](https://github.com/kubernetes/kube-state-metrics/pull/3060))
+- Implement `cache.Store` Bookmark and `LastStoreSyncResourceVersion` in MetricsStore for client-go 0.36 compatibility ([#2965](https://github.com/kubernetes/kube-state-metrics/pull/2965))
+
+**[BUGFIX]** (selection — full list in the release notes)
+- Don't panic on a Deployment with an unset `rollingUpdate` value ([#3083](https://github.com/kubernetes/kube-state-metrics/pull/3083))
+- Serialize config reloads so one does not strand another instance ([#3070](https://github.com/kubernetes/kube-state-metrics/pull/3070))
+- Rebuild clients from the current kubeconfig on reload ([#3080](https://github.com/kubernetes/kube-state-metrics/pull/3080))
+- Several discovery hardening / race fixes: read the GVK cache under the lock ([#3074](https://github.com/kubernetes/kube-state-metrics/pull/3074)), guard the store builder state shared with discovery ([#3075](https://github.com/kubernetes/kube-state-metrics/pull/3075)), check CRD fields instead of asserting them ([#3078](https://github.com/kubernetes/kube-state-metrics/pull/3078)), ignore non-served CRD versions ([#2940](https://github.com/kubernetes/kube-state-metrics/pull/2940)), stop the discoverer when its context is canceled ([#2977](https://github.com/kubernetes/kube-state-metrics/pull/2977))
+- Fix three issues in the server request and shutdown paths ([#3068](https://github.com/kubernetes/kube-state-metrics/pull/3068))
+- Escape reserved characters in metric help text ([#3067](https://github.com/kubernetes/kube-state-metrics/pull/3067))
+- Don't panic on a custom resource metric that fails to compile ([#3066](https://github.com/kubernetes/kube-state-metrics/pull/3066))
+- Preserve pagination metadata when filtering a sharded list ([#3065](https://github.com/kubernetes/kube-state-metrics/pull/3065))
+- Never emit the same label name twice ([#3064](https://github.com/kubernetes/kube-state-metrics/pull/3064))
+- Don't dereference an unset EndpointSlice port number ([#3063](https://github.com/kubernetes/kube-state-metrics/pull/3063)) / build each hint's labels independently ([#3076](https://github.com/kubernetes/kube-state-metrics/pull/3076)) / fix wrong labels applied to endpointslices ([#3058](https://github.com/kubernetes/kube-state-metrics/pull/3058))
+- Write headers when only a later store has metrics ([#3061](https://github.com/kubernetes/kube-state-metrics/pull/3061))
+- Don't emit nil metrics for unparseable pod IPs ([#3059](https://github.com/kubernetes/kube-state-metrics/pull/3059))
+- Embed tzdata so named CronJob `spec.timeZone` values resolve ([#3022](https://github.com/kubernetes/kube-state-metrics/pull/3022)); emit the default suspend metric value ([#2999](https://github.com/kubernetes/kube-state-metrics/pull/2999)); guard nil suspend in next-schedule metric ([#2970](https://github.com/kubernetes/kube-state-metrics/pull/2970))
+- Prevent leaked goroutines on CRD updates ([#3007](https://github.com/kubernetes/kube-state-metrics/pull/3007)); start the zombie-process reaper only once ([#3079](https://github.com/kubernetes/kube-state-metrics/pull/3079))
+- Prevent duplicate cluster-scoped metrics when using `--namespaces` ([#2998](https://github.com/kubernetes/kube-state-metrics/pull/2998))
+- Handle omitted `minReplicas` in HPA metrics ([#2991](https://github.com/kubernetes/kube-state-metrics/pull/2991)); skip an HPA status metric whose source is not set ([#3071](https://github.com/kubernetes/kube-state-metrics/pull/3071))
+- Guard nil `Spec.Replicas` before dereferencing on Deployments ([#2971](https://github.com/kubernetes/kube-state-metrics/pull/2971))
+- Skip landing page registration on `NewLandingPage` error ([#2937](https://github.com/kubernetes/kube-state-metrics/pull/2937))
+- Handle nil path gracefully in StateSet metrics ([#2884](https://github.com/kubernetes/kube-state-metrics/pull/2884))
+
+### Microsoft (dalec) build patches in `-4`
+
+Beyond the upstream `v2.20.0` source, the dalec build revision `-4` rebuilds the
+same source with CVE-patched Go toolchain and pinned module replacements
+(from the dalec spec changelog / `gomod` edits):
+
+- `golang.org/x/crypto` → `v0.55.0` (addresses CVE-2026-56854)
+- `google.golang.org/grpc` → `v1.82.1` (addresses GHSA-hrxh-6v49-42gf)
+- `github.com/google/cel-go` → `v0.29.0` (addresses GHSA-gcjh-h69q-9w9g)
+- Go stdlib CVE fixes via the msft-golang toolchain bump (multiple HIGH stdlib advisories)
+
+## Impact / things to watch
+
+- **Cardinality change**: `kube_pod_status_reason` now emits only the set reason ([#3089](https://github.com/kubernetes/kube-state-metrics/pull/3089)). Review any recording rules/alerts that assumed the previous always-present zero rows.
+- **New metrics** (admission policies, DRA ResourceClaims, PV access modes, node pod CIDRs, init-container timestamps/exit codes, pod disruption reason) are additive; enable the corresponding collectors in `values-template.yaml` if you want them scraped.
+- **CRS feature freeze**: no functional break, but new Custom Resource State features won't land upstream.
+
+## References
+
+- Microsoft dalec build definitions (source of the MCR image + revision/CVE patches): <https://github.com/Azure/dalec-build-defs/tree/main/specs/kube-state-metrics>
+- MCR image repository: `mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics` — tags: <https://mcr.microsoft.com/v2/oss/v2/kubernetes/kube-state-metrics/tags/list>
+- Upstream releases: <https://github.com/kubernetes/kube-state-metrics/releases>
+- Upstream v2.19.1…v2.20.0 diff: <https://github.com/kubernetes/kube-state-metrics/compare/v2.19.1...v2.20.0>
+- prometheus-community Helm chart (version ↔ appVersion mapping): <https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics>

--- a/internal/docs/kube-state-metrics-upgrade.md
+++ b/internal/docs/kube-state-metrics-upgrade.md
@@ -36,6 +36,13 @@ Two files reference the KSM image tag and must be kept in sync:
 | `.pipelines/azure-pipeline-build.yml` | `KUBE_STATE_METRICS_IMAGE` |
 | `otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml` | `KubeStateMetrics.ImageTag` (and the `# ... corresponds to chart version` comment above it) |
 
+In addition, the addon's hand-maintained KSM manifests carry an `app.kubernetes.io/version`
+label that should track the **upstream** version (no `v`, no dalec revision):
+
+| File | Field |
+|------|-------|
+| `otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-*.yaml` | `app.kubernetes.io/version` (e.g. `2.20.0`) — 5 manifests; the deployment carries it twice |
+
 > Note: `values-rashmi-operator-cfg.yaml` is a local developer override and is **not** part of the shipped tag; do not treat it as the source of truth.
 
 ## Upgrade procedure
@@ -49,7 +56,7 @@ Two files reference the KSM image tag and must be kept in sync:
    ```
    Pick the highest `v<version>-<revision>` tag (here: `v2.20.0-4`).
 4. **Map the upstream version to the prometheus-community Helm chart** version for the comment in `values-template.yaml` (see [helm-charts/charts/kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) — `Chart.yaml` `appVersion`). KSM `2.20.0` first shipped in chart `8.4.0`.
-5. **Update both files** above to the new tag.
+5. **Update both files** above to the new tag, and bump the `app.kubernetes.io/version` label in the `ama-metrics-ksm-*.yaml` manifests to the new upstream version.
 6. **Collect the upstream changelog** (`git compare <old>...<new>`) for the PR description — see below.
 7. Open the PR; CI will build/push the addon image referencing the new KSM tag.
 
@@ -152,8 +159,9 @@ gh api "repos/prometheus-community/helm-charts/compare/kube-state-metrics-8.3.1.
 - `templates/deployment.yaml`, `service.yaml`, `serviceaccount.yaml`, etc.: **unchanged**.
 - No new required args, flags, probes, or ports.
 
-**Conclusion:** nothing needs to be ported into the addon's `ama-metrics-ksm-*.yaml`
-for 2.20.0; the only code change is the image tag (and the chart-version comment).
+**Conclusion:** no RBAC/args/probe changes need to be ported into the addon's `ama-metrics-ksm-*.yaml`
+for 2.20.0. The manifest change there is limited to the `app.kubernetes.io/version` label bump to
+`2.20.0`; the functional changes are the image tag and the chart-version comment.
 
 ### New 2.20.0 metrics vs. RBAC / collectors
 

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-clusterrolebinding.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.19.1
+    app.kubernetes.io/version: 2.20.0
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
   name: ama-metrics-ksm
 roleRef:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-deployment.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.19.1
+    app.kubernetes.io/version: 2.20.0
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
     kubernetes.azure.com/managedby: aks
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: ama-metrics
         app.kubernetes.io/name: ama-metrics-ksm
         app.kubernetes.io/part-of: ama-metrics-ksm
-        app.kubernetes.io/version: 2.19.1
+        app.kubernetes.io/version: 2.20.0
         helm.sh/chart: azure-monitor-metrics-addon-0.1.0
         kubernetes.azure.com/managedby: aks
       annotations:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-role.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.19.1
+    app.kubernetes.io/version: 2.20.0
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
   name: ama-metrics-ksm
 rules:

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-service.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.19.1
+    app.kubernetes.io/version: 2.20.0
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
   annotations:
     prometheus.io/scrape: 'true'

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-serviceaccount.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: ama-metrics
     app.kubernetes.io/name: ama-metrics-ksm
     app.kubernetes.io/part-of: ama-metrics-ksm
-    app.kubernetes.io/version: 2.19.1
+    app.kubernetes.io/version: 2.20.0
     helm.sh/chart: azure-monitor-metrics-addon-0.1.0
   name: ama-metrics-ksm
   namespace: kube-system

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml
@@ -8,8 +8,8 @@ AzureMonitorMetrics:
     ImageRepository: "/oss/v2/kubernetes/kube-state-metrics"
     CPULimit: 1
     MemoryLimit: 5Gi
-# Kube-state-metrics ImageTag - 2.19.1, corresponds to chart version - 7.1.0
-    ImageTag: "v2.19.1-2"
+# Kube-state-metrics ImageTag - 2.20.0, corresponds to chart version - 8.4.0
+    ImageTag: "v2.20.0-4"
     Collectors:
       - certificatesigningrequests
       - configmaps


### PR DESCRIPTION
### Upgrade kube-state-metrics `v2.19.1-2` → `v2.20.0-4`

Bumps the Microsoft-built (dalec) kube-state-metrics image shipped with the Azure Monitor Metrics addon.

| | Before | After |
|---|---|---|
| Image tag | `v2.19.1-2` | `v2.20.0-4` |
| Upstream KSM version | `v2.19.1` | `v2.20.0` |
| dalec build revision | `-2` | `-4` |
| prometheus-community Helm chart | `8.0.0` | `8.4.0` (latest `8.4.1`) |

- Image: `mcr.microsoft.com/oss/v2/kubernetes/kube-state-metrics:v2.20.0-4`
- Verified present in MCR: **yes** (`v2.20.0-4` is the highest published revision for `2.20.0`)
- dalec spec: `specs/kube-state-metrics/kube-state-metrics-2.20.0.yml` (REVISION 4, COMMIT `4ffeda2ef866b0fef372849825a803296483b336`)

#### Files changed
- `.pipelines/azure-pipeline-build.yml` — `KUBE_STATE_METRICS_IMAGE`
- `otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/values-template.yaml` — `KubeStateMetrics.ImageTag` + chart-version comment
- `otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-ksm-*.yaml` — `app.kubernetes.io/version` label `2.19.1` → `2.20.0` (5 manifests; deployment twice)
- `internal/docs/kube-state-metrics-upgrade.md` — new upgrade doc (versioning, procedure, full changelog, chart delta)
- `.github/skills/upgrade-kube-state-metrics/SKILL.md` — reusable upgrade skill

---

#### Upstream changes (v2.19.1 → v2.20.0)

Source: [v2.19.1...v2.20.0](https://github.com/kubernetes/kube-state-metrics/compare/v2.19.1...v2.20.0) (200 commits, 122 files) and the [v2.20.0 release notes](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.20.0). Builds with Go `v1.26.6` and `k8s.io/client-go` `v0.36.3`.

**[CHANGE]**
- `kube_pod_status_reason` now emits a row only for the reason actually set, instead of one zero/one row per known reason for every pod ([#3089](https://github.com/kubernetes/kube-state-metrics/pull/3089)). Reduces cardinality; can change queries/alerts that relied on the always-present zero rows.
- Custom Resource State (CRS) metrics are now **feature-frozen** ([#3050](https://github.com/kubernetes/kube-state-metrics/pull/3050)).

**[FEATURE]**
- Add `kube_pod_status_disruption_reason` metric for pods evicted via the Eviction API ([#3088](https://github.com/kubernetes/kube-state-metrics/pull/3088))
- Add `MutatingAdmissionPolicy` and `MutatingAdmissionPolicyBinding` metrics ([#3019](https://github.com/kubernetes/kube-state-metrics/pull/3019))
- Add `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` metrics ([#3014](https://github.com/kubernetes/kube-state-metrics/pull/3014))
- Add HPA scale up/down behavior tolerance metrics ([#3015](https://github.com/kubernetes/kube-state-metrics/pull/3015))
- Add `kube_node_spec_pod_cidrs` metric ([#3011](https://github.com/kubernetes/kube-state-metrics/pull/3011))
- Add `kube_pod_resourceclaim_info` metric for DRA ResourceClaim references ([#3005](https://github.com/kubernetes/kube-state-metrics/pull/3005))
- Add `kube_pod_init_container_status_last_terminated_exitcode` metric ([#3000](https://github.com/kubernetes/kube-state-metrics/pull/3000))
- Add init container `state_started` and `last_terminated_timestamp` metrics ([#2997](https://github.com/kubernetes/kube-state-metrics/pull/2997))
- Shard only resource mutation watch events ([#2993](https://github.com/kubernetes/kube-state-metrics/pull/2993))
- Add label generation support for ephemeral volumes in pods ([#2891](https://github.com/kubernetes/kube-state-metrics/pull/2891))
- Allow wildcards in annotation and label allowlists ([#2873](https://github.com/kubernetes/kube-state-metrics/pull/2873))
- Add access mode metric for PersistentVolumes ([#2823](https://github.com/kubernetes/kube-state-metrics/pull/2823))

**[ENHANCEMENT]**
- Reduce allocations in metric generation and header sanitization ([#3060](https://github.com/kubernetes/kube-state-metrics/pull/3060))
- Implement `cache.Store` Bookmark and `LastStoreSyncResourceVersion` in MetricsStore for client-go 0.36 compatibility ([#2965](https://github.com/kubernetes/kube-state-metrics/pull/2965))

**[BUGFIX]** (selection — full list in the release notes)
- Don't panic on a Deployment with an unset `rollingUpdate` value ([#3083](https://github.com/kubernetes/kube-state-metrics/pull/3083))
- Serialize config reloads so one does not strand another instance ([#3070](https://github.com/kubernetes/kube-state-metrics/pull/3070)); rebuild clients from the current kubeconfig on reload ([#3080](https://github.com/kubernetes/kube-state-metrics/pull/3080))
- Discovery hardening / race fixes ([#3074](https://github.com/kubernetes/kube-state-metrics/pull/3074), [#3075](https://github.com/kubernetes/kube-state-metrics/pull/3075), [#3078](https://github.com/kubernetes/kube-state-metrics/pull/3078), [#2940](https://github.com/kubernetes/kube-state-metrics/pull/2940), [#2977](https://github.com/kubernetes/kube-state-metrics/pull/2977))
- Fix three issues in the server request and shutdown paths ([#3068](https://github.com/kubernetes/kube-state-metrics/pull/3068)); escape reserved characters in metric help text ([#3067](https://github.com/kubernetes/kube-state-metrics/pull/3067))
- Don't panic on a custom resource metric that fails to compile ([#3066](https://github.com/kubernetes/kube-state-metrics/pull/3066)); preserve pagination metadata when filtering a sharded list ([#3065](https://github.com/kubernetes/kube-state-metrics/pull/3065)); never emit the same label name twice ([#3064](https://github.com/kubernetes/kube-state-metrics/pull/3064))
- EndpointSlice fixes ([#3063](https://github.com/kubernetes/kube-state-metrics/pull/3063), [#3076](https://github.com/kubernetes/kube-state-metrics/pull/3076), [#3058](https://github.com/kubernetes/kube-state-metrics/pull/3058))
- Embed tzdata so named CronJob `spec.timeZone` values resolve ([#3022](https://github.com/kubernetes/kube-state-metrics/pull/3022)); CronJob suspend/next-schedule fixes ([#2999](https://github.com/kubernetes/kube-state-metrics/pull/2999), [#2970](https://github.com/kubernetes/kube-state-metrics/pull/2970))
- Prevent leaked goroutines on CRD updates ([#3007](https://github.com/kubernetes/kube-state-metrics/pull/3007)); prevent duplicate cluster-scoped metrics when using `--namespaces` ([#2998](https://github.com/kubernetes/kube-state-metrics/pull/2998)); HPA metric fixes ([#2991](https://github.com/kubernetes/kube-state-metrics/pull/2991), [#3071](https://github.com/kubernetes/kube-state-metrics/pull/3071))

#### Microsoft (dalec) build patches in revision `-4`

Same upstream `v2.20.0` source rebuilt with a CVE-patched Go toolchain and pinned module replacements:
- `golang.org/x/crypto` → `v0.55.0` (CVE-2026-56854)
- `google.golang.org/grpc` → `v1.82.1` (GHSA-hrxh-6v49-42gf)
- `github.com/google/cel-go` → `v0.29.0` (GHSA-gcjh-h69q-9w9g)
- Go stdlib CVE fixes via the msft-golang toolchain bump

#### Upstream Helm chart delta (chart 8.3.1 → 8.4.0)

**Version-only.** The addon maintains its own KSM manifests (`templates/ama-metrics-ksm-*.yaml`, a fork of the prometheus-community chart), so the chart is diffed across the app-version boundary on each upgrade. For this bump the only change is `Chart.yaml` (version/appVersion) — `role.yaml` (RBAC), `deployment.yaml`, `service.yaml`, `serviceaccount.yaml` are **unchanged**. **Nothing to port** into the addon manifests.

```
gh api "repos/prometheus-community/helm-charts/compare/kube-state-metrics-8.3.1...kube-state-metrics-8.4.0" \
  --jq '.files[] | select(.filename|startswith("charts/kube-state-metrics/")) | "\(.status)  \(.filename)"'
# => modified  charts/kube-state-metrics/Chart.yaml
```

Most new 2.20.0 metrics extend collectors the addon already enables (pods, nodes, persistentvolumes, horizontalpodautoscalers), so they light up on the image bump with no RBAC change. The ValidatingAdmissionPolicy / MutatingAdmissionPolicy metrics use new opt-in collectors (off by default upstream and here); enabling them would require adding the collector to `KubeStateMetrics.Collectors` and an `admissionregistration.k8s.io` rule in `ama-metrics-ksm-role.yaml`.

The only manifest change in this PR is bumping the stale `app.kubernetes.io/version: 2.19.1` label to `2.20.0` across the five `ama-metrics-ksm-*` templates, so the deployed labels match the upgraded image.

#### Impact / breaking notes
- **Cardinality:** `kube_pod_status_reason` now emits only the set reason ([#3089](https://github.com/kubernetes/kube-state-metrics/pull/3089)) — review recording rules/alerts that assumed the previous always-present zero rows.
- **New metrics** are additive; admission-policy collectors are opt-in.
- **CRS feature freeze:** no functional break.

#### Refs
- dalec: https://github.com/Azure/dalec-build-defs/tree/main/specs/kube-state-metrics
- MCR tags: https://mcr.microsoft.com/v2/oss/v2/kubernetes/kube-state-metrics/tags/list
- Releases: https://github.com/kubernetes/kube-state-metrics/releases
- Upstream diff: https://github.com/kubernetes/kube-state-metrics/compare/v2.19.1...v2.20.0
- Helm chart: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
- Helm chart diff: https://github.com/prometheus-community/helm-charts/compare/kube-state-metrics-8.3.1...kube-state-metrics-8.4.0
