### PR TITLE
fix: verify TLS for kube-apiserver scrapes

### DIFF
--- a/otelcollector/configmapparser/default-prom-configs/apiserverDefault.yml
+++ b/otelcollector/configmapparser/default-prom-configs/apiserverDefault.yml
@@ -12,7 +12,8 @@
     scheme: https
     tls_config:
       ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      insecure_skip_verify: true
+      server_name: kubernetes.default.svc
+      insecure_skip_verify: false
     bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
     relabel_configs:
     - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]

--- a/otelcollector/deploy/example-default-scrape-configs/default-prometheus-config-rs-advanced.yaml
+++ b/otelcollector/deploy/example-default-scrape-configs/default-prometheus-config-rs-advanced.yaml
@@ -89,7 +89,8 @@ scrape_configs:
   scheme: https
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
+    server_name: kubernetes.default.svc
+    insecure_skip_verify: false
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   relabel_configs:
   - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]

--- a/otelcollector/deploy/example-default-scrape-configs/default-prometheus-config-rs-simple.yaml
+++ b/otelcollector/deploy/example-default-scrape-configs/default-prometheus-config-rs-simple.yaml
@@ -81,7 +81,8 @@ scrape_configs:
   scheme: https
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
+    server_name: kubernetes.default.svc
+    insecure_skip_verify: false
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   relabel_configs:
   - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]

--- a/otelcollector/shared/configmap/mp/apiserver_config_test.go
+++ b/otelcollector/shared/configmap/mp/apiserver_config_test.go
@@ -1,0 +1,57 @@
+package configmapsettings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestAPIServerDefaultScrapeVerifiesTLS(t *testing.T) {
+	configPath := filepath.Join(
+		"..",
+		"..",
+		"..",
+		"configmapparser",
+		"default-prom-configs",
+		"apiserverDefault.yml",
+	)
+	contents, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read API server default config: %v", err)
+	}
+
+	var config struct {
+		ScrapeConfigs []struct {
+			JobName         string `yaml:"job_name"`
+			BearerTokenFile string `yaml:"bearer_token_file"`
+			TLSConfig       struct {
+				CAFile             string `yaml:"ca_file"`
+				ServerName         string `yaml:"server_name"`
+				InsecureSkipVerify *bool  `yaml:"insecure_skip_verify"`
+			} `yaml:"tls_config"`
+		} `yaml:"scrape_configs"`
+	}
+	if err := yaml.Unmarshal(contents, &config); err != nil {
+		t.Fatalf("parse API server default config: %v", err)
+	}
+
+	if len(config.ScrapeConfigs) != 1 || config.ScrapeConfigs[0].JobName != "kube-apiserver" {
+		t.Fatalf("expected one kube-apiserver scrape config, got %#v", config.ScrapeConfigs)
+	}
+
+	scrapeConfig := config.ScrapeConfigs[0]
+	if scrapeConfig.BearerTokenFile != "/var/run/secrets/kubernetes.io/serviceaccount/token" {
+		t.Fatalf("unexpected API server bearer token file %q", scrapeConfig.BearerTokenFile)
+	}
+	if scrapeConfig.TLSConfig.CAFile != "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" {
+		t.Fatalf("unexpected API server CA file %q", scrapeConfig.TLSConfig.CAFile)
+	}
+	if scrapeConfig.TLSConfig.ServerName != "kubernetes.default.svc" {
+		t.Fatalf("API server TLS server name = %q, want kubernetes.default.svc", scrapeConfig.TLSConfig.ServerName)
+	}
+	if scrapeConfig.TLSConfig.InsecureSkipVerify == nil || *scrapeConfig.TLSConfig.InsecureSkipVerify {
+		t.Fatal("API server TLS certificate verification must be explicitly enabled")
+	}
+}


### PR DESCRIPTION
# PR Description

## What this changes

The optional kube-apiserver scrape target now verifies that it is connecting to the Kubernetes API server before sending the collector credential. The maintained example configurations are updated to match, and a regression test prevents certificate verification from being disabled again.

## Why this is needed

[IcM 31000000709025](https://portal.microsofticm.com/imp/v5/incidents/details/31000000709025/summary) identified that the current scrape configuration trusts an HTTPS endpoint without verifying its identity. If the target changes unexpectedly, the collector credential could be sent to an endpoint that is not the Kubernetes API server.

This change makes the existing Kubernetes CA check effective and verifies the stable `kubernetes.default.svc` identity before the credential is sent.

## What this supersedes

This supersedes the current kube-apiserver default scrape behavior that skips certificate verification.

It complements [PR #1716](https://github.com/Azure/prometheus-collector/pull/1716), which removes broad Secret creation permission from the collector. That PR limits what a disclosed credential can do; this PR prevents the scrape job from disclosing the credential to an unverified endpoint in the first place.

## Validation

- Added `TestAPIServerDefaultScrapeVerifiesTLS` to require the Kubernetes CA, verified server name, and explicit certificate verification.
- Targeted regression test passes: `go test apiserver_config_test.go`.
- Parsed the deployed default configuration and confirmed the expected TLS settings.

# New Feature Checklist

This is a security fix to an existing scrape target, not a new feature.

- [ ] List telemetry added about the feature. Not applicable; no new telemetry is required.
- [ ] Link to the one-pager about the feature. Not applicable.
- [ ] List any tasks necessary for release (3P docs, AKS RP chart changes, etc.) after merging the PR. Standard managed Prometheus image and addon rollout is required.
- [ ] Attach results of scale and perf testing. Not applicable; this does not change scrape volume or frequency.

# Tests Checklist

- [ ] Have end-to-end Ginkgo tests been run on your cluster and passed? Not run locally; the existing MSRC validation should be used for the post-fix acceptance test.
  - [ ] `operator` — not applicable.
  - [ ] `windows` — not applicable.
  - [ ] `arm64` — not applicable.
  - [ ] `arc-extension` — not applicable.
  - [ ] `fips` — not applicable.
- [x] Have new tests been added? Yes, a focused regression test covers the corrected TLS configuration.
  - [ ] Is a new scrape job needed? No; this fixes the existing kube-apiserver job.
    - [ ] The scrape job was added to the correct test-cluster configuration. Not applicable.
  - [ ] Was a new test label added? No new test suite or label is needed.
    - [ ] A string constant for the label was added to `constants.go`. Not applicable.
    - [ ] The label and description were added to the test README. Not applicable.
    - [ ] The label was added to this PR checklist. Not applicable.
    - [ ] The label was added to `testkube-test-crs.yaml`. Not applicable.
  - [ ] Are additional API server permissions needed for the new tests? No.
    - [ ] These permissions were added to `api-server-permissions.yaml`. Not applicable.
  - [ ] Was a new test suite added? No.
    - [ ] The suite was included in `testkube-test-crs.yaml`. Not applicable.
