### PR TITLE
chore: scope ama-metrics secret writes to fixed names

### DIFF
--- a/otelcollector/configuration-reader-builder/main.go
+++ b/otelcollector/configuration-reader-builder/main.go
@@ -22,7 +22,6 @@ import (
 	configmapsettings "github.com/prometheus-collector/shared/configmap/mp"
 	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes"
@@ -433,22 +432,17 @@ func generateSecretWithServerCertsForTA(serverCertPem string, serverKeyPem strin
 		return err
 	}
 
-	// Create or update the secret in the kube-system namespace
-	_, err = clientset.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+	// The secret is pre-created (empty) by the Helm chart, so only `update` on a fixed name is
+	// needed here. It is deliberately not created by this code: a bare `secrets: create` grant
+	// cannot be constrained by resourceNames, which would let a holder of this service account's
+	// token mint a ServiceAccount-token Secret under a name this account can also read.
+	_, err = clientset.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 	if err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			_, err = clientset.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
-			if err != nil {
-				log.Printf("Unable to update secret %s in namespace %s: %v", secretName, namespace, err)
-				return err
-			}
-		} else {
-			log.Printf("Unable to create secret %s in namespace %s: %v", secretName, namespace, err)
-			return err
-		}
+		log.Printf("Unable to update secret %s in namespace %s: %v", secretName, namespace, err)
+		return err
 	}
 
-	log.Printf("Secret %s created/updated successfully in namespace %s", secretName, namespace)
+	log.Printf("Secret %s updated successfully in namespace %s", secretName, namespace)
 	return nil
 }
 
@@ -488,22 +482,17 @@ func generateSecretWithClientCertForRs(clientCertPem string, clientKeyPem string
 		return err
 	}
 
-	// Create or update the secret in the kube-system namespace
-	_, err = clientset.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+	// The secret is pre-created (empty) by the Helm chart, so only `update` on a fixed name is
+	// needed here. It is deliberately not created by this code: a bare `secrets: create` grant
+	// cannot be constrained by resourceNames, which would let a holder of this service account's
+	// token mint a ServiceAccount-token Secret under a name this account can also read.
+	_, err = clientset.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 	if err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			_, err = clientset.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
-			if err != nil {
-				log.Printf("Unable to update secret %s in namespace %s: %v", secretName, namespace, err)
-				return err
-			}
-		} else {
-			log.Printf("Unable to create secret %s in namespace %s: %v", secretName, namespace, err)
-			return err
-		}
+		log.Printf("Unable to update secret %s in namespace %s: %v", secretName, namespace, err)
+		return err
 	}
 
-	log.Printf("Secret %s created/updated successfully in namespace %s", secretName, namespace)
+	log.Printf("Secret %s updated successfully in namespace %s", secretName, namespace)
 	return nil
 }
 

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-clusterRole.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-clusterRole.yaml
@@ -34,13 +34,15 @@ rules:
     verbs: ["get", "list", "watch"]
 {{- end }}
 {{- if .Values.AzureMonitorMetrics.OperatorTargetsHttpsEnabled }}
+  # These two secrets are pre-created by ama-metrics-operator-targets-tls-secrets.yaml so that
+  # the config-reader can populate them with `update` on a fixed name. Do not add a bare
+  # `secrets: create` rule here: RBAC cannot constrain `create` by resourceNames, so it would
+  # let a holder of this service account's token mint a ServiceAccount-token Secret under a
+  # name this same account is allowed to read.
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames: ["ama-metrics-operator-targets-client-tls-secret", "ama-metrics-operator-targets-server-tls-secret"]
     verbs: ["get", "update"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create"]
 {{- end }}
   - apiGroups: [""]
     resources: ["events"]

--- a/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-operator-targets-tls-secrets.yaml
+++ b/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-operator-targets-tls-secrets.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.AzureMonitorMetrics.OperatorTargetsHttpsEnabled }}
+{{/*
+  mTLS secrets used between the ama-metrics collector replicaset and the target allocator.
+
+  The config-reader sidecar generates the certificates and writes them into these secrets at
+  startup. They are pre-created here, empty, so that the ama-metrics service account only needs
+  `update` on these two fixed names rather than a cluster-wide `secrets: create` grant. RBAC
+  cannot constrain `create` by resourceNames, so such a grant lets any holder of this service
+  account's token create a Secret under a name the same account is also allowed to read.
+
+  Existing data is preserved across upgrades via `lookup`, so `helm upgrade` does not reset live
+  certificates. This is the same pattern already used for the HPA in _ama-metrics-helpers.tpl.
+*/}}
+{{- range $secretName := list "ama-metrics-operator-targets-server-tls-secret" "ama-metrics-operator-targets-client-tls-secret" }}
+{{- $existing := lookup "v1" "Secret" "kube-system" $secretName }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: kube-system
+  labels:
+    component: ama-metrics-operator-targets
+    kubernetes.azure.com/managedby: aks
+type: Opaque
+{{- if and $existing $existing.data }}
+data:
+{{ toYaml $existing.data | indent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary

Removes the cluster-wide `secrets: create` grant from `ClusterRole/ama-metrics-reader`.

The config-reader needed it only to create the two operator-targets mTLS secrets on first run. Kubernetes RBAC [cannot constrain a top-level `create` by `resourceNames`](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources), so the rule permitted creating a Secret of **any name and any type, in any namespace** - including under a name this same account is separately allowed to read.

Instead the two secrets are pre-created (empty) by the chart, so the service account only needs `get`/`update` on those fixed names.

Repair item: [AB#39558214](https://msazure.visualstudio.com/InfrastructureInsights/_workitems/edit/39558214)

## Changes

| File | Change |
|---|---|
| `ama-metrics-clusterRole.yaml` | Drop `- resources: ["secrets"] verbs: ["create"]`. Add a comment explaining why it must not come back. |
| `ama-metrics-operator-targets-tls-secrets.yaml` (new) | Pre-create `ama-metrics-operator-targets-{server,client}-tls-secret` as empty `Opaque` secrets via a `pre-install,pre-upgrade` Helm hook, gated on `OperatorTargetsHttpsEnabled` and on the secret not already existing. |
| `configuration-reader-builder/main.go` | `generateSecretWithServerCertsForTA` / `generateSecretWithClientCertForRs` call `Update` directly, and resend the chart labels. |

### Why the Go change is required, not cosmetic

Both functions previously called `Create` and fell back to `Update` on `IsAlreadyExists`. Without the `create` permission the API server returns **403 Forbidden**, not `AlreadyExists`, so that fallback would never fire and certificate generation would silently fail. Dropping the chart rule without this change would break mTLS.

Removing both `apierrors.IsAlreadyExists` uses also makes the `apierrors` import unused, so it is removed.

`Update` replaces the whole object, so the labels the chart stamps are resent on every write; otherwise they would be dropped the first time certificates are generated.

### Why a Helm hook and not an ordinary chart resource

The first revision of this PR added the secrets as ordinary chart resources. That fails on **every cluster that has already run ama-metrics with HTTPS enabled**: the secrets exist there, created at runtime by the config-reader, so they carry no Helm ownership metadata and Helm's adoption check rejects them.

```
UPGRADE FAILED: rendered manifests contain a resource that already exists.
Unable to continue with update: Secret "ama-metrics-operator-targets-server-tls-secret"
in namespace "kube-system" exists and cannot be imported into the current release:
invalid ownership metadata; label validation error: missing key
"app.kubernetes.io/managed-by": must be set to "Helm" ...
```

That approach was also self-defeating on fresh installs. The config-reader replaces the whole object when it writes the certificates, which drops the ownership metadata Helm had just stamped, so the *next* upgrade fails the same check.

Hooks are stored in `release.Hooks` rather than `release.Manifest`, so they are excluded from the adoption check and are never pruned by Helm. The `lookup` guard renders the hook only when the secret is genuinely absent, so an upgrade never deletes and recreates a populated secret and live certificates are preserved. `lookup` returns empty under `helm template` and `--dry-run`, but hooks are not executed in those modes, so rendering them there is harmless.

## Compatibility

**No customer-visible behavior change.** Nothing that reads secrets is modified:

- the `semverCompare "<1.37.0"` cluster-wide `secrets: get,list,watch` rule is untouched, so basic auth in pod/service monitors keeps working below 1.37
- the fixed-name `get`/`watch` on `aad-msi-auth-token` and `ama-metrics-mtls-secret` is untouched and stays cluster-wide, so the documented mTLS scrape scenario (`deploy/example-custom-resources/pod-monitor/pod-monitor-reference-app-mtls.yaml`) keeps working in any namespace
- no custom resource is rejected and no scrape job is dropped

Only the write path narrows: from "create any secret anywhere" to "update two named secrets".

One behaviour change worth calling out: if either secret is deleted out from under the addon at runtime, the config-reader can no longer recreate it and it is restored on the next `helm upgrade` instead. Both volume mounts are already `optional: true`, so pods still start.

## Testing

- `go build ./...` passes in `otelcollector/configuration-reader-builder`
- `helm template` rendered across the matrix (k8s 1.33.7 / 1.36.0 / 1.37.0 / 1.38.0 x `OperatorTargetsHttpsEnabled` true / false). In all eight combinations no bare `secrets: create` rule is emitted, the `<1.37` broad read rule appears only below 1.37, and the fixed-name rule and secrets appear only when HTTPS is enabled.
- `helm template --no-hooks` emits neither secret, confirming they land in `release.Hooks` and not in the release manifest that the adoption check scans.

Against the three CI clusters that were failing (`ci-dev-aks-mac-eus`, `ci-dev-aks-tests`, `ciprom-dev-aks-otlp`), where both secrets exist with no labels or annotations:

- the previous revision reproduces the adoption failure exactly
- `helm upgrade --install --dry-run` (the command CI runs) now succeeds on all three
- `helm upgrade --install --dry-run=server`, where `lookup` is live, renders **no** hook at all because the secrets already exist, so a real upgrade is a no-op for them

On a throwaway kind cluster:

- fresh `helm install`: the pre-install hook creates both secrets, empty, `Opaque`, with the expected labels
- `helm upgrade` after writing certificate data into a secret: upgrade succeeds and all three data keys survive
- `helm rollback`: certificate data survives

Still worth a reviewer with a real cluster:
- [ ] Fresh install with `OperatorTargetsHttpsEnabled=true`: confirm both secrets are populated by the config-reader and the collector reaches the target allocator over mTLS on 443
- [ ] Arc extension path
